### PR TITLE
Performance Optimization: Pre-compute Card Priorities

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -7,7 +7,7 @@
   "version": {
     "major": 0,
     "minor": 2,
-    "patch": 13
+    "patch": 14
   },
   "unlisted": false,
   "theme": [],


### PR DESCRIPTION
## v0.2.14 - November 4, 2025

### Performance Optimization: Pre-compute Card Priorities

**Improved efficiency of the Pre-compute Card Priorities command:**

<img width="700" alt="image" src="https://github.com/user-attachments/assets/263d4d0d-4951-4b30-b737-1f097f481aad" />


- **Skip unnecessary updates**: Now only retags and updates `lastUpdated` timestamp when a card's priority value or source actually changes
- **Avoid redundant syncing**: Rems with unchanged priorities are skipped entirely, reducing RemNote sync and wiring operations and improving performance
- **Accurate reporting**: Fixed logic that was incorrectly detecting the presence of cardPriority tags, eliminating false "newly tagged" reports on subsequent runs
<img width="500" alt="image" src="https://github.com/user-attachments/assets/a1c6f962-ebf6-4f10-b47c-979dc46ca21e" />


**Result**: Now you can run pre-computation frequently to ensure the few priorities you have manually set in between will be inherited by many other cards, significantly improving the flashcard prioritization based on a few manual inputs that can be inherited by many other flashcards.
