### PR TITLE
Add document filter to incremental reading main view

### DIFF
--- a/src/components/IncRemTable.tsx
+++ b/src/components/IncRemTable.tsx
@@ -8,11 +8,20 @@ export interface IncRemWithDetails extends IncrementalRem {
   incRemType?: ActionItemType;
   percentile?: number;
   totalTimeSpent?: number;
+  documentId?: string;
+  documentName?: string;
 }
 
 type FilterStatus = 'all' | 'due' | 'scheduled';
 type SortBy = 'priority' | 'date' | 'reviews' | 'time';
 type SortOrder = 'asc' | 'desc';
+
+export interface DocumentInfo {
+  id: string;
+  name: string;
+  count: number;
+  dueCount: number;
+}
 
 interface IncRemTableProps {
   title: string;
@@ -23,6 +32,9 @@ interface IncRemTableProps {
   totalCount: number;
   onRemClick: (remId: string) => void;
   onClose?: () => void;
+  documents?: DocumentInfo[];
+  selectedDocumentId?: string | null;
+  onDocumentFilterChange?: (documentId: string | null) => void;
 }
 
 export function IncRemTable({
@@ -34,6 +46,9 @@ export function IncRemTable({
   totalCount,
   onRemClick,
   onClose,
+  documents,
+  selectedDocumentId,
+  onDocumentFilterChange,
 }: IncRemTableProps) {
   const [filterStatus, setFilterStatus] = useState<FilterStatus>('all');
   const [priorityMin, setPriorityMin] = useState<number>(0);
@@ -76,7 +91,7 @@ export function IncRemTable({
     return filtered;
   }, [incRems, filterStatus, priorityMin, priorityMax, searchText, sortBy, sortOrder]);
 
-  const hasActiveFilters = filterStatus !== 'all' || priorityMin !== 0 || priorityMax !== 100 || searchText !== '';
+  const hasActiveFilters = filterStatus !== 'all' || priorityMin !== 0 || priorityMax !== 100 || searchText !== '' || selectedDocumentId;
 
   return (
     <div className="flex flex-col h-full" style={{
@@ -183,6 +198,29 @@ export function IncRemTable({
           }}
         />
 
+        {/* Document filter */}
+        {documents && documents.length > 0 && onDocumentFilterChange && (
+          <select
+            value={selectedDocumentId || ''}
+            onChange={(e) => onDocumentFilterChange(e.target.value || null)}
+            className="px-2 py-1 text-xs rounded"
+            style={{
+              backgroundColor: 'var(--rn-clr-background-primary)',
+              color: 'var(--rn-clr-content-primary)',
+              border: 'none',
+              maxWidth: '200px',
+            }}
+            title="Filter by document"
+          >
+            <option value="">All documents</option>
+            {documents.map((doc) => (
+              <option key={doc.id} value={doc.id}>
+                {doc.name} ({doc.dueCount}/{doc.count})
+              </option>
+            ))}
+          </select>
+        )}
+
         {/* Priority range */}
         <div className="flex items-center gap-1 text-xs" style={{ color: 'var(--rn-clr-content-tertiary)' }}>
           <span>★</span>
@@ -223,6 +261,7 @@ export function IncRemTable({
               setPriorityMin(0);
               setPriorityMax(100);
               setSearchText('');
+              onDocumentFilterChange?.(null);
             }}
             className="px-2 py-1 text-xs rounded transition-colors"
             style={{ color: 'var(--rn-clr-content-tertiary)' }}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -14,4 +14,4 @@ export { InlinePriorityEditor, InlinePageRangeEditor, InlineHistoryEditor } from
 export { PdfRemItem } from './PdfRemItem';
 export type { EditingState } from './PdfRemItem';
 export { IncRemTable } from './IncRemTable';
-export type { IncRemWithDetails } from './IncRemTable';
+export type { IncRemWithDetails, DocumentInfo } from './IncRemTable';

--- a/src/lib/incRemHelpers.ts
+++ b/src/lib/incRemHelpers.ts
@@ -63,3 +63,27 @@ export function getTotalTimeSpent(incRem: IncrementalRem): number {
   if (!incRem.history || incRem.history.length === 0) return 0;
   return incRem.history.reduce((total, rep) => total + (rep.reviewTimeSeconds || 0), 0);
 }
+
+/**
+ * Find the top-level document (root ancestor) for a rem.
+ * Walks up the parent chain until finding a rem with no parent.
+ */
+export async function getTopLevelDocument(plugin: RNPlugin, rem: any): Promise<{ id: string; name: string } | null> {
+  try {
+    let current = rem;
+    const maxDepth = 100;
+
+    for (let i = 0; i < maxDepth; i++) {
+      const parent = await current.getParentRem();
+      if (!parent) {
+        const text = await current.text;
+        const name = extractText(text) || 'Untitled';
+        return { id: current._id, name: name.length > 50 ? name.substring(0, 50) + '...' : name };
+      }
+      current = parent;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary 🎯

Added a document filter dropdown to the main incremental reading view, allowing users to quickly filter all incremental rems by their parent document. This solves the issue of having to scroll through all rems when looking for content related to a specific topic.

## Changes 🔁

- Added `getTopLevelDocument()` helper to traverse rem hierarchy and find the root document
- Enhanced `IncRemTable` component with document filter dropdown showing document name and due/total counts
- Updated `IncRemMainView` to compute unique documents, handle document filtering using `buildDocumentScope()`, and display filtered results
- Document list is sorted alphabetically for easy navigation