### PR TITLE
Refine priority shield percentile calculations using a volume-based method

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -7,7 +7,7 @@
   "version": {
     "major": 0,
     "minor": 2,
-    "patch": 88
+    "patch": 89
   },
   "unlisted": false,
   "theme": [],


### PR DESCRIPTION
### 🛡️ Priority Shield Improvements

Significantly improved the calculation and display of the **Priority Shield** to address cases where large blocks of items have the same priority.

**What's new:**
*   **Volume-based Percentile (Dynamic Progress):** Instead of calculating the percentile based on rank alone (which caused the shield to stay stuck at 0% for large blocks of tied priorities), the shield now calculates progress **by volume**. As you review cards within a priority group (e.g., Priority 10), the percentile will now increase smoothly (e.g., `10.5%` → `12.1%` → `15.2%`), giving you a true sense of progress.
*   **Increased Precision:** The shield now displays **1 decimal place** (e.g., `45.2%`) for granular tracking.
*   **Performance Optimization:** The calculation logic was rewritten to use `O(N)` linear scans instead of `O(N log N)` sorting. It also uses efficient `Set` lookups during reviews. This means **zero lag** even when reviewing large documents with thousands of cards.
*   **Accuracy Fix for Priority Review Documents:** Fixed an issue where the Document Shield would show 0% for Priority Review Documents. It now correctly scopes to the original source document to calculate the universe size.
*   **Consistent History:** The [[Priority Shield History|Prioritization-&-Sorting#priority-shield-history]] graph now also uses this improved volume-based calculation, ensuring your historical data matches what you see during review.
