### PR TITLE
Improvements to the Priority Review Documents and renaming of a command

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -7,7 +7,7 @@
   "version": {
     "major": 0,
     "minor": 2,
-    "patch": 54
+    "patch": 55
   },
   "unlisted": false,
   "theme": [],

--- a/src/lib/card_priority/batch.ts
+++ b/src/lib/card_priority/batch.ts
@@ -98,23 +98,23 @@ export async function removeAllCardPriorityTags(plugin: RNPlugin) {
   }
 }
 
-export async function precomputeAllCardPriorities(plugin: RNPlugin) {
+export async function updateAllCardPriorities(plugin: RNPlugin) {
   const confirmed = confirm(
-    '📊 Pre-compute All Card Priorities\n\n' +
-      'This will analyze all flashcards in your knowledge base and pre-compute their priorities based on inheritance from their ancestors priorities.\n\n' +
+    '📊 Update All Inherited Card Priorities\n\n' +
+      'This will analyze all flashcards in your knowledge base and update all priorities that are inherited from their ancestors.\n\n' +
       'Your manually set card priorities will not be affected.\n\n' +
-      'This is a one-time optimization that will significantly speed up future plugin startups.\n\n' +
+      'This ensures that manual prioritization inputs made to ancestors are properly spread to their descendants .\n\n' +
       'This may take several minutes for large collections. Continue?'
   );
 
   if (!confirmed) {
-    console.log('Pre-computation cancelled by user');
-    await plugin.app.toast('Pre-computation cancelled');
+    console.log('Card Priorities Update cancelled by user');
+    await plugin.app.toast('Card Priorities Update cancelled');
     return;
   }
 
-  console.log('Starting card priority pre-computation...');
-  await plugin.app.toast('Starting card priority pre-computation. This may take a few minutes...');
+  console.log('Starting Card Priorities Update...');
+  await plugin.app.toast('Starting Card Priorities Update. This may take a few minutes...');
 
   try {
     const startTime = Date.now();
@@ -265,7 +265,7 @@ export async function precomputeAllCardPriorities(plugin: RNPlugin) {
     }
 
     const message =
-      `✅ Pre-computation complete!\n\n` +
+      `✅ Card Priorities Update complete!\n\n` +
       `• Total rems processed: ${processed}\n` +
       `• Newly tagged: ${tagged}${priorityChanged > 0 ? ` (${priorityChanged} with changed priority)` : ''}\n` +
       `• Preserved manual priorities: ${skippedManual}\n` +
@@ -276,13 +276,13 @@ export async function precomputeAllCardPriorities(plugin: RNPlugin) {
       `Future startups will be much faster!`;
 
     console.log(message);
-    await plugin.app.toast('✅ Pre-computation complete! See console for details.');
+    await plugin.app.toast('✅ Card Priorities Update complete! See console for details.');
     alert(message);
   } catch (error) {
-    console.error('Error during pre-computation:', error);
-    await plugin.app.toast('❌ Error during pre-computation. Check console for details.');
+    console.error('Error during Card Priorities Update:', error);
+    await plugin.app.toast('❌ Error during Card Priorities Update. Check console for details.');
     alert(
-      'An error occurred during pre-computation.\n\n' + 'Please check the console for details:\n' + String(error)
+      'An error occurred during Card Priorities Update.\n\n' + 'Please check the console for details:\n' + String(error)
     );
   }
 }

--- a/src/lib/card_priority/cache.ts
+++ b/src/lib/card_priority/cache.ts
@@ -165,7 +165,7 @@ export async function buildOptimizedCardPriorityCache(plugin: RNPlugin) {
 /**
  * Intelligently caches all card priorities with deferred loading.
  *
- * Phase 1: Load pre-tagged cards instantly
+ * Phase 1: Load pre-tagged cards
  * Phase 2: Process untagged cards in background
  *
  * @param plugin Plugin instance
@@ -240,15 +240,14 @@ export async function loadCardPriorityCache(plugin: RNPlugin) {
   console.log(`CACHE: Found ${untaggedRemIds.length} untagged cards for deferred processing`);
 
   if (enrichedTaggedPriorities.length > 0) {
-    await plugin.app.toast(`✅ Loaded ${enrichedTaggedPriorities.length} card priorities instantly`);
+    await plugin.app.toast(`✅ Loaded ${enrichedTaggedPriorities.length} pre-tagged card priorities`);
   }
 
   if (untaggedRemIds.length > 0) {
     const untaggedPercentage = Math.round((untaggedRemIds.length / uniqueRemIds.length) * 100);
     if (untaggedPercentage > 20) {
       await plugin.app.toast(
-        `⏳ Processing ${untaggedRemIds.length} untagged cards in background... ` +
-          `Consider running 'Pre-compute Card Priorities' for instant startups!`
+        `⏳ Processing ${untaggedRemIds.length} untagged cards in background... `
       );
     }
 
@@ -257,7 +256,7 @@ export async function loadCardPriorityCache(plugin: RNPlugin) {
     }, 3000);
   } else {
     console.log('CACHE: All cards are pre-tagged! No deferred processing needed.');
-    await plugin.app.toast('✅ All card priorities loaded instantly!');
+    await plugin.app.toast('✅ All card priorities loaded!');
   }
 }
 
@@ -344,7 +343,7 @@ async function processDeferredCardPriorityCache(plugin: RNPlugin, untaggedRemIds
     if (untaggedRemIds.length > 1000) {
       setTimeout(() => {
         plugin.app.toast(
-          `💡 Tip: Run 'Pre-compute Card Priorities' to avoid background processing in future sessions`
+          `💡 Tip: Run 'Update all inherited Card Priorities' to avoid background processing in future sessions`
         );
       }, 2000);
     }

--- a/src/lib/priority_review_document/index.ts
+++ b/src/lib/priority_review_document/index.ts
@@ -303,34 +303,7 @@ export async function createPriorityReviewDocument(
     }
   }
   
-  // 6. Create portals in the document
-  const reviewQueueTag = await findOrCreateTag(plugin, 'Priority Review Queue');
-  if (reviewQueueTag) { await reviewDoc.addTag(reviewQueueTag); }
-
-  for (const item of mixedItems) {
-    // Create a regular rem that will contain the portal reference
-    const childRem = await plugin.rem.createRem();
-    if (!childRem) continue;
-    
-    // Set it as a child of the review document first
-    await childRem.setParent(reviewDoc);
-    
-    // Set its text to be a portal reference to the target rem
-    const portalContent: RichTextInterface = [
-      {
-        i: 'q',
-        _id: item.rem._id,
-      }
-    ];
-    await childRem.setText(portalContent);
-
-    // Add type tag
-    const typeTagText = item.type === 'incremental' ? 'INC' : 'FC';
-    const typeTag = await findOrCreateTag(plugin, typeTagText);
-    if (typeTag) { await childRem.addTag(typeTag); }
-  }
-  
-  // 7. Add metadata to document
+  // 6. Add metadata to document
     const scopeName = scopeRemId 
     ? (await plugin.rem.findOne(scopeRemId))?.text?.join('') || 'Document'
     : 'Full Knowledge Base';
@@ -361,7 +334,7 @@ Created: ${timestamp}`;
     await metadataRem.setParent(reviewDoc);
   }
 
-  // 8. Generate Graph Data and Insert Graph Widget
+  // 7. Generate Graph Data and Insert Graph Widget
   
   // Initialize bins (0-5, 5-10, ... 95-100)
   const createBins = () => Array(20).fill(0).map((_, i) => ({
@@ -413,6 +386,34 @@ Created: ${timestamp}`;
     };
     
     await plugin.storage.setSynced(GRAPH_DATA_KEY_PREFIX + graphRem._id, graphData);
+  }
+
+    
+  // 8. Create portals in the document
+  const reviewQueueTag = await findOrCreateTag(plugin, 'Priority Review Queue');
+  if (reviewQueueTag) { await reviewDoc.addTag(reviewQueueTag); }
+
+  for (const item of mixedItems) {
+    // Create a regular rem that will contain the portal reference
+    const childRem = await plugin.rem.createRem();
+    if (!childRem) continue;
+    
+    // Set it as a child of the review document first
+    await childRem.setParent(reviewDoc);
+    
+    // Set its text to be a portal reference to the target rem
+    const portalContent: RichTextInterface = [
+      {
+        i: 'q',
+        _id: item.rem._id,
+      }
+    ];
+    await childRem.setText(portalContent);
+
+    // Add type tag
+    const typeTagText = item.type === 'incremental' ? 'INC' : 'FC';
+    const typeTag = await findOrCreateTag(plugin, typeTagText);
+    if (typeTag) { await childRem.addTag(typeTag); }
   }
   
   return reviewDoc;

--- a/src/register/commands.ts
+++ b/src/register/commands.ts
@@ -28,7 +28,7 @@ import {
 } from '../lib/mobileUtils';
 import {
   removeAllCardPriorityTags,
-  precomputeAllCardPriorities,
+  updateAllCardPriorities,
 } from '../lib/card_priority';
 import { loadCardPriorityCache } from '../lib/card_priority/cache';
 import { getPerformanceMode } from '../lib/utils';
@@ -450,11 +450,11 @@ export async function registerCommands(plugin: ReactRNPlugin) {
 
   // Pre-computation command
   await plugin.app.registerCommand({
-    id: 'precompute-card-priorities',
-    name: 'Pre-compute Card Priorities',
-    description: 'Pre-compute and tag all card priorities for faster plugin startups (run once)',
+    id: 'update-card-priorities',
+    name: 'Update all inherited Card Priorities',
+    description: 'Update all inherited Card Priorities (and pre-compute and tag all card not yet prioritized)',
     action: async () => {
-      await precomputeAllCardPriorities(plugin);
+      await updateAllCardPriorities(plugin);
     },
   });
 


### PR DESCRIPTION
## v0.2.55 - January 3rd, 2026
* Moved the **Summary** and [[Priority Distribution Graph|Priority-Review-Document#priority-review-document-graph-view]] to the top of [[Priority Review Document]]s (instead of the bottom).

<img width="800" alt="priority-review-doc-graphattop" src="https://github.com/user-attachments/assets/4cbed8d9-dda8-4120-a3d9-06df42d4695a" />


* Changed the name of the "**Pre-compute all card priorities**" command to "**[[Update all inherited Card Priorities|Priorities-for-Flashcards#maintenance-the-update-all-inherited-card-priorities-command]]**".

<img width="700" alt="CleanShot 2026-01-03 at 16 06 53@2x" src="https://github.com/user-attachments/assets/c04bec93-9af1-4de3-946c-959601f97d34" />

Closes #180 
Closes #181
