### PR TITLE
fix: Clear stale `priorityPopupTargetRemId` from session storage before opening the priority popup to prevent race conditions.

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -7,7 +7,7 @@
   "version": {
     "major": 0,
     "minor": 2,
-    "patch": 82
+    "patch": 83
   },
   "unlisted": false,
   "theme": [],

--- a/src/register/commands.ts
+++ b/src/register/commands.ts
@@ -88,6 +88,8 @@ export async function registerCommands(plugin: ReactRNPlugin) {
       if (!rem) {
         return;
       }
+      // Clear stale session storage to prevent race condition with widget context
+      await plugin.storage.setSession('priorityPopupTargetRemId', undefined);
       await plugin.widget.openPopup('priority_light', {
         remId: rem._id,
       });
@@ -172,6 +174,8 @@ export async function registerCommands(plugin: ReactRNPlugin) {
         return;
       }
 
+      // Clear stale session storage to prevent race condition with widget context
+      await plugin.storage.setSession('priorityPopupTargetRemId', undefined);
       await plugin.widget.openPopup('priority_light', {
         remId: remId,
       });
@@ -630,6 +634,8 @@ export async function registerCommands(plugin: ReactRNPlugin) {
       await new Promise(resolve => setTimeout(resolve, 50));
 
       if (args && args.remId) {
+        // Clear stale session storage to prevent race condition with widget context
+        await plugin.storage.setSession('priorityPopupTargetRemId', undefined);
         await plugin.widget.openPopup('priority_light', {
           remId: args.remId,
         });

--- a/src/register/menus.ts
+++ b/src/register/menus.ts
@@ -57,6 +57,8 @@ export async function registerMenus(plugin: ReactRNPlugin) {
         await initIncrementalRem(plugin, rem);
         // Removed setHighlightColor -> CSS handles styling via "incremental" tag
         await plugin.app.toast('✅ Tagged as Incremental Rem');
+        // Clear stale session storage to prevent race condition with widget context
+        await plugin.storage.setSession('priorityPopupTargetRemId', undefined);
         await plugin.widget.openPopup('priority_light', {
           remId: rem._id,
         });
@@ -82,6 +84,8 @@ export async function registerMenus(plugin: ReactRNPlugin) {
         await initIncrementalRem(plugin, rem);
         // Removed setHighlightColor -> CSS handles styling via "incremental" tag
         await plugin.app.toast('✅ Tagged as Incremental Rem');
+        // Clear stale session storage to prevent race condition with widget context
+        await plugin.storage.setSession('priorityPopupTargetRemId', undefined);
         await plugin.widget.openPopup('priority_light', {
           remId: rem._id,
         });


### PR DESCRIPTION
## Summary

- **Issue**: [priority_light.tsx](cci:7://file:///Users/hugomarins/incremental-everything/src/widgets/priority_light.tsx:0:0-0:0) showed wrong rem data (NAV) when a stale session storage value existed from a previous priority widget interaction
- **Root cause**: Race condition where the data hook ran before context resolved, falling back to stale `priorityPopupTargetRemId`
- **Fix**: Clear `priorityPopupTargetRemId` session storage before opening `priority_light` with a context remId in all 5 locations ([commands.ts](cci:7://file:///Users/hugomarins/incremental-everything/src/register/commands.ts:0:0-0:0) and [menus.ts](cci:7://file:///Users/hugomarins/incremental-everything/src/register/menus.ts:0:0-0:0))

The widget now correctly waits for context to resolve when opening with a valid remId, and only uses the session storage fallback for the specific "Create Incremental Rem" flow that requires it.
