### PR TITLE
Improved Card Priority inheritance logic:

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,12 @@ A RemNote plugin which allows you to interleave your flashcard reviews with note
 
 ### 🎥 Videos about the basics
 
-- **Introductory Video**: [Incremental Reading in RemNote](https://youtu.be/SL7wjgntrbg?si=MwsqzyCeI3LwY9Ag)
+- **Introductory Videos**: 
+  * [ncremental Reading Web Pages in RemNote](https://youtu.be/eXRlfCTOQNw)
+  * [Incremental Reading in RemNote](https://youtu.be/SL7wjgntrbg)
+  
 
-- **What is Incremental Reading?**: [Incremental Journey - Incremental Reading in Simple Terms](https://youtu.be/V4xEziM8mco?si=PlL1Qs-26wuh0YyS)
+- **What is Incremental Reading?**: [Incremental Journey - Incremental Reading in Simple Terms](hhttps://youtu.be/V4xEziM8mco)
 
 
 

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -7,7 +7,7 @@
   "version": {
     "major": 0,
     "minor": 2,
-    "patch": 49
+    "patch": 50
   },
   "unlisted": false,
   "theme": [],


### PR DESCRIPTION
Updated to prioritize **Manual** Card Priorities over Incremental Rem priorities, while keeping Incremental Rem priorities higher than **Inherited/Default** Card Priorities (in the case of the closest ancestor having both Incremental and CardPriority powerups, with different priorities set in each one).
