### PR TITLE
fix: prevent priority shield percentiles from becoming stale

### DIFF
--- a/src/components/PriorityBadge.tsx
+++ b/src/components/PriorityBadge.tsx
@@ -8,7 +8,8 @@ interface PriorityBadgeProps {
 }
 
 export function PriorityBadge({ priority, percentile, compact = false }: PriorityBadgeProps) {
-  const bgColor = percentile ? percentileToHslColor(percentile) : '#6b7280';
+  // Use percentile for color if available (including 0), otherwise fallback to gray
+  const bgColor = percentile !== undefined ? percentileToHslColor(percentile) : '#6b7280';
 
   if (compact) {
     return (


### PR DESCRIPTION
Closes: https://github.com/bjsi/incremental-everything/issues/142

### Summary 🎯

Fixes the Priority Shield display issue where percentiles were not showing or became 0/undefined after a few minutes in a queue session.

### Changes 🔁

- Fix PriorityBadge to correctly handle 0 percentile by checking `!== undefined` instead of truthy check
- Prevent shield percentiles from becoming stale by looking up current values from the main cache instead of relying on session cache
- Change shield calculation from async useTrackerPlugin to sync useMemo for cleaner logic and better cache freshness