### PR TITLE
Fix race condition preventing IncRems from displaying in empty queues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1097,6 +1097,7 @@
       "integrity": "sha512-hrmi5jWt2w60ayox3iIXwpMEnfUvOLJCRtrOPbHtH15nTjvO7uhnelvrdAs0dO0/zl5DZ3ZbahiaXEVb54ca/A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -1138,6 +1139,7 @@
       "integrity": "sha512-HEOvpzcFWkEcHq4EsTChnpimRc3Lz1/qzYRDFtobFp4obVa6QVjCDMjWmkgxgaTYttNvyjnldY8MUflGp5YiUw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "^0.16",
@@ -1465,6 +1467,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1504,6 +1507,7 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -1954,6 +1958,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.3",
         "caniuse-lite": "^1.0.30001741",
@@ -5899,6 +5904,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -6276,6 +6282,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
       "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -6289,6 +6296,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
       "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -6332,6 +6340,7 @@
       "integrity": "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7699,6 +7708,7 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -7783,6 +7793,7 @@
       "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7948,6 +7959,7 @@
       "integrity": "sha512-hUtqAR3ZLVEYDEABdBioQCIqSoguHbFn1K7WlPPWSuXmx0031BD73PSE35jKyftdSh4YLDoQNgK4pqBt5Q82MA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -7997,6 +8009,7 @@
       "integrity": "sha512-NLhDfH/h4O6UOy+0LSso42xvYypClINuMNBVVzX4vX98TmTaTUxwRbXdhucbFMd2qLaCTcLq/PdYrvi8onw90w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.5.0",
         "@webpack-cli/configtest": "^1.2.0",
@@ -8102,6 +8115,7 @@
       "integrity": "sha512-0XavAZbNJ5sDrCbkpWL8mia0o5WPOd2YGtxrEiZkBK9FjLppIUK2TgxK6qGD2P3hUXTJNNPVibrerKcx5WkR1g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/bonjour": "^3.5.9",
         "@types/connect-history-api-fallback": "^1.3.5",

--- a/src/widgets/index.tsx
+++ b/src/widgets/index.tsx
@@ -1669,17 +1669,29 @@ async function onActivate(plugin: ReactRNPlugin) {
       // Check if session cache is ready
       let docScopeRemIds = await plugin.storage.getSession<RemId[] | null>(currentScopeRemIdsKey);
 
-      // If in document queue but cache not ready, STOP.
+      // RACE CONDITION FIX:
+      // GetNextCard can be called before QueueEnter finishes calculating the scope.
+      // If the cache isn't ready yet, calculate a basic scope on-the-fly.
+      // This prevents returning null when there are IncRems to show.
       if (queueInfo.subQueueId && docScopeRemIds === null) {
-        console.log('⏳ GetNextCard: Session cache not ready yet, waiting for QueueEnter. Returning null.');
-        
-        // Hide the counter temporarily - QueueEnter will update it when ready
-        await plugin.app.registerCSS(queueCounterId, '');
-        
-        // Return null immediately. DO NOT run the fallback calculation.
-        return null;
+        console.log('⚠️ GetNextCard: Session cache not ready yet. Calculating scope on-the-fly...');
+
+        const scopeRem = await plugin.rem.findOne(queueInfo.subQueueId);
+        if (!scopeRem) {
+          console.log('❌ GetNextCard: Could not find scope Rem. Returning null.');
+          return null;
+        }
+
+        const descendants = await scopeRem.getDescendants();
+        const itemSelectionScope = new Set<RemId>([
+          scopeRem._id,
+          ...descendants.map(r => r._id)
+        ]);
+
+        docScopeRemIds = Array.from(itemSelectionScope);
+        console.log(`✅ GetNextCard: Calculated on-the-fly scope with ${docScopeRemIds.length} items`);
       }
-      
+
       // --- ⬆️ END OF MODIFICATION ⬆️ ---
 
 


### PR DESCRIPTION
## Summary

Fixes a race condition where queues with IncRems but no flashcards would display as empty.

## Problem

When opening a queue containing IncRems but no flashcards:
- `GetNextCard` was called before `QueueEnter` finished calculating the document scope
- `GetNextCard` would return `null` because the session cache wasn't ready
- Result: Empty queue display despite having due IncRems

## Solution

- Calculate a basic scope on-the-fly in `GetNextCard` when the session cache isn't ready yet
- This allows IncRems to be shown immediately
- `QueueEnter` continues its comprehensive scope calculation in the background
- Subsequent calls use the full cached scope once ready

## Changes

- Modified `src/widgets/index.tsx`: Added on-the-fly scope calculation in GetNextCard
- Updated `package-lock.json`: Automatic npm dependency updates