### PR TITLE
Refactor: CSS-Based PDF Highlight Styling & Fixes

### DIFF
--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -1,0 +1,6 @@
+### Priority Widget Performance & UX Improvements
+
+*   **Fixed Open Lag**: Changed default initialization to 'Light Mode' and implemented logic to totally skip expensive card checks (Tier 2/3) when in Light Mode.
+*   **Optimistic UI Loading**: The Inheritance interface now renders immediately in Full Mode without blocking on descendant card calculations.
+*   **Future Priority Support**: Enabled setting priority for descendant cards even if count is 0 (supports future cards), removing the "neither Incremental nor has flashcards" fallback state.
+*   **Code Refactoring**: Simplified visibility logic for `showInheritanceSection` and `showAddCardPriorityButton` to remove redundant checks.

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -7,7 +7,7 @@
   "version": {
     "major": 0,
     "minor": 2,
-    "patch": 58
+    "patch": 59
   },
   "unlisted": false,
   "theme": [],

--- a/src/lib/card_priority/cache.ts
+++ b/src/lib/card_priority/cache.ts
@@ -13,7 +13,7 @@ async function flushCacheUpdates(plugin: RNPlugin, forceHeavyRecalc = false) {
   const needsHeavyRecalc =
     forceHeavyRecalc || Array.from(pendingUpdates.values()).some((update) => !update.isLight);
 
-  console.log(`CACHE-FLUSH: Writing ${pendingUpdates.size} batched updates. Heavy Recalc: ${needsHeavyRecalc}`);
+
 
   const cache = (await plugin.storage.getSession<CardPriorityInfo[]>(allCardPriorityInfoKey)) || [];
 
@@ -32,7 +32,7 @@ async function flushCacheUpdates(plugin: RNPlugin, forceHeavyRecalc = false) {
   }
 
   if (needsHeavyRecalc) {
-    console.log(`CACHE-FLUSH: Re-calculating percentiles for ${cache.length} items...`);
+
     const sortedCache = _.sortBy(cache, (info) => info.priority);
     const totalItems = sortedCache.length;
     const enrichedCache = sortedCache.map((info, index) => {
@@ -40,10 +40,10 @@ async function flushCacheUpdates(plugin: RNPlugin, forceHeavyRecalc = false) {
       return { ...info, kbPercentile: percentile };
     });
     await plugin.storage.setSession(allCardPriorityInfoKey, enrichedCache);
-    console.log(`CACHE-FLUSH: Complete. Enriched cache size: ${enrichedCache.length}`);
+
   } else {
     await plugin.storage.setSession(allCardPriorityInfoKey, cache);
-    console.log(`CACHE-FLUSH: Light update complete. Cache size: ${cache.length}`);
+
   }
 
   pendingUpdates.clear();
@@ -51,7 +51,7 @@ async function flushCacheUpdates(plugin: RNPlugin, forceHeavyRecalc = false) {
 
 export async function updateCardPriorityCache(plugin: RNPlugin, remId: RemId, isLightUpdate = false) {
   try {
-    console.log(`CACHE-UPDATE: Queuing ${isLightUpdate ? 'light' : 'heavy'} update for RemId: ${remId}`);
+
 
     const rem = await plugin.rem.findOne(remId);
     const updatedInfo = rem ? await getCardPriority(plugin, rem) : null;
@@ -112,8 +112,7 @@ export async function buildOptimizedCardPriorityCache(plugin: RNPlugin) {
 
   const uniqueRemIds = _.uniq([...cardRemIds, ...inheritanceRemIds]);
   console.log(
-    `CACHE: Total ${uniqueRemIds.length} rems to process (${cardRemIds.length} with cards + ${
-      inheritanceRemIds.length - cardRemIds.length
+    `CACHE: Total ${uniqueRemIds.length} rems to process (${cardRemIds.length} with cards + ${inheritanceRemIds.length - cardRemIds.length
     } inheritance-only)`
   );
 
@@ -186,8 +185,7 @@ export async function loadCardPriorityCache(plugin: RNPlugin) {
 
   const uniqueRemIds = _.uniq([...cardRemIds, ...inheritanceRemIds]);
   console.log(
-    `CACHE: Total ${uniqueRemIds.length} rems to process (${cardRemIds.length} with cards + ${
-      inheritanceRemIds.length - cardRemIds.length
+    `CACHE: Total ${uniqueRemIds.length} rems to process (${cardRemIds.length} with cards + ${inheritanceRemIds.length - cardRemIds.length
     } inheritance-only)`
   );
 
@@ -334,8 +332,8 @@ async function processDeferredCardPriorityCache(plugin: RNPlugin, untaggedRemIds
     const totalTime = Math.round((Date.now() - startTime) / 1000);
     console.log(
       `DEFERRED: Background processing complete! ` +
-        `Processed ${processed} cards in ${totalTime}s ` +
-        `(${errorCount} errors)`
+      `Processed ${processed} cards in ${totalTime}s ` +
+      `(${errorCount} errors)`
     );
 
     await plugin.app.toast(`✅ Background processing complete! All ${processed} card priorities are now cached.`);

--- a/src/lib/highlightActions.ts
+++ b/src/lib/highlightActions.ts
@@ -59,7 +59,7 @@ const buildContextForSelector = (
   console.log('[ParentSelector:HighlightActions]   rootCandidates count:', rootCandidates.length);
   console.log('[ParentSelector:HighlightActions]   showPriorityPopupAfterCreate:', showPriorityPopupAfterCreate);
   console.log('[ParentSelector:HighlightActions]   highlightWasAlreadyIncremental:', highlightWasAlreadyIncremental);
-  
+
   return {
     pdfRemId,
     extractRemId: extractRem._id,
@@ -131,10 +131,37 @@ export const showPriorityPopupForRem = async (
   remId: RemId
 ): Promise<void> => {
   console.log('[ParentSelector:HighlightActions] Showing priority popup for rem:', remId);
-  
+
   // Store the rem ID for the priority popup to use
   await plugin.storage.setSession('priorityPopupTargetRemId', remId);
   await plugin.widget.openPopup('priority');
+};
+
+/**
+ * Helper to ensure a standard tag "pdfextract" exists.
+ * Returns the PluginRem for the tag.
+ */
+const ensurePdfExtractTag = async (plugin: ReactRNPlugin): Promise<PluginRem | undefined> => {
+  const tagName = 'pdfextract';
+  console.log(`[ParentSelector:HighlightActions] ensurePdfExtractTag: Searching for "${tagName}"...`);
+  // Attempt to find existing tag by name
+  const existingTag = await plugin.rem.findByName([tagName], null);
+  if (existingTag) {
+    console.log('[ParentSelector:HighlightActions] ensurePdfExtractTag: Found existing tag:', existingTag._id);
+    return existingTag;
+  }
+  // Create if missing
+  console.log('[ParentSelector:HighlightActions] ensurePdfExtractTag: Creating new tag...');
+  const newTag = await plugin.rem.createRem();
+  if (newTag) {
+    await newTag.setText([tagName]);
+    console.log('[ParentSelector:HighlightActions] ensurePdfExtractTag: Created new tag:', newTag._id);
+    // Optional: could set it as a stub or move it to a system folder, 
+    // but just creating it is sufficient for tagging.
+  } else {
+    console.error('[ParentSelector:HighlightActions] ensurePdfExtractTag: Failed to create new tag');
+  }
+  return newTag;
 };
 
 /**
@@ -156,7 +183,7 @@ export const createRemUnderParent = async (
   console.log('[ParentSelector:HighlightActions]   pdfRemId:', pdfRemId);
   console.log('[ParentSelector:HighlightActions]   contextRemId:', contextRemId);
   console.log('[ParentSelector:HighlightActions]   showPriorityPopup:', showPriorityPopup);
-  
+
   const newRem = await plugin.rem.createRem();
   if (!newRem) {
     await plugin.app.toast('Failed to create rem');
@@ -170,7 +197,33 @@ export const createRemUnderParent = async (
   await newRem.setParent(parentId);
 
   if (makeIncremental) {
-    await initIncrementalRem(plugin, newRem);
+    // DEBUG: Check parentage for priority inheritance
+    console.log('[ParentSelector:HighlightActions] Initializing Incremental Rem...');
+    console.log('[ParentSelector:HighlightActions] newRem.parent (local):', newRem.parent);
+
+    // Attempt to reload rem to ensure parent is strict?
+    // This is a suspicion for why priority inheritance might fail (defaulting to 25 if parent is unknown)
+    const reloadedRem = await plugin.rem.findOne(newRem._id);
+    console.log('[ParentSelector:HighlightActions] reloadedRem.parent:', reloadedRem?.parent);
+
+    // Pass the reloaded rem if available, otherwise original
+    await initIncrementalRem(plugin, reloadedRem || newRem);
+
+    // NEW: Tag the highlight as "pdfextract"
+    // This allows CSS to target [data-rem-tags~="pdfextract"]
+    console.log('[ParentSelector:HighlightActions] Attempting to tag highlight with "pdfextract"...');
+    try {
+      const pdfExtractTag = await ensurePdfExtractTag(plugin);
+      if (pdfExtractTag) {
+        console.log('[ParentSelector:HighlightActions] Found/Created tag rem:', pdfExtractTag._id);
+        await highlightRem.addTag(pdfExtractTag._id);
+        console.log('[ParentSelector:HighlightActions] Successfully added tag to highlight');
+      } else {
+        console.log('[ParentSelector:HighlightActions] Failed to ensure pdfextract tag exists');
+      }
+    } catch (err) {
+      console.error('[ParentSelector:HighlightActions] Error adding pdfextract tag:', err);
+    }
   }
 
   // Save this destination for future use
@@ -179,8 +232,9 @@ export const createRemUnderParent = async (
 
   // Clean up the original highlight
   await removeIncrementalRemCache(plugin, highlightRem._id);
+  // Remove "Incremental" powerup from the highlight
   await highlightRem.removePowerup(powerupCode);
-  await highlightRem.setHighlightColor('Yellow');
+  // Removed setHighlightColor('Yellow') -> CSS now handles styling via "pdfextract" tag
 
   const actionText = makeIncremental ? 'incremental rem' : 'rem';
   const parentSuffix = parentName ? ` under "${parentName.slice(0, 30)}..."` : ' under source';
@@ -216,12 +270,12 @@ export const createRemFromHighlight = async (
   console.log('[ParentSelector:HighlightActions] createRemFromHighlight CALLED');
   console.log('[ParentSelector:HighlightActions] options:', JSON.stringify(options, null, 2));
   console.log('[ParentSelector:HighlightActions] ============================================');
-  
+
   const { makeIncremental, sourceDocumentId, contextRemId, showPriorityPopupIfNew } = options;
-  
+
   // Normalize contextRemId: undefined becomes null
   const normalizedContextRemId = contextRemId ?? null;
-  
+
   console.log('[ParentSelector:HighlightActions] Normalized contextRemId:', normalizedContextRemId);
 
   // Check if the highlight is already an incremental rem
@@ -229,11 +283,11 @@ export const createRemFromHighlight = async (
   console.log('[ParentSelector:HighlightActions] Highlight is already incremental:', highlightIsAlreadyIncremental);
 
   // Determine if we should show priority popup after creating the rem
-  const shouldShowPriorityPopup = 
-    showPriorityPopupIfNew === true && 
-    !highlightIsAlreadyIncremental && 
+  const shouldShowPriorityPopup =
+    showPriorityPopupIfNew === true &&
+    !highlightIsAlreadyIncremental &&
     makeIncremental;
-  
+
   console.log('[ParentSelector:HighlightActions] Should show priority popup:', shouldShowPriorityPopup);
 
   // Step 1: Resolve the source document (PDF or HTML)
@@ -243,16 +297,16 @@ export const createRemFromHighlight = async (
     await plugin.app.toast('Could not find the source document for this highlight');
     return;
   }
-  
+
   console.log('[ParentSelector:HighlightActions] Source document resolved:', sourceDocument._id);
 
   // Check source type: PDF or HTML
   const isPdfSource = await sourceDocument.hasPowerup(BuiltInPowerupCodes.UploadedFile);
   const isHtmlSourceDoc = await isHtmlSource(sourceDocument);
-  
+
   console.log('[ParentSelector:HighlightActions] Is PDF source:', isPdfSource);
   console.log('[ParentSelector:HighlightActions] Is HTML source:', isHtmlSourceDoc);
-  
+
   // Step 2: If not a PDF or HTML, create directly under source
   // This handles YouTube videos, regular rems, etc.
   if (!isPdfSource && !isHtmlSourceDoc) {
@@ -273,7 +327,7 @@ export const createRemFromHighlight = async (
   // Step 3: Find all rems for this source as a tree structure
   // Use appropriate function based on source type
   let rootCandidates: ParentTreeNode[];
-  
+
   if (isPdfSource) {
     console.log('[ParentSelector:HighlightActions] Finding all rems for PDF as tree...');
     rootCandidates = await findAllRemsForPDFAsTree(plugin, sourceDocument._id);
@@ -281,7 +335,7 @@ export const createRemFromHighlight = async (
     console.log('[ParentSelector:HighlightActions] Finding all rems for HTML as tree...');
     rootCandidates = await findAllRemsForHTMLAsTree(plugin, sourceDocument._id);
   }
-  
+
   // FIX: If no candidates found, add the source document itself as the root
   // so the user can select it or create a child under it
   if (rootCandidates.length === 0) {
@@ -315,9 +369,9 @@ export const createRemFromHighlight = async (
 
   // Step 5: Decision logic - Always show popup for PDF and HTML sources
   // This allows users to choose where to place the new rem
-  
+
   console.log('[ParentSelector:HighlightActions] DECISION: Showing hierarchical popup');
-  
+
   const context = buildContextForSelector(
     sourceDocument._id,  // This is used as "pdfRemId" but works for HTML too
     highlightRem,
@@ -328,17 +382,17 @@ export const createRemFromHighlight = async (
     shouldShowPriorityPopup,
     highlightIsAlreadyIncremental
   );
-  
+
   console.log('[ParentSelector:HighlightActions] Storing context in session...');
   await plugin.storage.setSession('parentSelectorContext', context);
-  
+
   // Verify context was stored
   const storedContext = await plugin.storage.getSession<ExtendedParentSelectorContext>('parentSelectorContext');
   console.log('[ParentSelector:HighlightActions] Verified stored context:');
   console.log('[ParentSelector:HighlightActions]   contextRemId:', storedContext?.contextRemId);
   console.log('[ParentSelector:HighlightActions]   lastSelectedDestination:', storedContext?.lastSelectedDestination);
   console.log('[ParentSelector:HighlightActions]   showPriorityPopupAfterCreate:', storedContext?.showPriorityPopupAfterCreate);
-  
+
   console.log('[ParentSelector:HighlightActions] Opening popup...');
   await plugin.widget.openPopup(parentSelectorWidgetId);
 };

--- a/src/lib/incremental_rem/cache.ts
+++ b/src/lib/incremental_rem/cache.ts
@@ -62,18 +62,18 @@ export async function loadIncrementalRemCache(
   batchSize: number = 500,
   batchDelayMs: number = 100
 ): Promise<IncrementalRem[]> {
-  console.log('TRACKER: Incremental Rem tracker starting...');
+
 
   const powerup = await plugin.powerup.getPowerupByCode(powerupCode);
   const taggedRem = (await powerup?.taggedRem()) || [];
-  console.log(`TRACKER: Found ${taggedRem.length} Incremental Rems. Starting batch processing...`);
+
 
   const updatedAllRem: IncrementalRem[] = [];
   const numBatches = Math.ceil(taggedRem.length / batchSize);
 
   for (let i = 0; i < taggedRem.length; i += batchSize) {
     const batch = taggedRem.slice(i, i + batchSize);
-    console.log(`TRACKER: Processing IncRem batch ${Math.floor(i / batchSize) + 1} of ${numBatches}...`);
+
 
     const batchInfos = (
       await Promise.all(batch.map((rem) => getIncrementalRemFromRem(plugin, rem)))
@@ -84,9 +84,9 @@ export async function loadIncrementalRemCache(
     await new Promise((resolve) => setTimeout(resolve, batchDelayMs));
   }
 
-  console.log(`TRACKER: Processing complete. Final IncRem cache size is ${updatedAllRem.length}.`);
+
   await plugin.storage.setSession(allIncrementalRemKey, updatedAllRem);
-  console.log('TRACKER: Incremental Rem cache has been saved.');
+
 
   return updatedAllRem;
 }

--- a/src/lib/ui_helpers.ts
+++ b/src/lib/ui_helpers.ts
@@ -32,7 +32,7 @@ export function registerQueueCounter(plugin: ReactRNPlugin, count: number): void
 }
 
 export async function registerQueueHidingCSS(plugin: ReactRNPlugin) {
-  
+
   const css = `
       /* Hide Priority and Priority Source Slots  */
       [data-rem-property~="priority"],
@@ -45,6 +45,23 @@ export async function registerQueueHidingCSS(plugin: ReactRNPlugin) {
 
   await plugin.app.registerCSS('hide-priority-in-queue', css);
 
+}
+
+// Register CSS for PDF Highlight coloring based on tags
+// This replaces the old manual color setting logic
+export async function registerPdfHighlightCSS(plugin: ReactRNPlugin) {
+  const css = `
+    [data-rem-tags~="pdf-highlight"][data-rem-tags~="pdfextract"] { 
+      background-color: #75ccf8 !important;
+      padding-bottom: 2.7px;
+    } 
+    [data-rem-tags~="pdf-highlight"][data-rem-tags~="incremental"] { 
+      background-color: #75f8b2 !important;
+      padding-bottom: 2.7px;
+    }
+  `;
+
+  await plugin.app.registerCSS('pdf-inc-highlight-styling', css);
 }
 
 /**

--- a/src/register/events.ts
+++ b/src/register/events.ts
@@ -106,8 +106,7 @@ async function resolveQueueScopes(
   console.log('QUEUE ENTER: Priority Review Document setup:');
   console.log(`  - Item selection from: Priority Review Doc (${subQueueId})`);
   console.log(
-    `  - Priority calculations for: ${
-      extractedScopeId ? `Original scope (${extractedScopeId})` : 'Full KB'
+    `  - Priority calculations for: ${extractedScopeId ? `Original scope (${extractedScopeId})` : 'Full KB'
     }`
   );
 
@@ -238,7 +237,7 @@ export function registerQueueEnterListener(
       originalScopeId,
       isPriorityReviewDoc,
     } = await resolveQueueScopes(plugin, subQueueId);
-    
+
     await plugin.storage.setSession(currentSubQueueIdKey, subQueueId || null);
     await plugin.storage.setSession('originalScopeId', originalScopeId);
     await plugin.storage.setSession('isPriorityReviewDoc', isPriorityReviewDoc);
@@ -255,11 +254,11 @@ export function registerQueueEnterListener(
     let dueCardsInScope: CardPriorityInfo[] = [];
 
     const allIncRems = (await plugin.storage.getSession<IncrementalRem[]>(allIncrementalRemKey)) || [];
-    
+
     if (allIncRems.length === 0) {
       console.warn('QUEUE ENTER: Incremental Rem cache is empty! IncRem calculations will be skipped.');
     }
-    
+
     const dueIncRemsInKB = allIncRems?.filter(rem => Date.now() >= rem.nextRepDate) || [];
     let dueIncRemsInScope: IncrementalRem[] = [];
     let incRemDocPercentiles: Record<RemId, number> = {};
@@ -275,9 +274,9 @@ export function registerQueueEnterListener(
       console.log(`QUEUE ENTER: ${scopeType} scope: ${itemSelectionScope.size} items (${elapsed}ms)`);
 
       await plugin.storage.setSession(currentScopeRemIdsKey, Array.from(itemSelectionScope));
-      
+
       let priorityCalcScope: Set<RemId> = new Set<RemId>();
-      
+
       if (isPriorityReviewDoc && scopeForPriorityCalc !== undefined) {
         if (scopeForPriorityCalc === null) {
           const fullKbIds = [
@@ -294,9 +293,9 @@ export function registerQueueEnterListener(
       }
 
       if (priorityCalcScope.size > 0) {
-        
+
         await plugin.storage.setSession(priorityCalcScopeRemIdsKey, Array.from(priorityCalcScope));
-        
+
         if (await isFullPerformanceMode(plugin)) {
           console.log('QUEUE ENTER: Full mode. Calculating session cache...');
 
@@ -318,7 +317,7 @@ export function registerQueueEnterListener(
           console.log('QUEUE ENTER: Light mode. Skipping session cache calculation.');
         }
       }
-      
+
     }
 
     const sessionCache: QueueSessionCache = {
@@ -437,7 +436,7 @@ export function registerGlobalRemChangedListener(plugin: ReactRNPlugin) {
           return;
         }
 
-        console.log(`LISTENER: (Debounced) GlobalRemChanged fired for RemId: ${data.remId} (Full Mode)`);
+
 
         if (recentlyProcessedCards.has(data.remId)) {
           console.log('LISTENER: Skipping - recently processed by QueueCompleteCard');
@@ -458,7 +457,7 @@ export function registerGlobalRemChangedListener(plugin: ReactRNPlugin) {
         }
 
         await updateCardPriorityCache(plugin, data.remId);
-        console.log('LISTENER: (Debounced) Finished processing event.');
+
       }, REM_CHANGE_DEBOUNCE_MS);
     }
   );

--- a/src/register/menus.ts
+++ b/src/register/menus.ts
@@ -7,7 +7,6 @@ import {
   powerupCode,
   priorityShieldHistoryMenuItemId,
   currentSubQueueIdKey,
-  pdfHighlightColorId,
   noIncRemMenuItemId,
   noIncRemTimerKey,
   pageRangeWidgetId,
@@ -72,19 +71,11 @@ export async function registerMenus(plugin: ReactRNPlugin) {
 
       if (isIncremental) {
         await rem.removePowerup(powerupCode);
-        await rem.setHighlightColor('Yellow');
+        // Removed setHighlightColor -> CSS handles cleanup when tag is removed
         await plugin.app.toast('❌ Removed Incremental tag');
       } else {
         await initIncrementalRem(plugin, rem);
-        const highlightColor =
-          ((await plugin.settings.getSetting(pdfHighlightColorId)) as
-            | 'Red'
-            | 'Orange'
-            | 'Yellow'
-            | 'Green'
-            | 'Blue'
-            | 'Purple') || 'Blue';
-        await rem.setHighlightColor(highlightColor);
+        // Removed setHighlightColor -> CSS handles styling via "incremental" tag
         await plugin.app.toast('✅ Tagged as Incremental Rem');
         await plugin.widget.openPopup('priority', {
           remId: rem._id,
@@ -102,7 +93,7 @@ export async function registerMenus(plugin: ReactRNPlugin) {
       : `${plugin.rootURL}/highlight-sparkles.png`,
     action: async (args: { remId: string }) => {
       console.log('[ParentSelector:Menu] CREATE INCREMENTAL REM triggered for:', args.remId);
-      
+
       const highlight = await plugin.rem.findOne(args.remId);
       if (!highlight) {
         console.log('[ParentSelector:Menu] ERROR: Could not find highlight rem');
@@ -114,15 +105,15 @@ export async function registerMenus(plugin: ReactRNPlugin) {
         incrementalRemId: string | null;
         pdfRemId: string | null;
       }>('pageRangeContext');
-      
+
       const currentIncRemId = await plugin.storage.getSession<string>('current-inc-rem');
-      
+
       // Determine contextRemId
       let contextRemId: string | null = null;
-      
-      if (pageRangeContext?.incrementalRemId && 
-          pageRangeContext?.pdfRemId && 
-          pageRangeContext.incrementalRemId !== pageRangeContext.pdfRemId) {
+
+      if (pageRangeContext?.incrementalRemId &&
+        pageRangeContext?.pdfRemId &&
+        pageRangeContext.incrementalRemId !== pageRangeContext.pdfRemId) {
         contextRemId = pageRangeContext.incrementalRemId;
       } else if (currentIncRemId) {
         const incRem = await plugin.rem.findOne(currentIncRemId);
@@ -130,7 +121,7 @@ export async function registerMenus(plugin: ReactRNPlugin) {
           contextRemId = currentIncRemId;
         }
       }
-      
+
       console.log('[ParentSelector:Menu] contextRemId:', contextRemId);
 
       // Call createRemFromHighlight with the NEW option
@@ -143,7 +134,7 @@ export async function registerMenus(plugin: ReactRNPlugin) {
       });
     },
   });
-  
+
   plugin.app.registerMenuItem({
     id: 'batch_priority_menuitem',
     location: PluginCommandMenuLocation.DocumentMenu,

--- a/src/register/settings.ts
+++ b/src/register/settings.ts
@@ -8,7 +8,6 @@ import {
   alwaysUseLightModeOnMobileId,
   alwaysUseLightModeOnWebId,
   remnoteEnvironmentId,
-  pdfHighlightColorId,
   showRemsAsIsolatedInQueueId,
 } from '../lib/consts';
 
@@ -214,18 +213,5 @@ export async function registerPluginSettings(plugin: ReactRNPlugin) {
     ],
   });
 
-  plugin.settings.registerDropdownSetting({
-    id: pdfHighlightColorId,
-    title: 'Incremental PDF Highlight Color',
-    description:
-      'Choose the highlight color for PDF highlights tagged as Incremental Rem. When toggling OFF (removing Incremental tag), the highlight will be reset to Yellow.',
-    defaultValue: 'Blue',
-    options: [
-      { key: 'Red', label: 'Red', value: 'Red' },
-      { key: 'Orange', label: 'Orange', value: 'Orange' },
-      { key: 'Green', label: 'Green', value: 'Green' },
-      { key: 'Blue', label: 'Blue', value: 'Blue' },
-      { key: 'Purple', label: 'Purple', value: 'Purple' },
-    ],
-  });
+
 }

--- a/src/widgets/index.tsx
+++ b/src/widgets/index.tsx
@@ -15,8 +15,7 @@ import { registerCommands } from '../register/commands';
 import { registerCallbacks, resetSessionItemCounter } from '../register/callbacks';
 import { registerIncrementalRemTracker } from '../register/tracker';
 import { registerJumpToRemHelper } from '../register/window';
-import { registerQueueHidingCSS } from '../lib/ui_helpers';
-dayjs.extend(relativeTime);
+import { registerQueueHidingCSS, registerPdfHighlightCSS } from '../lib/ui_helpers';
 
 async function onActivate(plugin: ReactRNPlugin) {
   //Debug
@@ -29,6 +28,7 @@ async function onActivate(plugin: ReactRNPlugin) {
   (window as any).__plugin = plugin;
   registerJumpToRemHelper(plugin);
 
+
   await registerPluginPowerups(plugin);
   await registerPluginSettings(plugin);
 
@@ -38,7 +38,9 @@ async function onActivate(plugin: ReactRNPlugin) {
 
   registerCallbacks(plugin);
   registerWidgets(plugin);
-  
+
+  // Register CSS rules
+  await registerPdfHighlightCSS(plugin);
   await registerQueueHidingCSS(plugin);
 
   await registerCommands(plugin);
@@ -59,6 +61,6 @@ async function onActivate(plugin: ReactRNPlugin) {
   }
 }
 
-async function onDeactivate(_: ReactRNPlugin) {}
+async function onDeactivate(_: ReactRNPlugin) { }
 
 declareIndexPlugin(onActivate, onDeactivate);

--- a/src/widgets/priority.tsx
+++ b/src/widgets/priority.tsx
@@ -72,7 +72,17 @@ function Priority() {
   }, []);
 
   const rem = useTrackerPlugin(async (plugin) => {
-    const remId = widgetContext?.contextData?.remId;
+    let remId = widgetContext?.contextData?.remId;
+
+    // Fallback: Check if we just came from Highlight Actions (Create Incremental Rem)
+    if (!remId) {
+      remId = await plugin.storage.getSession<string>('priorityPopupTargetRemId');
+      if (remId) {
+        // Clear it immediately so it doesn't persist for other uses
+        // await plugin.storage.setSession('priorityPopupTargetRemId', undefined);
+      }
+    }
+
     if (!remId) {
       return null;
     }


### PR DESCRIPTION
## 🎨 Styling Overhaul
- **CSS-Driven Highlighting**: Replaced manual `setHighlightColor` calls with a robust CSS solution. Highlights are now styled based on their tags:
    - `pdfextract` tag → **Blue** background (`#75ccf8`). Added when you click "Create Incremental Rem" from a pdf highlight. This way the user is aware that he has already created an extract of that highlight. 
    - `incremental` tag/powerup → **Green** background (`#75f8b2`)
- **Tagging Logic**: Implemented `ensurePdfExtractTag` to automatically tag extracted PDF highlights with `pdfextract`, ensuring consistent styling without modifying the user's color palette directly.
- **Settings Cleanup**: Removed the "Incremental PDF Highlight Color" setting (`pdfHighlightColorId`) as it is no longer needed.

## 🛠️ Technical Details
- **Centralized Logic**: `highlightActions.ts` now serves as the single source of truth for creating Rems from highlights, preventing logic drift between the context menu and the parent selector popup.
- **CSS Injection**: New styles represent a cleaner separation of concerns, moving visual logic out of the TypeScript business logic and into standard CSS injection via `ui_helpers.ts`. It was only possible because RemNote recently exposed the data-rem-tags of PDF highlights in the DOM.
