### PR TITLE
fix: improve history page initialization fallback logic

### DIFF
--- a/src/widgets/page-range.tsx
+++ b/src/widgets/page-range.tsx
@@ -224,7 +224,21 @@ function PageRangeWidget() {
   const startEditingHistory = (remId: string, currentPage: number | null) => {
     setEditingHistoryRemId(remId);
     // Pre-fill with the current page to make it easier to increment
-    setEditingHistoryPage(currentPage || 0); 
+    // If currentPage is not set, try to get the last page from history
+    if (currentPage && currentPage > 0) {
+      setEditingHistoryPage(currentPage);
+    } else {
+      // Check if we have history for this rem
+      const history = remHistories[remId];
+      if (history && history.length > 0) {
+        // Use the last recorded page from history
+        const lastEntry = history[history.length - 1];
+        setEditingHistoryPage(lastEntry.page);
+      } else {
+        // Default to 1 if no history exists
+        setEditingHistoryPage(1);
+      }
+    }
   };
   
   // --- NEW: Save reading history record ---


### PR DESCRIPTION
Closes: https://github.com/bjsi/incremental-everything/issues/124

### Summary 🎯

Improve the fallback logic when initializing the reading history editor. When a current page is not set, the component now tries to use the last recorded page from history instead of defaulting to 0, making it easier to continue reading from where you left off.

### Changes 🔁

- Enhanced `startEditingHistory()` to check history records when current page is unavailable
- Falls back to page 1 if no history exists
- Provides better UX for continuing interrupted reading sessions