### PR TITLE
refactor: use cache for incremental rem powerup checks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1097,6 +1097,7 @@
       "integrity": "sha512-hrmi5jWt2w60ayox3iIXwpMEnfUvOLJCRtrOPbHtH15nTjvO7uhnelvrdAs0dO0/zl5DZ3ZbahiaXEVb54ca/A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -1138,6 +1139,7 @@
       "integrity": "sha512-HEOvpzcFWkEcHq4EsTChnpimRc3Lz1/qzYRDFtobFp4obVa6QVjCDMjWmkgxgaTYttNvyjnldY8MUflGp5YiUw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "^0.16",
@@ -1465,6 +1467,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1504,6 +1507,7 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -1954,6 +1958,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.3",
         "caniuse-lite": "^1.0.30001741",
@@ -5899,6 +5904,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -6276,6 +6282,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
       "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -6289,6 +6296,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
       "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -6332,6 +6340,7 @@
       "integrity": "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7699,6 +7708,7 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -7783,6 +7793,7 @@
       "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7948,6 +7959,7 @@
       "integrity": "sha512-hUtqAR3ZLVEYDEABdBioQCIqSoguHbFn1K7WlPPWSuXmx0031BD73PSE35jKyftdSh4YLDoQNgK4pqBt5Q82MA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -7997,6 +8009,7 @@
       "integrity": "sha512-NLhDfH/h4O6UOy+0LSso42xvYypClINuMNBVVzX4vX98TmTaTUxwRbXdhucbFMd2qLaCTcLq/PdYrvi8onw90w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.5.0",
         "@webpack-cli/configtest": "^1.2.0",
@@ -8102,6 +8115,7 @@
       "integrity": "sha512-0XavAZbNJ5sDrCbkpWL8mia0o5WPOd2YGtxrEiZkBK9FjLppIUK2TgxK6qGD2P3hUXTJNNPVibrerKcx5WkR1g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/bonjour": "^3.5.9",
         "@types/connect-history-api-fallback": "^1.3.5",

--- a/src/components/ExtractViewer.tsx
+++ b/src/components/ExtractViewer.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useCallback } from 'react';
 import { PluginRem, RNPlugin, DocumentViewer, BuiltInPowerupCodes, RemId } from '@remnote/plugin-sdk';
 import { powerupCode } from '../lib/consts';
 import { safeRemTextToString } from '../lib/pdfUtils';
+import { isIncrementalRem } from '../lib/incremental_rem/cache';
 
 interface ExtractViewerProps {
   rem: PluginRem;
@@ -119,7 +120,7 @@ export function ExtractViewer({ rem, plugin }: ExtractViewerProps) {
           const batchResults = await Promise.all(
               batch.map(async (r) => ({
                   remId: r._id,
-                  isIncremental: await r.hasPowerup(powerupCode),
+                  isIncremental: await isIncrementalRem(plugin, r._id),
                   cards: await r.getCards(),
               }))
           );

--- a/src/components/Reader.tsx
+++ b/src/components/Reader.tsx
@@ -23,6 +23,7 @@ import {
   PageRangeContext,
   findIncrementalRemForPDF,
 } from '../lib/pdfUtils';
+import { isIncrementalRem } from '../lib/incremental_rem/cache';
 
 interface ReaderProps {
   actionItem: PDFActionItem | PDFHighlightActionItem | HTMLActionItem | HTMLHighlightActionItem;
@@ -417,7 +418,7 @@ export function Reader(props: ReaderProps) {
         const batchResults = await Promise.all(
           batch.map(async (r) => ({
             remId: r._id,
-            isIncremental: await r.hasPowerup(powerupCode),
+            isIncremental: await isIncrementalRem(plugin, r._id),
             cards: await r.getCards(),
           }))
         );

--- a/src/lib/incremental_rem/cache.ts
+++ b/src/lib/incremental_rem/cache.ts
@@ -4,6 +4,60 @@ import { IncrementalRem } from './types';
 import { getIncrementalRemFromRem } from './index';
 
 /**
+ * Checks if a rem is in the incremental cache (i.e., is an incremental rem).
+ *
+ * This is the preferred way to check if a rem has the incremental powerup,
+ * as it uses the cache instead of making API calls.
+ *
+ * @param plugin Plugin instance
+ * @param remId The ID of the rem to check
+ * @returns Promise that resolves to true if the rem is incremental, false otherwise
+ */
+export async function isIncrementalRem(
+  plugin: RNPlugin,
+  remId: string | undefined
+): Promise<boolean> {
+  if (!remId) return false;
+  const allRems: IncrementalRem[] =
+    (await plugin.storage.getSession(allIncrementalRemKey)) || [];
+  return allRems.some((r) => r.remId === remId);
+}
+
+/**
+ * Gets all incremental rems from the cache.
+ *
+ * This is the preferred way to get all incremental rem data,
+ * as it uses the cache instead of making API calls.
+ *
+ * @param plugin Plugin instance
+ * @returns Promise that resolves to array of all IncrementalRem objects
+ */
+export async function getAllIncrementalRemsFromCache(
+  plugin: RNPlugin
+): Promise<IncrementalRem[]> {
+  return (await plugin.storage.getSession(allIncrementalRemKey)) || [];
+}
+
+/**
+ * Gets an incremental rem from the cache.
+ *
+ * This is the preferred way to get incremental rem data,
+ * as it uses the cache instead of making API calls.
+ *
+ * @param plugin Plugin instance
+ * @param remId The ID of the rem to get
+ * @returns Promise that resolves to the IncrementalRem if found, null otherwise
+ */
+export async function getIncrementalRemFromCache(
+  plugin: RNPlugin,
+  remId: string | undefined
+): Promise<IncrementalRem | null> {
+  if (!remId) return null;
+  const allRems = await getAllIncrementalRemsFromCache(plugin);
+  return allRems.find((r) => r.remId === remId) || null;
+}
+
+/**
  * Updates the incremental rem cache in session storage.
  *
  * This helper function updates a single rem in the cache by:

--- a/src/lib/scheduler.ts
+++ b/src/lib/scheduler.ts
@@ -5,6 +5,7 @@ import * as _ from 'remeda';
 import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
 import { getIncrementalRemFromRem } from './incremental_rem';
+import { updateIncrementalRemCache } from './incremental_rem/cache';
 import { getDailyDocReferenceForDate } from './utils';
 dayjs.extend(relativeTime);
 
@@ -132,4 +133,13 @@ export async function updateSRSDataForRem(
   }
   await rem?.setPowerupProperty(powerupCode, nextRepDateSlotCode, dateReference);
   await rem?.setPowerupProperty(powerupCode, repHistorySlotCode, [JSON.stringify(newHistory)]);
+
+  // Update cache with fresh data
+  if (rem) {
+    const updatedIncRem = await getIncrementalRemFromRem(plugin, rem);
+    if (updatedIncRem) {
+      await updateIncrementalRemCache(plugin, updatedIncRem);
+      console.log('✅ Cache updated for rem', remId);
+    }
+  }
 }

--- a/src/widgets/batch_card_priority.tsx
+++ b/src/widgets/batch_card_priority.tsx
@@ -10,7 +10,8 @@ import { safeRemTextToString } from '../lib/pdfUtils';
 import { getCardPriority } from '../lib/card_priority';
 import { getIncrementalRemFromRem } from '../lib/incremental_rem';
 import { powerupCode } from '../lib/consts';
-import { updateCardPriorityCache } from '../lib/card_priority/cache'; // <-- 1. IMPORT ADDED
+import { updateCardPriorityCache } from '../lib/card_priority/cache';
+import { getIncrementalRemFromCache } from '../lib/incremental_rem/cache';
 
 interface RemWithPriority {
   remId: string;
@@ -119,14 +120,14 @@ function BatchCardPriority() {
             // Check if it's manually set (not inherited or default)
             const hasManualCardPriority = hasCardPriority && cardPrioritySource === 'manual';
 
-            // Check for Incremental Rem powerup directly
-            const hasIncremental = await rem.hasPowerup(powerupCode);
+            // Check for Incremental Rem using cache
+            const incInfo = await getIncrementalRemFromCache(plugin, rem._id);
+            const hasIncremental = incInfo !== null;
             let incRemPriority = null;
 
-            if (hasIncremental) {
-              const incInfo = await getIncrementalRemFromRem(plugin, rem);
+            if (hasIncremental && incInfo) {
               console.log(`IncRem detected for "${remText}":`, { hasIncremental, incInfo });
-              if (incInfo && incInfo.priority !== undefined) {
+              if (incInfo.priority !== undefined) {
                 incRemPriority = incInfo.priority;
               }
             }

--- a/src/widgets/card_priority_display.tsx
+++ b/src/widgets/card_priority_display.tsx
@@ -5,9 +5,9 @@ import {
   WidgetLocation,
 } from '@remnote/plugin-sdk';
 import React, { useMemo } from 'react';
-import { 
-  powerupCode, 
-  seenCardInSessionKey, 
+import {
+  powerupCode,
+  seenCardInSessionKey,
   allCardPriorityInfoKey,
   queueSessionCacheKey,
   cardPriorityCacheRefreshKey,
@@ -16,6 +16,7 @@ import {
 import { CardPriorityInfo, QueueSessionCache, getCardPriority } from '../lib/card_priority';
 import { percentileToHslColor, PERFORMANCE_MODE_LIGHT } from '../lib/utils';
 import { getEffectivePerformanceMode } from '../lib/mobileUtils';
+import { isIncrementalRem } from '../lib/incremental_rem/cache';
 import * as _ from 'remeda';
 
 export function CardPriorityDisplay() {
@@ -49,11 +50,11 @@ export function CardPriorityDisplay() {
     return (await rp.rem.findOne(ctx.remId)) ?? null;
   }, []);
 
-  const isIncRem = useTrackerPlugin(async (_rp) => {
+  const isIncRem = useTrackerPlugin(async (rp) => {
     if (!rem) {
       return false;
     }
-    return rem.hasPowerup(powerupCode);
+    return isIncrementalRem(rp, rem._id);
   }, [rem]);
 
 

--- a/src/widgets/editor_review.tsx
+++ b/src/widgets/editor_review.tsx
@@ -56,11 +56,7 @@ async function handleEditorReview(
   ];
   
   await updateSRSDataForRem(plugin, remId, newNextRepDate, newHistory);
-
-  const updatedIncRem = await getIncrementalRemFromRem(plugin, rem);
-  if (updatedIncRem) {
-    await updateIncrementalRemCache(plugin, updatedIncRem);
-  }
+  // Note: updateSRSDataForRem now updates the cache automatically
 
   return { rem, newNextRepDate };
 }

--- a/src/widgets/editor_review_timer.tsx
+++ b/src/widgets/editor_review_timer.tsx
@@ -104,11 +104,7 @@ function EditorReviewTimer() {
     ];
     
     await updateSRSDataForRem(plugin, timerData.remId, newNextRepDate, newHistory);
-
-    const updatedIncRem = await getIncrementalRemFromRem(plugin, rem);
-    if (updatedIncRem) {
-      await updateIncrementalRemCache(plugin, updatedIncRem);
-    }
+    // Note: updateSRSDataForRem now updates the cache automatically
 
     // Clear timer data
     await plugin.storage.setSession('editor-review-timer-rem-id', null);

--- a/src/widgets/priority.tsx
+++ b/src/widgets/priority.tsx
@@ -8,7 +8,7 @@ import {
 } from '@remnote/plugin-sdk';
 import React, { useCallback, useEffect, useState, useRef, useMemo } from 'react';
 import { getIncrementalRemFromRem, initIncrementalRem } from '../lib/incremental_rem';
-import { updateIncrementalRemCache, removeIncrementalRemCache } from '../lib/incremental_rem/cache';
+import { updateIncrementalRemCache, removeIncrementalRemCache, getAllIncrementalRemsFromCache } from '../lib/incremental_rem/cache';
 import {
   getCardPriority,
   setCardPriority,
@@ -93,7 +93,7 @@ function Priority() {
       : Promise.resolve(null), 
   [performanceMode]);
   
-  const allIncRems = useTrackerPlugin(async (plugin) => await plugin.storage.getSession<IncrementalRem[]>(allIncrementalRemKey) || [], []);
+  const allIncRems = useTrackerPlugin(async (plugin) => await getAllIncrementalRemsFromCache(plugin), []);
   
   const allCardInfos = useTrackerPlugin(async (plugin) => 
     (performanceMode === PERFORMANCE_MODE_FULL)

--- a/src/widgets/priority_editor.tsx
+++ b/src/widgets/priority_editor.tsx
@@ -6,7 +6,7 @@ import {
 } from '@remnote/plugin-sdk';
 import { useMemo, useState, useCallback } from 'react';
 import { getIncrementalRemFromRem } from '../lib/incremental_rem';
-import { updateIncrementalRemCache } from '../lib/incremental_rem/cache';
+import { updateIncrementalRemCache, getAllIncrementalRemsFromCache } from '../lib/incremental_rem/cache';
 import { getCardPriority, setCardPriority, CardPriorityInfo } from '../lib/card_priority';
 import { allIncrementalRemKey, powerupCode, prioritySlotCode, allCardPriorityInfoKey, cardPriorityCacheRefreshKey } from '../lib/consts';
 import { IncrementalRem } from '../lib/incremental_rem';
@@ -60,7 +60,7 @@ export function PriorityEditor() {
         getCardPriority(plugin, rem),
         rem.getCards(),
         rem.hasPowerup('cardPriority'),
-        plugin.storage.getSession<IncrementalRem[]>(allIncrementalRemKey),
+        getAllIncrementalRemsFromCache(plugin),
         plugin.storage.getSession<CardPriorityInfo[]>(allCardPriorityInfoKey),
         plugin.settings.getSetting<string>('priorityEditorDisplayMode')
       ]);

--- a/src/widgets/reschedule.tsx
+++ b/src/widgets/reschedule.tsx
@@ -61,11 +61,7 @@ async function handleRescheduleAndPriorityUpdate(
   ];
   
   await updateSRSDataForRem(plugin, remId, newNextRepDate, newHistory);
-
-  const updatedIncRem = await getIncrementalRemFromRem(plugin, rem);
-  if (updatedIncRem) {
-    await updateIncrementalRemCache(plugin, updatedIncRem);
-  }
+  // Note: updateSRSDataForRem now updates the cache automatically
 
   // Clear the start time (same as Next button does)
   await plugin.storage.setSession('increm-review-start-time', null);


### PR DESCRIPTION
## Summary
- Replaces expensive `hasPowerup()` API calls with cache-based lookups across all widgets and components
- Adds new cache utility functions for checking incremental rem status
- Updates cache automatically when SRS data is modified

## Changes
- Added `isIncrementalRem()` and `getIncrementalRemFromCache()` utility functions
- Replaced `rem.hasPowerup(powerupCode)` calls with cache lookups throughout codebase
- Replaced `powerup.taggedRem()` with `getAllIncrementalRemsFromCache()` for better performance
- Modified `updateSRSDataForRem()` to automatically update cache after changes
- Removed redundant manual cache updates in editor review widgets

## Performance Impact
This change significantly reduces API calls when checking if rems have the incremental powerup, improving overall plugin performance especially in widgets that process multiple rems.