### PR TITLE
seems to work on mobile mode on Chrome; perhaps fix-css-registration …

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -7,11 +7,11 @@
   "version": {
     "major": 0,
     "minor": 0,
-    "patch": 19
+    "patch": 20
   },
   "unlisted": false,
   "theme": [],
-  "enableOnMobile": false,
+  "enableOnMobile": true,
   "description": "Review notes, PDFs and web articles incrementally alongside your flashcards.",
   "requestNative": false,
   "requiredScopes": [


### PR DESCRIPTION
I'd like to enable your extension on the mobile store!

### Summary 🎯

I tested the code on Chrome mobile and it seemed to work fine; perhaps the fix-css-registration was what's needed


### Changes 🔁

- patch number
- "enableOnMobile": true
