### PR TITLE
Enhance parent selector filtering and improve highlight IncRem creation UX

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -7,7 +7,7 @@
   "version": {
     "major": 0,
     "minor": 2,
-    "patch": 44
+    "patch": 45
   },
   "unlisted": false,
   "theme": [],


### PR DESCRIPTION
**Description:**
* **Refined Powerup Filtering:** Significantly expanded `powerupSlotFilter.ts` to filter out internal RemNote metadata and structural Rems that should not be used as parents. This includes:
    * Search Portals and queries (e.g., "Automatic Backlink Search Portal").
    * PDF/Reader state Rems (e.g., "Pages", "Highlights", "Last Zoom Workspace Point", "ShouldOpenInTextReader").
    * Common powerup slots (Headers, AutoSort, Aliases, Todos).
    * Empty/"Untitled" nodes and generic "Query" Rems.
* **Improved Highlight IncRem Creation Workflow:** Updated `createRemFromHighlight` to consistently open the Parent Selector popup.
    * Removed the auto-creation fallback when no existing candidates are found (or only the PDF is found).
    * The source PDF is now explicitly added as a candidate in these cases, ensuring the user always has the opportunity to create a new "Parent Holder" (using the `+` button) before saving the highlight.

**Related Files:**
* `src/lib/powerupSlotFilter.ts`
* `src/lib/highlightActions.ts`
