### PR TITLE
Priority Shield history bug fix

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -7,7 +7,7 @@
   "version": {
     "major": 0,
     "minor": 2,
-    "patch": 64
+    "patch": 65
   },
   "unlisted": false,
   "theme": [],

--- a/src/lib/card_priority/cache.ts
+++ b/src/lib/card_priority/cache.ts
@@ -294,6 +294,7 @@ export async function loadCardPriorityCache(plugin: RNPlugin) {
   } else {
     console.log('CACHE: All cards are pre-tagged! No deferred processing needed.');
     await plugin.app.toast('✅ All card priorities loaded!');
+    await plugin.storage.setSession('card_priority_cache_fully_loaded', true);
   }
 }
 
@@ -376,6 +377,7 @@ async function processDeferredCardPriorityCache(plugin: RNPlugin, untaggedRemIds
     );
 
     await plugin.app.toast(`✅ Background processing complete! All ${processed} card priorities are now cached.`);
+    await plugin.storage.setSession('card_priority_cache_fully_loaded', true);
 
     if (untaggedRemIds.length > 1000) {
       setTimeout(() => {

--- a/src/lib/incremental_rem/cache.ts
+++ b/src/lib/incremental_rem/cache.ts
@@ -86,7 +86,7 @@ export async function loadIncrementalRemCache(
 
 
   await plugin.storage.setSession(allIncrementalRemKey, updatedAllRem);
-
+  await plugin.storage.setSession('inc_rem_cache_fully_loaded', true);
 
   return updatedAllRem;
 }

--- a/src/lib/session_helpers.ts
+++ b/src/lib/session_helpers.ts
@@ -24,6 +24,8 @@ export async function resetQueueSession(plugin: ReactRNPlugin): Promise<void> {
   await plugin.storage.setSession('originalScopeId', null);
   await plugin.storage.setSession('isPriorityReviewDoc', null);
   await plugin.storage.setSession(queueSessionCacheKey, null);
+  await plugin.storage.setSession('skipCardHistorySave', null);
+  await plugin.storage.setSession('skipIncRemHistorySave', null);
 }
 
 /**
@@ -79,8 +81,8 @@ export async function calculateDueIncRemCount(
   const scopeRemIds = (await plugin.storage.getSession<RemId[]>(currentScopeRemIdsKey)) || [];
   const count = scopeRemIds.length
     ? allIncRems.filter(
-        (rem) => Date.now() >= rem.nextRepDate && scopeRemIds.includes(rem.remId)
-      ).length
+      (rem) => Date.now() >= rem.nextRepDate && scopeRemIds.includes(rem.remId)
+    ).length
     : 0;
   console.log(`QUEUE ENTER: Light mode - found ${count} due IncRems`);
   return count;


### PR DESCRIPTION
**Fix:** Resolved an issue where **Priority Shield history** was recorded with incorrect data if the queue was exited before the cache fully loaded. This eliminates spurious "humps" in the history graph caused by partial universe sizes, ensuring history is only saved when the cache is complete.
