### PR TITLE
New Button for HTML IncRem: Open URL for Web Clipper

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -7,7 +7,7 @@
   "version": {
     "major": 0,
     "minor": 2,
-    "patch": 46
+    "patch": 47
   },
   "unlisted": false,
   "theme": [],


### PR DESCRIPTION
Added a new "📎 Open URL" button to the answer bar for HTML-type Incremental Rems. When reviewing IncRems with web pages sources, this button opens the original URL in a new browser tab, allowing you to use the Clipper's side panel for additional notes and extracts, improving the experience of Incremental Reading web pages. The button features an animated design to highlight when you're reviewing web content.

<img width="800" alt="Open html IncRem in browser for Clipper" src="https://github.com/user-attachments/assets/c6539d74-6b00-4e20-8d37-6fbe6bae2d03" />


<img width="1000" alt="IR on RemNote Clipper" src="https://github.com/user-attachments/assets/842393b8-0787-47ef-9ad6-5a2304145efa" />
