### PR TITLE
Injected css to hide Priority and Priority Source slots from Editor and Queue

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -7,7 +7,7 @@
   "version": {
     "major": 0,
     "minor": 2,
-    "patch": 51
+    "patch": 52
   },
   "unlisted": false,
   "theme": [],

--- a/src/lib/ui_helpers.ts
+++ b/src/lib/ui_helpers.ts
@@ -31,6 +31,22 @@ export function registerQueueCounter(plugin: ReactRNPlugin, count: number): void
   console.log(`QUEUE ENTER: Queue counter updated to show ${count} due IncRems`);
 }
 
+export async function registerQueueHidingCSS(plugin: ReactRNPlugin) {
+  
+  const css = `
+      /* Hide Priority and Priority Source Slots  */
+      [data-rem-property~="priority"],
+      [data-rem-container-property~="priority"],
+      [data-rem-property~="priority-source"],
+      [data-rem-container-property~="priority-source"] {
+        display: none !important; 
+      }
+  `;
+
+  await plugin.app.registerCSS('hide-priority-in-queue', css);
+
+}
+
 /**
  * Clears all queue-specific UI elements (menu items and CSS).
  * Called when the user navigates away from the flashcards view.

--- a/src/register/widgets.ts
+++ b/src/register/widgets.ts
@@ -145,6 +145,6 @@ export function registerWidgets(plugin: ReactRNPlugin) {
 
   // Register parent selector popup for creating rems under incremental rems
   plugin.app.registerWidget(parentSelectorWidgetId, WidgetLocation.Popup, {
-    dimensions: { height: 'auto', width: '400px' },
+    dimensions: { height: '850px', width: '400px' },
   });
 }

--- a/src/widgets/index.tsx
+++ b/src/widgets/index.tsx
@@ -15,6 +15,7 @@ import { registerCommands } from '../register/commands';
 import { registerCallbacks, resetSessionItemCounter } from '../register/callbacks';
 import { registerIncrementalRemTracker } from '../register/tracker';
 import { registerJumpToRemHelper } from '../register/window';
+import { registerQueueHidingCSS } from '../lib/ui_helpers';
 dayjs.extend(relativeTime);
 
 async function onActivate(plugin: ReactRNPlugin) {
@@ -37,6 +38,8 @@ async function onActivate(plugin: ReactRNPlugin) {
 
   registerCallbacks(plugin);
   registerWidgets(plugin);
+  
+  await registerQueueHidingCSS(plugin);
 
   await registerCommands(plugin);
   await registerMenus(plugin);


### PR DESCRIPTION
This aims to declutter the interface from these usually unhelpful information.

What was this:

<img width="600" alt="clutter priority slots" src="https://github.com/user-attachments/assets/b0775d2e-50a7-4299-8bf3-bc124f95164c" />


Now looks like this:

<img width="600" alt="no more clutter priority slots" src="https://github.com/user-attachments/assets/4af46856-9fc2-4344-ae39-392b4c920a02" />



