### PR TITLE
fix: advance queue when incremental powerup is removed

### DIFF
--- a/src/lib/incremental_rem/action_items.ts
+++ b/src/lib/incremental_rem/action_items.ts
@@ -11,24 +11,21 @@ export const remToActionItemType = async (
   plugin: RNPlugin,
   rem: PluginRem
 ): Promise<RemAndType | null> => {
-  console.log('📋 remToActionItemType CALLED for rem:', rem._id);
-  
   // Check if this rem has a tag reference to "extractviewer"
   try {
     const tags = await rem.getTagRems();
-    
+
     for (const tagRem of tags) {
       if (!tagRem.text) continue;
       const tagText = await safeRemTextToString(plugin, tagRem.text);
-      
-      if (tagText.toLowerCase() === 'extractviewer' || 
+
+      if (tagText.toLowerCase() === 'extractviewer' ||
           tagText.toLowerCase() === 'extract viewer') {
-        console.log('📋 remToActionItemType RETURNING: extractviewer (rem type)');
         return { rem, type: 'rem' };
       }
     }
   } catch (error) {
-    console.log('Error checking for extractviewer tag:', error);
+    // Ignore errors
   }
 
   if (await rem.hasPowerup(BuiltInPowerupCodes.PDFHighlight)) {
@@ -43,10 +40,8 @@ export const remToActionItemType = async (
     const pdf = await plugin.rem.findOne(pdfId);
     if (!pdf) {
       await plugin.app.toast('PDF not found for extract. Skipping.');
-      console.log('📋 remToActionItemType RETURNING: null (PDF not found)');
       return null;
     } else {
-      console.log('📋 remToActionItemType RETURNING: pdf-highlight');
       return { extract: rem, type: 'pdf-highlight', rem: pdf };
     }
   } else if (await rem.hasPowerup(BuiltInPowerupCodes.HTMLHighlight)) {
@@ -61,17 +56,13 @@ export const remToActionItemType = async (
     const htmlRem = await plugin.rem.findOne(html);
     if (!htmlRem) {
       await plugin.app.toast('HTML not found for extract. Skipping.');
-      console.log('📋 remToActionItemType RETURNING: null (HTML not found)');
       return null;
     } else {
-      console.log('📋 remToActionItemType RETURNING: html-highlight');
       return { extract: rem, type: 'html-highlight', rem: htmlRem };
     }
   } else if (await rem.hasPowerup(BuiltInPowerupCodes.UploadedFile)) {
-    console.log('📋 remToActionItemType RETURNING: pdf (UploadedFile)');
     return { rem, type: 'pdf' };
   } else if (await rem.hasPowerup('vi')) {
-    console.log('📋 remToActionItemType RETURNING: video (vi powerup)');
     return { rem, type: 'video' };
   } else if (
     (await rem.hasPowerup(BuiltInPowerupCodes.Link)) &&
@@ -82,14 +73,12 @@ export const remToActionItemType = async (
       'URL'
     );
     if (['youtube', 'youtu.be'].some((x) => url.includes(x))) {
-      console.log('📋 remToActionItemType RETURNING: youtube');
       return {
         type: 'youtube',
         url,
         rem,
       };
     } else {
-      console.log('📋 remToActionItemType RETURNING: html (Link)');
       return {
         type: 'html',
         rem,
@@ -105,7 +94,6 @@ export const remToActionItemType = async (
     if (isLink && url && url.includes('youtube')) {
       const data = await remToActionItemType(plugin, source);
       if (data) {
-        console.log('📋 remToActionItemType RETURNING: youtube from source');
         return {
           ...data,
           rem,
@@ -114,14 +102,11 @@ export const remToActionItemType = async (
     } else {
       const data = await remToActionItemType(plugin, source);
       if (data) {
-        console.log('📋 remToActionItemType RETURNING: data from source');
         return data;
       }
     }
-    console.log('📋 remToActionItemType RETURNING: rem (has sources)');
     return { rem, type: 'rem' };
   } else {
-    console.log('📋 remToActionItemType RETURNING: rem (default)');
     return { rem, type: 'rem' };
   }
 };

--- a/src/register/tracker.ts
+++ b/src/register/tracker.ts
@@ -1,8 +1,72 @@
 import { ReactRNPlugin } from '@remnote/plugin-sdk';
 import { loadIncrementalRemCache } from '../lib/incremental_rem/cache';
+import { incrementalQueueActiveKey, currentIncRemKey, powerupCode } from '../lib/consts';
 
 export function registerIncrementalRemTracker(plugin: ReactRNPlugin) {
   plugin.track(async (rp) => {
     await loadIncrementalRemCache(rp);
+  });
+
+  // Track queue state and current rem to detect when powerup is removed
+  let intervalId: NodeJS.Timeout | null = null;
+  let lastCheckedRemId: string | null = null;
+  let pollCount = 0;
+  const MAX_POLLS_PER_REM = 60; // 60 polls * 500ms = 30 seconds max per item
+
+  plugin.track(async (rp) => {
+    const isQueueActive = await rp.storage.getSession<boolean>(incrementalQueueActiveKey);
+    const currentRemId = await rp.storage.getSession<string>(currentIncRemKey);
+
+    // Clear existing interval if any
+    if (intervalId) {
+      clearInterval(intervalId);
+      intervalId = null;
+    }
+
+    // Only start polling if queue is active and we have a current rem
+    if (isQueueActive && currentRemId) {
+      // Reset counters when rem changes
+      if (currentRemId !== lastCheckedRemId) {
+        lastCheckedRemId = currentRemId;
+        pollCount = 0;
+      }
+
+      // Start polling for this rem
+      intervalId = setInterval(async () => {
+        try {
+          pollCount++;
+
+          // Stop polling after 30 seconds for the same rem
+          if (pollCount > MAX_POLLS_PER_REM) {
+            if (intervalId) {
+              clearInterval(intervalId);
+              intervalId = null;
+            }
+            return;
+          }
+
+          const rem = await plugin.rem.findOne(currentRemId);
+          if (!rem) {
+            return;
+          }
+
+          const hasPowerup = await rem.hasPowerup(powerupCode);
+
+          if (!hasPowerup) {
+            await plugin.queue.removeCurrentCardFromQueue(true);
+            if (intervalId) {
+              clearInterval(intervalId);
+              intervalId = null;
+            }
+          }
+        } catch (error) {
+          // Silently handle errors
+        }
+      }, 500);
+    } else {
+      // Queue not active, reset state
+      lastCheckedRemId = null;
+      pollCount = 0;
+    }
   });
 }


### PR DESCRIPTION
Closes: https://github.com/bjsi/incremental-everything/issues/16

### Summary 🎯

Fixes the queue breaking when an incremental powerup is removed from an item while it's displayed. The queue now automatically advances to the next item when the powerup is removed.

### Changes 🔁

- Add reactive tracker that detects when incremental powerup is removed from current queue item
- Implement polling mechanism that only runs when queue is active, stops after 30 seconds per item
- Automatically advance to next item when powerup removal is detected
- Remove debug console logs from action_items.ts