### PR TITLE
feat: Record the new priority during rescheduling and display it in the repetition history

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -7,7 +7,7 @@
   "version": {
     "major": 0,
     "minor": 2,
-    "patch": 86
+    "patch": 87
   },
   "unlisted": false,
   "theme": [],

--- a/src/widgets/repetition_history.tsx
+++ b/src/widgets/repetition_history.tsx
@@ -416,6 +416,7 @@ function RepetitionHistoryPopup() {
                                 }}>
                                     📅 Rescheduled in Editor — {dayjs(rep.date).format('MMM D, YYYY')}
                                     {rep.interval !== undefined && ` → ${rep.interval}d`}
+                                    {rep.priority !== undefined && ` — Pri: ${rep.priority}`}
                                 </div>
                             );
                         }
@@ -438,6 +439,7 @@ function RepetitionHistoryPopup() {
                                 }}>
                                     ✏️ Manual Date Reset — {dayjs(rep.date).format('MMM D, YYYY')}
                                     {rep.interval !== undefined && ` → ${rep.interval}d`}
+                                    {rep.priority !== undefined && ` — Pri: ${rep.priority}`}
                                 </div>
                             );
                         }

--- a/src/widgets/reschedule.tsx
+++ b/src/widgets/reschedule.tsx
@@ -59,7 +59,7 @@ async function handleRescheduleAndPriorityUpdate(
       wasEarly: wasEarly,
       daysEarlyOrLate: daysEarlyOrLate,
       reviewTimeSeconds: reviewTimeSeconds,
-      priority: incRem.priority, // Record priority at time of rep
+      priority: newPriority, // Record the NEW priority set during reschedule
       eventType: eventType as 'rescheduledInQueue' | 'rescheduledInEditor',
     },
   ];


### PR DESCRIPTION
### 🐛 Bug Fix: Priority Display in Reschedule Events

Fixed an issue where the **Repetition History widget** was not displaying the priority value for "Rescheduled in Editor" events.

**What was fixed:**
- **Recording the correct priority**: The reschedule function now records the **new priority** set by the user during the reschedule action, instead of the old priority value.
- **Displaying priority in event markers**: Both "Rescheduled in Editor" (📅) and "Manual Date Reset" (✏️) event markers now display the priority value (e.g., `— Pri: 5`).
