### PR TITLE
feat: Add commands/menu items to open Sorting Criteria and Priority Shield History Graph

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -7,7 +7,7 @@
   "version": {
     "major": 0,
     "minor": 2,
-    "patch": 95
+    "patch": 96
   },
   "unlisted": false,
   "theme": [],

--- a/src/register/commands.ts
+++ b/src/register/commands.ts
@@ -12,6 +12,7 @@ import {
   alwaysUseLightModeOnMobileId,
   alwaysUseLightModeOnWebId,
   dismissedPowerupCode,
+  currentSubQueueIdKey,
 } from '../lib/consts';
 import { initIncrementalRem } from './powerups';
 import { getIncrementalRemFromRem, handleNextRepetitionClick, getCurrentIncrementalRem } from '../lib/incremental_rem';
@@ -742,6 +743,40 @@ export async function registerCommands(plugin: ReactRNPlugin) {
       }
 
       await plugin.app.toast('This Rem has no repetition history (not Incremental/Dismissed and no such descendants).');
+    },
+  });
+
+  // Open Sorting Criteria Widget Command
+  plugin.app.registerCommand({
+    id: 'open-sorting-criteria',
+    name: 'Open Sorting Criteria',
+    description: 'Open the Sorting Criteria widget to adjust randomness and cards per rem.',
+    action: async () => {
+      await plugin.widget.openPopup('sorting_criteria');
+    },
+  });
+
+  // Open Priority Shield Graph Command
+  plugin.app.registerCommand({
+    id: 'open-priority-shield',
+    name: 'Open Priority Shield Graph',
+    description: 'Open the Priority Shield Graph history.',
+    action: async () => {
+      let subQueueId: string | null = null;
+      const url = await plugin.window.getURL();
+
+      // Check if we are in the queue to get context
+      if (url.includes('/flashcards')) {
+        subQueueId = (await plugin.storage.getSession<string | null>(currentSubQueueIdKey)) ?? null;
+      } else {
+        // In editor, use focused rem
+        const focusedRem = await plugin.focus.getFocusedRem();
+        subQueueId = focusedRem?._id || null;
+      }
+
+      await plugin.widget.openPopup('priority_shield_graph', {
+        subQueueId,
+      });
     },
   });
 }

--- a/src/register/menus.ts
+++ b/src/register/menus.ts
@@ -40,6 +40,18 @@ export async function registerMenus(plugin: ReactRNPlugin) {
   });
 
   plugin.app.registerMenuItem({
+    id: 'priority_shield_document_menuitem',
+    name: 'Priority Shield History',
+    location: PluginCommandMenuLocation.DocumentMenu,
+    action: async (args: { remId: string }) => {
+      // For document menu, the remId IS the scope/subQueueId
+      await plugin.widget.openPopup('priority_shield_graph', {
+        subQueueId: args.remId,
+      });
+    },
+  });
+
+  plugin.app.registerMenuItem({
     id: 'tag_rem_menuitem',
     location: PluginCommandMenuLocation.DocumentMenu,
     name: 'Toggle Incremental Rem',


### PR DESCRIPTION
## v0.2.96 - February 9th, 2026

### 🎮 Improved Accessibility for Power Tools

We've made the advanced "Sorting Criteria" and "Priority Shield" features much easier to access, whether you're in the queue or the editor.

**What's new:**
*   **New Commands:**
    *   **"Open Sorting Criteria":** Quickly open the sorting settings widget from anywhere via the Command Palette.
    *   **"Open Priority Shield Graph":** access your priority stats instantly.
*   **Context-Aware Priority Shield:**
    *   **In the Queue:** Shows the history for your current queue (Flashcards or Document).
    *   **In the Editor:** Shows the history for the focused Rem or Document.
    *   **Document Menu Item:** Added "Priority Shield History" to the 3-dot menu of documents for easy access.
