### PR TITLE
🗓️ IncRem List: Date-Based Filtering, New Sort Options & Created At Tracking; Incremental History Widget: Unified Timeline

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -7,7 +7,7 @@
   "version": {
     "major": 0,
     "minor": 2,
-    "patch": 167
+    "patch": 168
   },
   "unlisted": false,
   "theme": [],

--- a/src/components/IncRemRow.tsx
+++ b/src/components/IncRemRow.tsx
@@ -16,6 +16,7 @@ export interface IncRemRowData {
   historyCount?: number;
   totalTimeSpent?: number;
   lastReviewDate?: number;
+  createdAt?: number;
   breadcrumb?: string;
 }
 
@@ -62,7 +63,7 @@ export function IncRemRow({
           <div className="truncate" title={incRem.breadcrumb ? `${incRem.breadcrumb} > ${incRem.remText}` : incRem.remText}>
             {incRem.remText || 'Loading...'}
           </div>
-          {(incRem.historyCount !== undefined && incRem.historyCount > 0) || (incRem.totalTimeSpent !== undefined && incRem.totalTimeSpent > 0) ? (
+          {((incRem.historyCount !== undefined && incRem.historyCount > 0) || (incRem.totalTimeSpent !== undefined && incRem.totalTimeSpent > 0) || incRem.lastReviewDate || incRem.createdAt) ? (
             <div className="text-xs mt-0.5 flex items-center gap-2" style={{ color: 'var(--rn-clr-content-tertiary)' }}>
               {incRem.historyCount !== undefined && incRem.historyCount > 0 && (
                 <span>{incRem.historyCount} review{incRem.historyCount !== 1 ? 's' : ''}</span>
@@ -75,6 +76,11 @@ export function IncRemRow({
               {incRem.lastReviewDate && (
                 <span style={{ color: 'var(--rn-clr-content-tertiary)' }} title="Last review date">
                   • Last reviewed: {timeSince(new Date(incRem.lastReviewDate))}
+                </span>
+              )}
+              {incRem.createdAt && (
+                <span style={{ color: 'var(--rn-clr-content-tertiary)' }} title={`Created at: ${new Date(incRem.createdAt).toLocaleString()}`}>
+                  • Created: {new Date(incRem.createdAt).toLocaleDateString()}
                 </span>
               )}
             </div>

--- a/src/components/IncRemTable.tsx
+++ b/src/components/IncRemTable.tsx
@@ -160,7 +160,7 @@ function DateFilterField({ label, filter, onChange }: DateFilterFieldProps) {
       borderRadius: 4,
       padding: '1px 4px',
       fontSize: 11,
-      width: 100,
+      width: 90,
       outline: 'none',
       transition: 'border-color 0.15s, background-color 0.15s',
     };
@@ -179,20 +179,20 @@ function DateFilterField({ label, filter, onChange }: DateFilterFieldProps) {
 
   const isBetween = filter.op === 'between';
   const hasValue = filter.value.trim() !== '';
-  const PLACEHOLDER = 'MM/DD/YYYY or N days';
+  const PLACEHOLDER = '';
 
   // Normalize MM/DD/YYYY or MM/DD to YYYY-MM-DD for the native date picker value
   const toPickerValue = (v: string): string => {
     const full = v.trim().match(/^(\d{1,2})\/(\d{1,2})\/(\d{4})$/);
     if (full) {
       const [, m, d, y] = full;
-      return `${y}-${m.padStart(2,'0')}-${d.padStart(2,'0')}`;
+      return `${y}-${m.padStart(2, '0')}-${d.padStart(2, '0')}`;
     }
     const short = v.trim().match(/^(\d{1,2})\/(\d{1,2})$/);
     if (short) {
       const [, m, d] = short;
       const y = new Date().getFullYear();
-      return `${y}-${m.padStart(2,'0')}-${d.padStart(2,'0')}`;
+      return `${y}-${m.padStart(2, '0')}-${d.padStart(2, '0')}`;
     }
     return '';
   };
@@ -395,11 +395,11 @@ export function IncRemTable({
     if (cutoff === null) return true; // unparseable value — don't filter
     const t = ts ?? 0;
     switch (op) {
-      case 'is':          return t >= cutoff && t < cutoff + 86_400_000; // same day
-      case 'before':      return t < cutoff;
-      case 'after':       return t > cutoff + 86_399_999; // strictly after that day ends
+      case 'is': return t >= cutoff && t < cutoff + 86_400_000; // same day
+      case 'before': return t < cutoff;
+      case 'after': return t > cutoff + 86_399_999; // strictly after that day ends
       case 'on-or-before': return t < cutoff + 86_400_000;
-      case 'on-or-after':  return t >= cutoff;
+      case 'on-or-after': return t >= cutoff;
       case 'between': {
         const cutoff2 = parseDateValue(value2);
         if (cutoff2 === null) return t >= cutoff;
@@ -855,8 +855,8 @@ export function IncRemTable({
             onChange={setCreatedAtFilter}
           />
         </div>
-        <div style={{ fontSize: 9, color: 'var(--rn-clr-content-tertiary)', marginTop: 2, letterSpacing: '0.01em' }}>
-          Date formats: MM/DD/YYYY · MM/DD (current year) · N (days ago). Use the 📅 button to pick from a calendar.
+        <div style={{ fontSize: 11, color: 'var(--rn-clr-content-tertiary)', marginTop: 2, letterSpacing: '0.01em' }}>
+          Date formats: MM/DD/YYYY · MM/DD (current year) · N (days ago). Use the calendar button to pick from a calendar.
         </div>
       </div>
 

--- a/src/components/IncRemTable.tsx
+++ b/src/components/IncRemTable.tsx
@@ -134,16 +134,38 @@ interface DateFilterFieldProps {
 }
 
 function DateFilterField({ label, filter, onChange }: DateFilterFieldProps) {
-  const inputStyle: React.CSSProperties = {
-    backgroundColor: 'var(--rn-clr-background-primary)',
-    color: 'var(--rn-clr-content-primary)',
-    border: '1px solid var(--rn-clr-border-primary)',
-    borderRadius: 4,
-    padding: '1px 4px',
-    fontSize: 11,
-    width: 90,
-    outline: 'none',
+  // Validate: empty = ok, plain integer (N days ago) = ok, MM/DD/YYYY or MM/DD = ok, else invalid
+  const isValueInvalid = (v: string): boolean => {
+    const trimmed = v.trim();
+    if (!trimmed) return false;
+    // Pure integer → N days ago → always valid
+    if (/^\d+$/.test(trimmed)) return false;
+    if (/^\d{1,2}\/\d{1,2}\/\d{4}$/.test(trimmed)) {
+      const [m, d, y] = trimmed.split('/').map(Number);
+      return isNaN(new Date(y, m - 1, d).getTime());
+    }
+    if (/^\d{1,2}\/\d{1,2}$/.test(trimmed)) {
+      const [m, d] = trimmed.split('/').map(Number);
+      return isNaN(new Date(new Date().getFullYear(), m - 1, d).getTime());
+    }
+    return true; // anything else is invalid
   };
+
+  const makeInputStyle = (value: string): React.CSSProperties => {
+    const invalid = isValueInvalid(value);
+    return {
+      backgroundColor: invalid ? 'rgba(239,68,68,0.08)' : 'var(--rn-clr-background-primary)',
+      color: 'var(--rn-clr-content-primary)',
+      border: `1px solid ${invalid ? '#ef4444' : 'var(--rn-clr-border-primary)'}`,
+      borderRadius: 4,
+      padding: '1px 4px',
+      fontSize: 11,
+      width: 100,
+      outline: 'none',
+      transition: 'border-color 0.15s, background-color 0.15s',
+    };
+  };
+
   const selectStyle: React.CSSProperties = {
     backgroundColor: 'var(--rn-clr-background-primary)',
     color: 'var(--rn-clr-content-secondary)',
@@ -157,9 +179,33 @@ function DateFilterField({ label, filter, onChange }: DateFilterFieldProps) {
 
   const isBetween = filter.op === 'between';
   const hasValue = filter.value.trim() !== '';
+  const PLACEHOLDER = 'MM/DD/YYYY or N days';
+
+  // Normalize MM/DD/YYYY or MM/DD to YYYY-MM-DD for the native date picker value
+  const toPickerValue = (v: string): string => {
+    const full = v.trim().match(/^(\d{1,2})\/(\d{1,2})\/(\d{4})$/);
+    if (full) {
+      const [, m, d, y] = full;
+      return `${y}-${m.padStart(2,'0')}-${d.padStart(2,'0')}`;
+    }
+    const short = v.trim().match(/^(\d{1,2})\/(\d{1,2})$/);
+    if (short) {
+      const [, m, d] = short;
+      const y = new Date().getFullYear();
+      return `${y}-${m.padStart(2,'0')}-${d.padStart(2,'0')}`;
+    }
+    return '';
+  };
+
+  // Convert YYYY-MM-DD from the picker back to MM/DD/YYYY
+  const fromPickerValue = (iso: string): string => {
+    const m = iso.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+    if (!m) return iso;
+    return `${Number(m[2])}/${Number(m[3])}/${m[1]}`;
+  };
 
   return (
-    <div style={{ display: 'flex', alignItems: 'center', gap: 3, position: 'relative' }}>
+    <div style={{ display: 'flex', alignItems: 'center', gap: 3 }}>
       <span style={{ color: 'var(--rn-clr-content-tertiary)', whiteSpace: 'nowrap', fontSize: 10, fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.04em' }}>
         {label}
       </span>
@@ -179,15 +225,14 @@ function DateFilterField({ label, filter, onChange }: DateFilterFieldProps) {
       <div style={{ display: 'flex', alignItems: 'center', gap: 1 }}>
         <input
           type="text"
-          placeholder="YYYY-MM-DD or N days"
+          placeholder={PLACEHOLDER}
           value={filter.value}
           onChange={(e) => onChange({ ...filter, value: e.target.value })}
-          style={inputStyle}
-          title="Enter a date (YYYY-MM-DD) or number of days ago (e.g. 30)"
+          style={makeInputStyle(filter.value)}
         />
         <CalendarPickerButton
-          value={filter.value.match(/^\d{4}-\d{2}-\d{2}$/) ? filter.value : ''}
-          onPick={(date) => onChange({ ...filter, value: date })}
+          value={toPickerValue(filter.value)}
+          onPick={(iso) => onChange({ ...filter, value: fromPickerValue(iso) })}
         />
       </div>
       {isBetween && (
@@ -196,15 +241,14 @@ function DateFilterField({ label, filter, onChange }: DateFilterFieldProps) {
           <div style={{ display: 'flex', alignItems: 'center', gap: 1 }}>
             <input
               type="text"
-              placeholder="YYYY-MM-DD or N days"
+              placeholder={PLACEHOLDER}
               value={filter.value2}
               onChange={(e) => onChange({ ...filter, value2: e.target.value })}
-              style={inputStyle}
-              title="End date for 'between' filter"
+              style={makeInputStyle(filter.value2)}
             />
             <CalendarPickerButton
-              value={filter.value2.match(/^\d{4}-\d{2}-\d{2}$/) ? filter.value2 : ''}
-              onPick={(date) => onChange({ ...filter, value2: date })}
+              value={toPickerValue(filter.value2)}
+              onPick={(iso) => onChange({ ...filter, value2: fromPickerValue(iso) })}
             />
           </div>
         </>
@@ -283,11 +327,6 @@ export function IncRemTable({
   const [lastReviewFilter, setLastReviewFilter] = useState<DateFilter>(initialState?.lastReviewFilter ?? defaultDateFilter());
   const [createdAtFilter, setCreatedAtFilter] = useState<DateFilter>(initialState?.createdAtFilter ?? defaultDateFilter());
 
-  // Calendar picker visibility per field
-  const [showDuePicker, setShowDuePicker] = useState(false);
-  const [showLastReviewPicker, setShowLastReviewPicker] = useState(false);
-  const [showCreatedAtPicker, setShowCreatedAtPicker] = useState(false);
-
   // Inline priority editing state
   const [editingPriorityRemId, setEditingPriorityRemId] = useState<string | null>(null);
   const [editingPriorityValue, setEditingPriorityValue] = useState<number>(0);
@@ -312,22 +351,37 @@ export function IncRemTable({
   }, [filterStatus, filterType, priorityMin, priorityMax, searchText, sortBy, sortOrder, dueDateFilter, lastReviewFilter, createdAtFilter, onStateChange]);
 
   /**
-   * Parse a filter field value string → millisecond timestamp cutoff.
+   * Parse a filter field value string → millisecond timestamp.
    * Accepts:
-   *   - YYYY-MM-DD string → parsed as that calendar day (start of day, local time)
-   *   - A plain integer N → means "N days ago" from now
-   * Returns null if the string is empty or invalid.
+   *   - MM/DD/YYYY → that specific date
+   *   - MM/DD      → that month/day in the current year
+   * Returns null for empty or unrecognised input.
    */
   function parseDateValue(value: string): number | null {
     const trimmed = value.trim();
     if (!trimmed) return null;
-    const asNum = Number(trimmed);
-    if (!isNaN(asNum) && trimmed !== '') {
-      // Treat as days ago; 0 = today's start
-      return Date.now() - asNum * 86_400_000;
+
+    // Plain integer N → N days ago from now
+    if (/^\d+$/.test(trimmed)) {
+      return Date.now() - Number(trimmed) * 86_400_000;
     }
-    const d = new Date(trimmed);
-    return isNaN(d.getTime()) ? null : d.getTime();
+
+    // MM/DD/YYYY
+    const fullMatch = trimmed.match(/^(\d{1,2})\/(\d{1,2})\/(\d{4})$/);
+    if (fullMatch) {
+      const d = new Date(Number(fullMatch[3]), Number(fullMatch[1]) - 1, Number(fullMatch[2]));
+      return isNaN(d.getTime()) ? null : d.getTime();
+    }
+
+    // MM/DD → current year
+    const shortMatch = trimmed.match(/^(\d{1,2})\/(\d{1,2})$/);
+    if (shortMatch) {
+      const year = new Date().getFullYear();
+      const d = new Date(year, Number(shortMatch[1]) - 1, Number(shortMatch[2]));
+      return isNaN(d.getTime()) ? null : d.getTime();
+    }
+
+    return null;
   }
 
   /**
@@ -778,27 +832,32 @@ export function IncRemTable({
 
       {/* Date filter bar */}
       <div
-        className="flex flex-wrap items-center gap-x-4 gap-y-1 px-4 py-1.5 shrink-0"
-        style={{ borderBottom: '1px solid var(--rn-clr-border-primary)', backgroundColor: 'var(--rn-clr-background-secondary)', fontSize: '11px' }}
+        className="flex flex-col px-4 py-1.5 shrink-0"
+        style={{ borderBottom: '1px solid var(--rn-clr-border-primary)', backgroundColor: 'var(--rn-clr-background-secondary)' }}
       >
-        {/* Due Date filter */}
-        <DateFilterField
-          label="Due"
-          filter={dueDateFilter}
-          onChange={setDueDateFilter}
-        />
-        {/* Last Review filter */}
-        <DateFilterField
-          label="Last Review"
-          filter={lastReviewFilter}
-          onChange={setLastReviewFilter}
-        />
-        {/* Created At filter */}
-        <DateFilterField
-          label="Created"
-          filter={createdAtFilter}
-          onChange={setCreatedAtFilter}
-        />
+        <div className="flex flex-wrap items-center gap-x-4 gap-y-1" style={{ fontSize: '11px' }}>
+          {/* Due Date filter */}
+          <DateFilterField
+            label="Due"
+            filter={dueDateFilter}
+            onChange={setDueDateFilter}
+          />
+          {/* Last Review filter */}
+          <DateFilterField
+            label="Last Review"
+            filter={lastReviewFilter}
+            onChange={setLastReviewFilter}
+          />
+          {/* Created At filter */}
+          <DateFilterField
+            label="Created"
+            filter={createdAtFilter}
+            onChange={setCreatedAtFilter}
+          />
+        </div>
+        <div style={{ fontSize: 9, color: 'var(--rn-clr-content-tertiary)', marginTop: 2, letterSpacing: '0.01em' }}>
+          Date formats: MM/DD/YYYY · MM/DD (current year) · N (days ago). Use the 📅 button to pick from a calendar.
+        </div>
       </div>
 
       {/* Rem List */}

--- a/src/components/IncRemTable.tsx
+++ b/src/components/IncRemTable.tsx
@@ -12,11 +12,21 @@ export interface IncRemWithDetails extends IncrementalRem {
   documentName?: string;
   lastReviewDate?: number;
   breadcrumb?: string;
+  // createdAt is already part of IncrementalRem base type (from originalIncrementalDateSlotCode)
 }
 
 type FilterStatus = 'all' | 'due' | 'scheduled';
-type SortBy = 'priority' | 'date' | 'reviews' | 'time' | 'lastReview' | 'queueOrder';
+type SortBy = 'priority' | 'date' | 'reviews' | 'time' | 'lastReview' | 'createdAt' | 'queueOrder';
 type SortOrder = 'asc' | 'desc';
+type DateFilterOp = 'is' | 'before' | 'after' | 'on-or-before' | 'on-or-after' | 'between';
+
+interface DateFilter {
+  op: DateFilterOp;
+  value: string;   // YYYY-MM-DD or N (days ago)
+  value2: string;  // only used for 'between'
+}
+
+const defaultDateFilter = (): DateFilter => ({ op: 'on-or-after', value: '', value2: '' });
 
 export interface IncRemListState {
   filterStatus: FilterStatus;
@@ -26,6 +36,9 @@ export interface IncRemListState {
   searchText: string;
   sortBy: SortBy;
   sortOrder: SortOrder;
+  dueDateFilter?: DateFilter;
+  lastReviewFilter?: DateFilter;
+  createdAtFilter?: DateFilter;
 }
 
 export interface DocumentInfo {
@@ -34,6 +47,189 @@ export interface DocumentInfo {
   count: number;
   dueCount: number;
 }
+
+// ─── CalendarPickerButton ─────────────────────────────────────────────────────
+// Uses a ref to an always-mounted hidden <input type="date"> and calls
+// .showPicker() imperatively — the only reliable cross-browser way to open
+// the native calendar from a custom button.
+interface CalendarPickerButtonProps {
+  value: string;
+  onPick: (date: string) => void;
+}
+
+function CalendarPickerButton({ value, onPick }: CalendarPickerButtonProps) {
+  const pickerRef = useRef<HTMLInputElement>(null);
+
+  const handleButtonClick = (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    const input = pickerRef.current;
+    if (!input) return;
+    // showPicker() is the standard imperative API (Chrome 99+, Firefox 101+, Safari 16+)
+    if (typeof input.showPicker === 'function') {
+      input.showPicker();
+    } else {
+      // Fallback: make the input briefly interactive so the user can click it
+      input.style.opacity = '1';
+      input.style.height = '24px';
+      input.focus();
+      setTimeout(() => {
+        if (pickerRef.current) {
+          pickerRef.current.style.opacity = '0';
+          pickerRef.current.style.height = '0';
+        }
+      }, 2000);
+    }
+  };
+
+  return (
+    <div style={{ position: 'relative', display: 'inline-flex', alignItems: 'center' }}>
+      {/* Always-mounted hidden native date input — positioned over the button */}
+      <input
+        ref={pickerRef}
+        type="date"
+        value={value}
+        onChange={(e) => onPick(e.target.value)}
+        tabIndex={-1}
+        style={{
+          position: 'absolute',
+          right: 0,
+          top: 0,
+          width: '22px',
+          height: '22px',
+          opacity: 0,
+          cursor: 'pointer',
+          zIndex: 1,
+          // Hide the default calendar icon; we provide our own button
+          colorScheme: 'light dark',
+        }}
+      />
+      {/* Visual 📅 button sits below the invisible input in stacking order */}
+      <button
+        onClick={handleButtonClick}
+        title="Pick date from calendar"
+        style={{
+          background: 'none',
+          border: 'none',
+          cursor: 'pointer',
+          padding: '0 2px',
+          color: 'var(--rn-clr-content-tertiary)',
+          fontSize: 11,
+          lineHeight: 1,
+          position: 'relative',
+          zIndex: 0,
+        }}
+      >
+        📅
+      </button>
+    </div>
+  );
+}
+
+// ─── DateFilterField ─────────────────────────────────────────────────────────
+interface DateFilterFieldProps {
+  label: string;
+  filter: { op: string; value: string; value2: string };
+  onChange: (f: { op: any; value: string; value2: string }) => void;
+}
+
+function DateFilterField({ label, filter, onChange }: DateFilterFieldProps) {
+  const inputStyle: React.CSSProperties = {
+    backgroundColor: 'var(--rn-clr-background-primary)',
+    color: 'var(--rn-clr-content-primary)',
+    border: '1px solid var(--rn-clr-border-primary)',
+    borderRadius: 4,
+    padding: '1px 4px',
+    fontSize: 11,
+    width: 90,
+    outline: 'none',
+  };
+  const selectStyle: React.CSSProperties = {
+    backgroundColor: 'var(--rn-clr-background-primary)',
+    color: 'var(--rn-clr-content-secondary)',
+    border: '1px solid var(--rn-clr-border-primary)',
+    borderRadius: 4,
+    padding: '1px 2px',
+    fontSize: 11,
+    outline: 'none',
+    cursor: 'pointer',
+  };
+
+  const isBetween = filter.op === 'between';
+  const hasValue = filter.value.trim() !== '';
+
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 3, position: 'relative' }}>
+      <span style={{ color: 'var(--rn-clr-content-tertiary)', whiteSpace: 'nowrap', fontSize: 10, fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.04em' }}>
+        {label}
+      </span>
+      <select
+        value={filter.op}
+        onChange={(e) => onChange({ ...filter, op: e.target.value as any })}
+        style={selectStyle}
+        title="Filter comparison"
+      >
+        <option value="is">is</option>
+        <option value="before">is before</option>
+        <option value="after">is after</option>
+        <option value="on-or-before">is on/before</option>
+        <option value="on-or-after">is on/after</option>
+        <option value="between">is between</option>
+      </select>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+        <input
+          type="text"
+          placeholder="YYYY-MM-DD or N days"
+          value={filter.value}
+          onChange={(e) => onChange({ ...filter, value: e.target.value })}
+          style={inputStyle}
+          title="Enter a date (YYYY-MM-DD) or number of days ago (e.g. 30)"
+        />
+        <CalendarPickerButton
+          value={filter.value.match(/^\d{4}-\d{2}-\d{2}$/) ? filter.value : ''}
+          onPick={(date) => onChange({ ...filter, value: date })}
+        />
+      </div>
+      {isBetween && (
+        <>
+          <span style={{ color: 'var(--rn-clr-content-tertiary)' }}>–</span>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+            <input
+              type="text"
+              placeholder="YYYY-MM-DD or N days"
+              value={filter.value2}
+              onChange={(e) => onChange({ ...filter, value2: e.target.value })}
+              style={inputStyle}
+              title="End date for 'between' filter"
+            />
+            <CalendarPickerButton
+              value={filter.value2.match(/^\d{4}-\d{2}-\d{2}$/) ? filter.value2 : ''}
+              onPick={(date) => onChange({ ...filter, value2: date })}
+            />
+          </div>
+        </>
+      )}
+      {hasValue && (
+        <button
+          onClick={() => onChange({ ...filter, value: '', value2: '' })}
+          title="Clear this date filter"
+          style={{
+            background: 'none',
+            border: 'none',
+            cursor: 'pointer',
+            padding: '0 2px',
+            color: 'var(--rn-clr-content-tertiary)',
+            fontSize: 11,
+            lineHeight: 1,
+          }}
+        >
+          ✕
+        </button>
+      )}
+    </div>
+  );
+}
+// ─────────────────────────────────────────────────────────────────────────────
 
 interface IncRemTableProps {
   title: string;
@@ -82,6 +278,16 @@ export function IncRemTable({
   const [sortBy, setSortBy] = useState<SortBy>(initialState?.sortBy ?? 'priority');
   const [sortOrder, setSortOrder] = useState<SortOrder>(initialState?.sortOrder ?? 'asc');
 
+  // Date filters
+  const [dueDateFilter, setDueDateFilter] = useState<DateFilter>(initialState?.dueDateFilter ?? defaultDateFilter());
+  const [lastReviewFilter, setLastReviewFilter] = useState<DateFilter>(initialState?.lastReviewFilter ?? defaultDateFilter());
+  const [createdAtFilter, setCreatedAtFilter] = useState<DateFilter>(initialState?.createdAtFilter ?? defaultDateFilter());
+
+  // Calendar picker visibility per field
+  const [showDuePicker, setShowDuePicker] = useState(false);
+  const [showLastReviewPicker, setShowLastReviewPicker] = useState(false);
+  const [showCreatedAtPicker, setShowCreatedAtPicker] = useState(false);
+
   // Inline priority editing state
   const [editingPriorityRemId, setEditingPriorityRemId] = useState<string | null>(null);
   const [editingPriorityValue, setEditingPriorityValue] = useState<number>(0);
@@ -101,9 +307,55 @@ export function IncRemTable({
   // Use the actual state values, not the effective ones, so if they change sort they get their old filters back
   useEffect(() => {
     if (onStateChange) {
-      onStateChange({ filterStatus, filterType, priorityMin, priorityMax, searchText, sortBy, sortOrder });
+      onStateChange({ filterStatus, filterType, priorityMin, priorityMax, searchText, sortBy, sortOrder, dueDateFilter, lastReviewFilter, createdAtFilter });
     }
-  }, [filterStatus, filterType, priorityMin, priorityMax, searchText, sortBy, sortOrder, onStateChange]);
+  }, [filterStatus, filterType, priorityMin, priorityMax, searchText, sortBy, sortOrder, dueDateFilter, lastReviewFilter, createdAtFilter, onStateChange]);
+
+  /**
+   * Parse a filter field value string → millisecond timestamp cutoff.
+   * Accepts:
+   *   - YYYY-MM-DD string → parsed as that calendar day (start of day, local time)
+   *   - A plain integer N → means "N days ago" from now
+   * Returns null if the string is empty or invalid.
+   */
+  function parseDateValue(value: string): number | null {
+    const trimmed = value.trim();
+    if (!trimmed) return null;
+    const asNum = Number(trimmed);
+    if (!isNaN(asNum) && trimmed !== '') {
+      // Treat as days ago; 0 = today's start
+      return Date.now() - asNum * 86_400_000;
+    }
+    const d = new Date(trimmed);
+    return isNaN(d.getTime()) ? null : d.getTime();
+  }
+
+  /**
+   * Given a timestamp `ts` and a DateFilter, returns true if `ts` passes the filter.
+   * A missing / empty filter always passes.
+   */
+  function passesDateFilter(ts: number | undefined, filter: DateFilter): boolean {
+    const { op, value, value2 } = filter;
+    if (!value.trim()) return true; // no filter set
+    const cutoff = parseDateValue(value);
+    if (cutoff === null) return true; // unparseable value — don't filter
+    const t = ts ?? 0;
+    switch (op) {
+      case 'is':          return t >= cutoff && t < cutoff + 86_400_000; // same day
+      case 'before':      return t < cutoff;
+      case 'after':       return t > cutoff + 86_399_999; // strictly after that day ends
+      case 'on-or-before': return t < cutoff + 86_400_000;
+      case 'on-or-after':  return t >= cutoff;
+      case 'between': {
+        const cutoff2 = parseDateValue(value2);
+        if (cutoff2 === null) return t >= cutoff;
+        const lo = Math.min(cutoff, cutoff2);
+        const hi = Math.max(cutoff, cutoff2) + 86_399_999;
+        return t >= lo && t <= hi;
+      }
+      default: return true;
+    }
+  }
 
   // Apply sorting criteria, preserving a stable random order for 'queueOrder'
   const randomOrderCache = useRef<Record<string, number>>({});
@@ -126,6 +378,10 @@ export function IncRemTable({
       if (searchText && rem.remText && !rem.remText.toLowerCase().includes(searchText.toLowerCase())) {
         return false;
       }
+      // Date filters
+      if (!passesDateFilter(rem.nextRepDate, dueDateFilter)) return false;
+      if (!passesDateFilter(rem.lastReviewDate, lastReviewFilter)) return false;
+      if (!passesDateFilter(rem.createdAt, createdAtFilter)) return false;
       return true;
     });
 
@@ -176,15 +432,21 @@ export function IncRemTable({
           const aDate = a.lastReviewDate || 0;
           const bDate = b.lastReviewDate || 0;
           comparison = aDate - bDate;
+        } else if (sortBy === 'createdAt') {
+          const aDate = a.createdAt || 0;
+          const bDate = b.createdAt || 0;
+          comparison = aDate - bDate;
         }
         return effectiveSortOrder === 'asc' ? comparison : -comparison;
       });
     }
 
     return filtered;
-  }, [incRems, effectiveFilterStatus, filterType, priorityMin, priorityMax, searchText, sortBy, effectiveSortOrder, sortingRandomness]);
+  }, [incRems, effectiveFilterStatus, filterType, priorityMin, priorityMax, searchText, sortBy, effectiveSortOrder, sortingRandomness, dueDateFilter, lastReviewFilter, createdAtFilter]);
 
-  const hasActiveFilters = filterStatus !== 'all' || filterType !== 'all' || priorityMin !== 0 || priorityMax !== 100 || searchText !== '' || selectedDocumentId;
+  const hasDateFilter = (f: DateFilter) => f.value.trim() !== '';
+  const hasActiveFilters = filterStatus !== 'all' || filterType !== 'all' || priorityMin !== 0 || priorityMax !== 100 || searchText !== '' || selectedDocumentId ||
+    hasDateFilter(dueDateFilter) || hasDateFilter(lastReviewFilter) || hasDateFilter(createdAtFilter);
 
   return (
     <div className="flex flex-col h-full" style={{
@@ -246,6 +508,7 @@ export function IncRemTable({
             <option value="reviews">Reviews</option>
             <option value="time">Time Spent</option>
             <option value="lastReview">Last Review Date</option>
+            <option value="createdAt">Created At</option>
             <option value="queueOrder">Sort for Review</option>
           </select>
           <button
@@ -497,6 +760,9 @@ export function IncRemTable({
               setPriorityMin(0);
               setPriorityMax(100);
               setSearchText('');
+              setDueDateFilter(defaultDateFilter());
+              setLastReviewFilter(defaultDateFilter());
+              setCreatedAtFilter(defaultDateFilter());
               onDocumentFilterChange?.(null);
             }}
             className="px-2 py-1 text-xs rounded transition-colors"
@@ -508,6 +774,31 @@ export function IncRemTable({
             ✕
           </button>
         )}
+      </div>
+
+      {/* Date filter bar */}
+      <div
+        className="flex flex-wrap items-center gap-x-4 gap-y-1 px-4 py-1.5 shrink-0"
+        style={{ borderBottom: '1px solid var(--rn-clr-border-primary)', backgroundColor: 'var(--rn-clr-background-secondary)', fontSize: '11px' }}
+      >
+        {/* Due Date filter */}
+        <DateFilterField
+          label="Due"
+          filter={dueDateFilter}
+          onChange={setDueDateFilter}
+        />
+        {/* Last Review filter */}
+        <DateFilterField
+          label="Last Review"
+          filter={lastReviewFilter}
+          onChange={setLastReviewFilter}
+        />
+        {/* Created At filter */}
+        <DateFilterField
+          label="Created"
+          filter={createdAtFilter}
+          onChange={setCreatedAtFilter}
+        />
       </div>
 
       {/* Rem List */}
@@ -528,6 +819,7 @@ export function IncRemTable({
                     historyCount: incRem.history?.length,
                     totalTimeSpent: incRem.totalTimeSpent,
                     lastReviewDate: incRem.lastReviewDate,
+                    createdAt: incRem.createdAt,
                     breadcrumb: incRem.breadcrumb,
                   } as IncRemRowData}
                   onClick={() => onRemClick(incRem.remId)}

--- a/src/lib/history_utils.ts
+++ b/src/lib/history_utils.ts
@@ -8,6 +8,8 @@ export interface IncrementalHistoryData {
     kbId?: string;
     text?: string;
     _v?: number;
+    /** 'reviewed' = a review session; 'created' = the rem was first made Incremental */
+    eventType?: 'reviewed' | 'created';
 }
 
 const HISTORY_KEY = 'incrementalHistoryData';
@@ -22,7 +24,7 @@ export async function addToIncrementalHistory(plugin: RNPlugin, remId: RemId) {
     const historyRaw = (await plugin.storage.getSynced<IncrementalHistoryData[]>(HISTORY_KEY)) || [];
 
     // Remove existing entry for this remId if it exists to bump it to the top
-    const existingIndex = historyRaw.findIndex((x) => x.remId === remId);
+    const existingIndex = historyRaw.findIndex((x) => x.remId === remId && x.eventType !== 'created');
     if (existingIndex !== -1) {
         historyRaw.splice(existingIndex, 1);
     }
@@ -34,7 +36,42 @@ export async function addToIncrementalHistory(plugin: RNPlugin, remId: RemId) {
         time: Date.now(),
         kbId,
         _v: 1,
+        eventType: 'reviewed',
         // Text will be backfilled by the widget to keep this function fast
+    };
+
+    historyRaw.unshift(newEntry);
+
+    // Limit size
+    if (historyRaw.length > MAX_HISTORY_ITEMS) {
+        historyRaw.length = MAX_HISTORY_ITEMS;
+    }
+
+    await plugin.storage.setSynced(HISTORY_KEY, historyRaw);
+}
+
+/**
+ * Adds a "created" event to the incremental history log.
+ * Unlike the review helper, this never deduplicates — creation is a one-time event.
+ */
+export async function addCreationToIncrementalHistory(plugin: RNPlugin, remId: RemId) {
+    if (!remId) return;
+
+    const currentKb = await plugin.kb.getCurrentKnowledgeBaseData();
+    const kbId = currentKb._id;
+
+    const historyRaw = (await plugin.storage.getSynced<IncrementalHistoryData[]>(HISTORY_KEY)) || [];
+
+    // Skip if a creation entry for this remId already exists (idempotent guard)
+    if (historyRaw.some((x) => x.remId === remId && x.eventType === 'created')) return;
+
+    const newEntry: IncrementalHistoryData = {
+        key: Math.random(),
+        remId,
+        time: Date.now(),
+        kbId,
+        _v: 1,
+        eventType: 'created',
     };
 
     historyRaw.unshift(newEntry);

--- a/src/lib/incremental_rem/index.ts
+++ b/src/lib/incremental_rem/index.ts
@@ -323,6 +323,8 @@ export async function initIncrementalRem(plugin: ReactRNPlugin, rem: PluginRem, 
         if (todayRef) {
           await rem.setPowerupProperty(powerupCode, originalIncrementalDateSlotCode, todayRef);
         }
+        // Record creation event in incremental history (fire and forget)
+        addCreationToIncrementalHistory(plugin, rem._id).catch(console.error);
       }
 
       const newIncRem = await getIncrementalRemFromRem(plugin, rem);
@@ -360,7 +362,7 @@ export const getCurrentIncrementalRem = async (plugin: RNPlugin) => {
   return rem;
 };
 
-import { addToIncrementalHistory } from '../history_utils';
+import { addToIncrementalHistory, addCreationToIncrementalHistory } from '../history_utils';
 
 /**
  * Sets the current Incremental Rem in session storage.

--- a/src/lib/incremental_rem/index.ts
+++ b/src/lib/incremental_rem/index.ts
@@ -219,11 +219,31 @@ export const getIncrementalRemFromRem = async (
     }
   }
 
+  // Read the original incremental date slot (Daily Document reference)
+  let createdAt: number | undefined;
+  const createdAtRichText = (await r.getPowerupPropertyAsRichText(
+    powerupCode,
+    originalIncrementalDateSlotCode
+  )) as RichTextElementRemInterface[];
+  if (createdAtRichText && createdAtRichText.length > 0 && createdAtRichText[0]?._id) {
+    const createdAtDoc = await plugin.rem.findOne(createdAtRichText[0]._id);
+    if (createdAtDoc) {
+      const createdAtYYYYMMDD = await createdAtDoc.getPowerupProperty<BuiltInPowerupCodes.DailyDocument>(
+        BuiltInPowerupCodes.DailyDocument,
+        'Date'
+      );
+      if (createdAtYYYYMMDD) {
+        createdAt = dayjs(createdAtYYYYMMDD, 'YYYY-MM-DD').valueOf();
+      }
+    }
+  }
+
   const rawData = {
     remId: r._id,
     nextRepDate: date.valueOf(),
     priority: priority,
     history: tryParseJson(await r.getPowerupProperty(powerupCode, repHistorySlotCode)),
+    createdAt,
   };
 
   const parsed = IncrementalRem.safeParse(rawData);

--- a/src/lib/incremental_rem/types.ts
+++ b/src/lib/incremental_rem/types.ts
@@ -100,6 +100,12 @@ export const IncrementalRem = z.object({
   nextRepDate: z.number(),
   priority: z.number().min(0).max(100),
   history: z.array(IncrementalRep).optional(),
+  /**
+   * Timestamp (ms) when the Rem was first made Incremental.
+   * Corresponds to the `originalIncrementalDateSlotCode` powerup slot.
+   * Not set for rems that were re-incrementalized from a dismissed state.
+   */
+  createdAt: z.number().optional(),
 });
 
 export type IncrementalRem = z.infer<typeof IncrementalRem>;

--- a/src/register/widgets.ts
+++ b/src/register/widgets.ts
@@ -158,7 +158,7 @@ export function registerWidgets(plugin: ReactRNPlugin) {
 
   // Register incremental rem list popup
   plugin.app.registerWidget('inc_rem_list', WidgetLocation.Popup, {
-    dimensions: { height: 600, width: 800 },
+    dimensions: { height: 800, width: 1000 },
   });
 
   // Register incremental rem main view - comprehensive view with filters

--- a/src/widgets/debug.tsx
+++ b/src/widgets/debug.tsx
@@ -93,6 +93,20 @@ function Debug() {
           />
           <Info className="priority" label="Priority" data={incrementalRem.priority} />
           <Info
+            className="created-at-raw"
+            label="Created At (Raw)"
+            data={incrementalRem.createdAt !== undefined
+              ? incrementalRem.createdAt
+              : <span style={{ color: 'var(--rn-clr-content-tertiary)', fontStyle: 'italic' }}>Not set (dismissed or legacy rem)</span>}
+          />
+          <Info
+            className="created-at-human"
+            label="Created At (Human)"
+            data={incrementalRem.createdAt !== undefined
+              ? `${dayjs(incrementalRem.createdAt).format('MMMM D, YYYY')} (${dayjs(incrementalRem.createdAt).fromNow()})`
+              : <span style={{ color: 'var(--rn-clr-content-tertiary)', fontStyle: 'italic' }}>Not set (dismissed or legacy rem)</span>}
+          />
+          <Info
             className="history"
             label="History"
             data={<pre style={preStyle}>{incrementalRem?.history ? JSON.stringify(incrementalRem.history, null, 2) : '[]'}</pre>}

--- a/src/widgets/incremental_history.tsx
+++ b/src/widgets/incremental_history.tsx
@@ -269,7 +269,6 @@ function HistoryItem({
                     </div>
                     <RemViewer
                         remId={remId}
-                        constraintRef="parent"
                         width="100%"
                         className="font-light cursor-pointer line-clamp-2"
                     />

--- a/src/widgets/incremental_history.tsx
+++ b/src/widgets/incremental_history.tsx
@@ -78,7 +78,7 @@ function IncrementalHistory() {
         }
     }, [historyDataRaw, plugin]);
 
-    // Effect to filter data by Knowledge Base AND Search Text
+    // Effect to filter data by Knowledge Base AND Search Text, then sort chronologically
     useEffect(() => {
         async function filterData() {
             const currentKb = await plugin.kb.getCurrentKnowledgeBaseData();
@@ -117,6 +117,9 @@ function IncrementalHistory() {
                         return b.item.time - a.item.time;
                     })
                     .map(x => x.item);
+            } else {
+                // No search active: sort chronologically (most recent first)
+                filtered = [...filtered].sort((a, b) => b.time - a.time);
             }
 
             setFilteredData(filtered);
@@ -170,7 +173,7 @@ function IncrementalHistory() {
             </div>
             {filteredData.length === 0 && (
                 <div className="p-2 rn-clr-content-primary">
-                    Study some Incremental Rems to see your history here.
+                    Study or create Incremental Rems to see your history here.
                 </div>
             )}
             {filteredData.slice(0, NUM_TO_LOAD_IN_BATCH * numLoaded).map((data) => (
@@ -194,6 +197,30 @@ function IncrementalHistory() {
     );
 }
 
+/** Small pill badge to differentiate event types */
+function EventBadge({ eventType }: { eventType?: 'reviewed' | 'created' }) {
+    const isCreated = eventType === 'created';
+    return (
+        <span
+            style={{
+                display: 'inline-block',
+                fontSize: 9,
+                fontWeight: 700,
+                letterSpacing: '0.05em',
+                textTransform: 'uppercase',
+                padding: '1px 5px',
+                borderRadius: 3,
+                backgroundColor: isCreated ? 'rgba(16,185,129,0.15)' : 'rgba(99,102,241,0.12)',
+                color: isCreated ? '#10b981' : '#818cf8',
+                flexShrink: 0,
+                alignSelf: 'center',
+            }}
+        >
+            {isCreated ? 'Created' : 'Reviewed'}
+        </span>
+    );
+}
+
 function HistoryItem({
     data,
     remId,
@@ -214,6 +241,11 @@ function HistoryItem({
         }
     };
 
+    const isCreated = data.eventType === 'created';
+    const timeLabel = isCreated
+        ? `Created ${timeSince(new Date(data.time))}`
+        : `Seen ${timeSince(new Date(data.time))}`;
+
     return (
         <div className="px-1 py-4 border-b border-gray-100" key={data.key}>
             <div className="flex gap-2 mb-2">
@@ -232,6 +264,9 @@ function HistoryItem({
                     />
                 </div>
                 <div className="flex-grow min-w-0" onClick={() => openRem(remId)}>
+                    <div className="flex items-center gap-1.5 mb-0.5">
+                        <EventBadge eventType={data.eventType} />
+                    </div>
                     <RemViewer
                         remId={remId}
                         constraintRef="parent"
@@ -239,7 +274,7 @@ function HistoryItem({
                         className="font-light cursor-pointer line-clamp-2"
                     />
                     <div className="text-xs rn-clr-content-tertiary">
-                        Seen {timeSince(new Date(data.time))}
+                        {timeLabel}
                     </div>
                 </div>
                 <div
@@ -268,3 +303,4 @@ function HistoryItem({
 }
 
 renderWidget(IncrementalHistory);
+

--- a/src/widgets/priority_interval.tsx
+++ b/src/widgets/priority_interval.tsx
@@ -23,6 +23,9 @@ function PriorityInterval() {
     // Refs
     const prioritySliderRef = useRef<PrioritySliderRef>(null);
     const intervalInputRef = useRef<HTMLInputElement>(null);
+    const saveButtonRef = useRef<HTMLButtonElement>(null);
+    const next7ButtonRef = useRef<HTMLButtonElement>(null);
+    const next30ButtonRef = useRef<HTMLButtonElement>(null);
     const isSaving = useRef(false);
 
     // Context
@@ -121,18 +124,38 @@ function PriorityInterval() {
         }, 50);
     }, [!!data]);
 
-    // Tab cycling: priority → interval → priority
+    // Tab cycling: priority → interval → Save → Next 7 Days → Next 30 Days → priority
+    // Shift+Tab reverses the cycle.
+    const focusCycle = [
+        () => { prioritySliderRef.current?.focus(); prioritySliderRef.current?.select(); },
+        () => { intervalInputRef.current?.focus(); intervalInputRef.current?.select(); },
+        () => saveButtonRef.current?.focus(),
+        () => next7ButtonRef.current?.focus(),
+        () => next30ButtonRef.current?.focus(),
+    ];
+
     const handleTab = (e: React.KeyboardEvent) => {
-        if (e.key !== 'Tab' || e.shiftKey) return;
+        if (e.key !== 'Tab') return;
         e.preventDefault();
-        const active = document.activeElement;
-        if (active?.closest('[data-section="priority"]')) {
-            intervalInputRef.current?.focus();
-            intervalInputRef.current?.select();
-        } else {
-            prioritySliderRef.current?.focus();
-            prioritySliderRef.current?.select();
+        const active = document.activeElement as HTMLElement | null;
+        // Determine current position:
+        // - Priority slider: active element is inside [data-section="priority"]
+        // - Others: direct ref comparison
+        let currentIdx = 0;
+        if (active?.closest?.('[data-section="priority"]')) {
+            currentIdx = 0;
+        } else if (active === intervalInputRef.current) {
+            currentIdx = 1;
+        } else if (active === saveButtonRef.current) {
+            currentIdx = 2;
+        } else if (active === next7ButtonRef.current) {
+            currentIdx = 3;
+        } else if (active === next30ButtonRef.current) {
+            currentIdx = 4;
         }
+        const step = e.shiftKey ? -1 : 1;
+        const nextIdx = (currentIdx + step + focusCycle.length) % focusCycle.length;
+        focusCycle[nextIdx]?.();
     };
 
     // handleSave: writes job to session storage, closes popup immediately.
@@ -190,6 +213,9 @@ function PriorityInterval() {
             }}
             onKeyDown={(e) => {
                 if (e.key === 'Enter') {
+                    const active = document.activeElement;
+                    // Let preset buttons handle Enter themselves via native click
+                    if (active === next7ButtonRef.current || active === next30ButtonRef.current) return;
                     e.preventDefault();
                     handleSave();
                 } else if (e.key === 'Escape') {
@@ -304,24 +330,39 @@ function PriorityInterval() {
             {/* Buttons */}
             <div className="flex gap-2 mt-2 flex-wrap">
                 <button
+                    ref={saveButtonRef}
                     onClick={() => handleSave()}
+                    onKeyDown={handleTab}
+                    tabIndex={0}
                     className="px-3 py-1.5 text-xs font-bold rounded text-white transition-opacity hover:opacity-90 flex-1"
-                    style={{ backgroundColor: '#3B82F6' }}
+                    style={{ backgroundColor: '#3B82F6', outline: 'none' }}
+                    onFocus={(e) => { e.currentTarget.style.boxShadow = '0 0 0 3px rgba(59, 130, 246, 0.6), 0 0 0 1px white'; }}
+                    onBlur={(e) => { e.currentTarget.style.boxShadow = 'none'; }}
                 >
                     Save
                 </button>
                 <button
+                    ref={next7ButtonRef}
                     onClick={() => handleSave(7)}
+                    onKeyDown={handleTab}
+                    tabIndex={0}
                     className="px-3 py-1.5 text-xs font-bold rounded text-white transition-opacity hover:opacity-90"
-                    style={{ backgroundColor: '#10B981' }}
+                    style={{ backgroundColor: '#10B981', outline: 'none' }}
+                    onFocus={(e) => { e.currentTarget.style.boxShadow = '0 0 0 3px rgba(16, 185, 129, 0.6), 0 0 0 1px white'; }}
+                    onBlur={(e) => { e.currentTarget.style.boxShadow = 'none'; }}
                     title="Set priority and schedule next review in 7 days"
                 >
                     Next 7 Days
                 </button>
                 <button
+                    ref={next30ButtonRef}
                     onClick={() => handleSave(30)}
+                    onKeyDown={handleTab}
+                    tabIndex={0}
                     className="px-3 py-1.5 text-xs font-bold rounded text-white transition-opacity hover:opacity-90"
-                    style={{ backgroundColor: '#8B5CF6' }}
+                    style={{ backgroundColor: '#8B5CF6', outline: 'none' }}
+                    onFocus={(e) => { e.currentTarget.style.boxShadow = '0 0 0 3px rgba(139, 92, 246, 0.6), 0 0 0 1px white'; }}
+                    onBlur={(e) => { e.currentTarget.style.boxShadow = 'none'; }}
                     title="Set priority and schedule next review in 30 days"
                 >
                     Next 30 Days


### PR DESCRIPTION
## v0.2.169 - April 10th, 2026

### 🗓️ IncRem List: Date-Based Filtering, New Sort Options & Created At Tracking

A significant upgrade to the **IncRem List** and **All Inc Rems** widgets, adding fine-grained date filtering, new sort options, and a new "Created At" metadata field for every Incremental Rem.

#### Date Filters

A dedicated date filter bar has been added below the existing status/type/priority filters. It contains three independent date fields — **Due**, **Last Review**, and **Created** — each supporting six comparison operators:

| Operator | Meaning |
|---|---|
| **is** | Exactly on that date |
| **is before** | Strictly earlier than the date |
| **is after** | Strictly later than the date |
| **is on/before** | On or before the date |
| **is on/after** | On or after the date |
| **is between** | Within a date range (shows a second input) |

Each field accepts three input formats:
- **MM/DD/YYYY** — a specific date
- **MM/DD** — that month and day in the current year
- **N** (plain integer) — N days ago from today (e.g. `30` = 30 days ago)

A **calendar button** (📅) next to each input opens the native date picker. Typing directly into the field is also supported; invalid values are highlighted with a **red border** and a red background tint. A shared hint line at the bottom of the filter bar explains all accepted formats.

#### New Sort Options

Two new options have been added to the sort dropdown:
- **Created At** — sort by the date the Rem was first made Incremental
- **Last Review Date** — sort by the most recent review session

The "Created At" field is also now visible on each row below the last-reviewed date.

<img src="./assets/increm-list-date-filters.png" width="800" alt="IncRem List Date Filters" />

#### Incremental History Widget: Unified Timeline

The **Incremental History** sidebar widget now shows a **unified chronological timeline** of both review sessions and creation events:

- When a new Incremental Rem is created, a **"Created"** event is logged automatically and appears in the history.
- Each entry now carries a pill badge:
  - 🟢 **Created** — the Rem was first made Incremental on this date
  - 🟣 **Reviewed** — a review session on this date
- All events are sorted together by time (most recent first), giving a single coherent log of all your Incremental activity.
