### PR TITLE
fix: queue broken when removing actual incremenetal rem from the editor

### DIFF
--- a/src/register/tracker.ts
+++ b/src/register/tracker.ts
@@ -47,6 +47,12 @@ export function registerIncrementalRemTracker(plugin: ReactRNPlugin) {
 
           const rem = await plugin.rem.findOne(currentRemId);
           if (!rem) {
+            // Rem was deleted while in the queue -> skip it and move on.
+            await plugin.queue.removeCurrentCardFromQueue(true);
+            if (intervalId) {
+              clearInterval(intervalId);
+              intervalId = null;
+            }
             return;
           }
 


### PR DESCRIPTION
## Summary
- detect when the current incremental rem is deleted while in the queue
- remove the card from the queue immediately and clear the poller to advance to the next item
- avoids flashing an "Action item type not found" error after deletion

