### PR TITLE
Card Counter's colors for Dark Theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,4 +115,4 @@ npm i
 npm run dev
 ```
 
-Then follow [this part of the quick start guide](https://github.com/bjsi/incremental-everything) to get the plugin running in RemNote.
+Then follow [this part of the quick start guide](https://plugins.remnote.com/getting-started/quick_start_guide#run-the-plugin-template-inside-remnote) to get the plugin running in RemNote.

--- a/src/widgets/index.tsx
+++ b/src/widgets/index.tsx
@@ -185,10 +185,20 @@ async function onActivate(plugin: ReactRNPlugin) {
     visibility: hidden;
   }
 
-  .rn-queue__card-counter:after {
+  .light .rn-queue__card-counter:after {
     content: '${queueInfo.numCardsRemaining} + ${filtered.length}';
     visibility: visible;
     background-color: #f0f0f0;
+    display: inline-block;
+    padding: 0.5rem 1rem;
+    font-size: 0.875rem;
+    border-radius: 0.25rem;
+  }
+  .dark .rn-queue__card-counter:after {
+    content: '${queueInfo.numCardsRemaining} + ${filtered.length}';
+    visibility: visible;
+    background-color: #34343c;
+    font-color: #d4d4d0;
     display: inline-block;
     padding: 0.5rem 1rem;
     font-size: 0.875rem;


### PR DESCRIPTION
### Summary 🎯

<!-- Please explain the purpose, and **link** any relevant issues-->

### Changes 🔁

- Corrected the colors of the card counter in the queue when using dark mode
- Corrected the link at the end of the README to point to the relevant section of the RemNote's Plugin Documentation 
