### PR TITLE
Extended improvements of the cardPriority inheritance logic to the precompute-card-priorities command

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -7,7 +7,7 @@
   "version": {
     "major": 0,
     "minor": 2,
-    "patch": 50
+    "patch": 51
   },
   "unlisted": false,
   "theme": [],


### PR DESCRIPTION
findClosestAncestorWithPriority used by precompute-card-priorities command now also uses the improved inheritance logic of findClosestAncestorWithAnyPriority

