### PR TITLE
feat: Record review time and priority in incremental repetition history upon dismissal 

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -7,7 +7,7 @@
   "version": {
     "major": 0,
     "minor": 2,
-    "patch": 90
+    "patch": 91
   },
   "unlisted": false,
   "theme": [],


### PR DESCRIPTION
This also corrected the issue of the Dismissed powerup being not appended by the Done button if the IncRem had no previous repetitions recorded.