### PR TITLE
fix: import CSS in inc_rem widgets for mobile styling

### DIFF
--- a/src/widgets/inc_rem_counter.tsx
+++ b/src/widgets/inc_rem_counter.tsx
@@ -2,6 +2,8 @@ import { renderWidget, usePlugin, useTrackerPlugin, WidgetLocation } from '@remn
 import React from 'react';
 import { allIncrementalRemKey, currentDocumentIdKey, popupDocumentIdKey } from '../lib/consts';
 import { collectPdfSourcesFromRems, findPdfExtractIds } from '../lib/scope_helpers';
+import '../style.css';
+import '../App.css';
 
 // Inject CSS for hover effects
 const style = document.createElement('style');

--- a/src/widgets/inc_rem_list.tsx
+++ b/src/widgets/inc_rem_list.tsx
@@ -5,6 +5,8 @@ import { IncrementalRem } from '../lib/incremental_rem';
 import { collectPdfSourcesFromRems, findPdfExtractIds } from '../lib/scope_helpers';
 import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
+import '../style.css';
+import '../App.css';
 
 dayjs.extend(relativeTime);
 


### PR DESCRIPTION
## Summary
- Fixed CSS styling issues on mobile for `inc_rem_counter` and `inc_rem_list` widgets
- Added missing CSS imports (`style.css` and `App.css`) to both widgets

## Problem
The inc_rem widgets were not rendering styles correctly on mobile devices. This was because:
- In production builds, webpack's `MiniCssExtractPlugin` bundles CSS separately for each widget
- The widgets were using Tailwind classes but not importing the CSS files
- In development mode, `style-loader` injects CSS globally, so the issue wasn't visible

## Solution
Added explicit CSS imports to both widgets:
- `src/widgets/inc_rem_counter.tsx`
- `src/widgets/inc_rem_list.tsx`

Now each widget includes its own CSS bundle in production builds, ensuring Tailwind classes render correctly on all devices.

## Test plan
- [x] Build the plugin with `npm run build`
- [x] Verify CSS files are generated for both widgets
- [ ] Test on mobile device to confirm styling works correctly
- [ ] Verify no regression on desktop