### PR TITLE
✨ New: SuperMemo-style Extract & Cloze Logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,12 +57,14 @@ This README covers the basics. For the comprehensive guides, please visit the **
 
 ### Getting Started
 1. **Make Incremental**: Make any Rem, PDF, or Website `Incremental` using the `/Incremental Everything` command (Shortcut: `Alt+X`).
+   * **Extract Selection**: If you have text selected, `Alt+X` will extract that specific piece into a new child Rem and link it back.
 
 ![Make Incremental using the command](https://raw.githubusercontent.com/bjsi/incremental-everything/main/img/tag-inc-rem.gif)
 
-2. **Prioritize it**: Use `Alt+P` to set its importance.
-3. **Review it**: The plugin interleaves these items into your regular flashcard queue.
-4. **Disable it**: Remove the `Incremental` tag or press the **Dismiss** button in the queue if you are done reviewing it.
+2. **Prioritize it**: Use `Alt+P` or `Alt+Shift+X` (Extract with Priority) to set its importance.
+3. **Create Flashcards**: Use `Alt+Z` to quickly create a **Cloze Deletion** from selected text.
+4. **Review it**: The plugin interleaves these items into your regular flashcard queue.
+5. **Disable it**: Remove the `Incremental` tag or press the **Dismiss** button in the queue if you are done reviewing it.
 
 ### ⚡ Prioritization & Sorting
 - 0 is for your most important material and 100 is for the least important.

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -7,7 +7,7 @@
   "version": {
     "major": 0,
     "minor": 2,
-    "patch": 168
+    "patch": 169
   },
   "unlisted": false,
   "theme": [],

--- a/scratch.ts
+++ b/scratch.ts
@@ -1,0 +1,2 @@
+import { RICH_TEXT_FORMATTING, RemColor } from '@remnote/plugin-sdk';
+console.log(RICH_TEXT_FORMATTING.HIGHLIGHT, RemColor.Blue);

--- a/scratch.ts
+++ b/scratch.ts
@@ -1,2 +1,0 @@
-import { RICH_TEXT_FORMATTING, RemColor } from '@remnote/plugin-sdk';
-console.log(RICH_TEXT_FORMATTING.HIGHLIGHT, RemColor.Blue);

--- a/src/lib/consts.ts
+++ b/src/lib/consts.ts
@@ -56,6 +56,7 @@ export const nextInQueueCommandId = 'next-in-queue';
 
 // --- Keys for our successful fixes ---
 export const queueLayoutFixId = 'incremental-everything-queue-layout-fix';
+export const queueHideElementsId = 'incremental-everything-queue-hide-elements';
 export const incrementalQueueActiveKey = 'incremental-queue-active';
 export const activeHighlightIdKey = 'active-highlight-id-key';
 export const currentIncrementalRemTypeKey = 'current-incremental-rem-type-key';

--- a/src/lib/shield_history.ts
+++ b/src/lib/shield_history.ts
@@ -278,7 +278,8 @@ export async function saveKBShield<T extends PriorityItem>(
   const status = calculateShieldStatus(allItems, unreviewedDue, isDue, seenIds, dismissedCount, computeWeighted);
 
   await saveKBShieldHistory(plugin, storageKey, status, today);
-  console.log(`[QueueExit] Saved KB ${label} shield:`, status);
+  const kbTriggerItem = unreviewedDue.find(item => item.priority === status.absolute);
+  console.log(`[QueueExit] Saved KB ${label} shield:`, status, `Triggered by remId: ${kbTriggerItem?.remId ?? 'none'}`);
 }
 
 /**
@@ -326,9 +327,11 @@ export async function saveDocumentShield<T extends PriorityItem>(
   const status = calculateShieldStatus(scopedItems, unreviewedDueInScope, isDue, seenIds, scopedDismissedCount, computeWeighted);
 
   await saveScopedShieldHistory(plugin, storageKey, historyKey, status, today);
+  const docTriggerItem = unreviewedDueInScope.find(item => item.priority === status.absolute);
   console.log(
     `[QueueExit] ${label} doc shield - Priority: ${status.absolute}, ` +
-    `Percentile: ${status.percentile}%, Universe: ${status.universeSize}, Dismissed: ${scopedDismissedCount}`
+    `Percentile: ${status.percentile}%, Universe: ${status.universeSize}, Dismissed: ${scopedDismissedCount}, ` +
+    `Triggered by remId: ${docTriggerItem?.remId ?? 'none'}`
   );
   console.log(`Saved ${label} document history for original scope ${historyKey}:`, status);
 }

--- a/src/register/callbacks.ts
+++ b/src/register/callbacks.ts
@@ -71,6 +71,31 @@ const QUEUE_HIDE_ELEMENTS_CSS = `
   }
 `;
 
+const HIDE_PARENT_CSS = `
+  /* Hide Parent Styles */
+  .rn-queue__content--answer-hidden .indented-rem:has(> .rn-question-rem[data-queue-rem-container-tags~="hide-parent"]) > .RichTextViewer,
+  .rn-queue__content--answer-hidden .indented-rem:has(> .rn-question-rem[data-queue-rem-container-tags~="hide-parent"]) > .rn-flashcard-delimiter,
+  .rn-queue__content--answer-hidden .indented-rem:has(> .rn-question-rem[data-queue-rem-container-tags~="hide-parent"]) > .rn-queue-rem > .RichTextViewer,
+  .rn-queue__content--answer-hidden .indented-rem:has(> .rn-question-rem[data-queue-rem-container-tags~="hide-parent"]) > .rem-bullet__document {
+    display: none !important;
+  }
+
+  .rn-queue__content--answer-hidden .indented-rem:has(> .rn-question-rem[data-queue-rem-container-tags~="hide-parent"]) > .rn-queue-rem > .rn-bullet-container,
+  .rn-queue__content--answer-hidden .indented-rem:has(> .rn-question-rem[data-queue-rem-container-tags~="hide-parent"]) > .rn-queue-rem > .rem-bullet__document {
+    position: relative;
+  }
+
+  .rn-queue__content--answer-hidden .indented-rem:has(> .rn-question-rem[data-queue-rem-container-tags~="hide-parent"]) > .rn-queue-rem > .rn-bullet-container:after,
+  .rn-queue__content--answer-hidden .indented-rem:has(> .rn-question-rem[data-queue-rem-container-tags~="hide-parent"]) > .rn-queue-rem > .rem-bullet__document:after {
+    content: "Hidden in queue";
+    opacity: .3;
+    white-space: nowrap;
+    position: absolute;
+    left: 25px;
+    top: 0;
+  }
+`;
+
 let sessionItemCounter = 0;
 
 export const resetSessionItemCounter = () => {
@@ -79,6 +104,7 @@ export const resetSessionItemCounter = () => {
 
   export function registerCallbacks(plugin: ReactRNPlugin) {
   plugin.app.registerCSS(queueLayoutFixId, QUEUE_LAYOUT_FIX_CSS);
+  plugin.app.registerCSS('hide-parent-css', HIDE_PARENT_CSS);
 
   plugin.app.registerCallback<SpecialPluginCallback.GetNextCard>(
     SpecialPluginCallback.GetNextCard,

--- a/src/register/callbacks.ts
+++ b/src/register/callbacks.ts
@@ -11,6 +11,7 @@ import {
   currentScopeRemIdsKey,
   queueCounterId,
   queueLayoutFixId,
+  queueHideElementsId,
   seenRemInSessionKey,
   noIncRemTimerKey,
   incremReviewStartTimeKey,
@@ -20,6 +21,8 @@ import { getIncrementalRemFromRem, IncrementalRem } from '../lib/incremental_rem
 import { getCardsPerRem, getSortingRandomness } from '../lib/sorting';
 
 
+// Registered once globally — safe because all selectors are highly specific to the
+// incremental-everything plugin iframe and do not affect regular flashcard layout.
 const QUEUE_LAYOUT_FIX_CSS = `
   .rn-queue:has(iframe[data-plugin-id="incremental-everything"][src*="widgetName=queue"]) {
     height: 100% !important;
@@ -33,15 +36,28 @@ const QUEUE_LAYOUT_FIX_CSS = `
   .rn-queue:has(iframe[data-plugin-id="incremental-everything"][src*="widgetName=queue"]) iframe[data-plugin-id="incremental-everything"][src*="widgetName=queue"] {
     flex-grow: 1 !important;
   }
+`;
 
+// Registered dynamically in GetNextCard — applied ONLY when we are returning a Plugin
+// (QueueItemType.Plugin) item so that rems that are both an IncRem and a flashcard
+// do NOT have these elements hidden when they appear on a regular flashcard turn.
+//
+// Belt-and-suspenders against the pre-fetch race (same pattern as QUEUE_LAYOUT_FIX_CSS):
+// all selectors are rooted at .rn-queue:has(iframe[data-plugin-id="incremental-everything"]).
+// This means even if a concurrent GetNextCard null-return fires registerCSS('') a few ms
+// late, the rules stop matching the instant RemNote removes the plugin iframe from the DOM —
+// the CSS is self-deactivating at the DOM level and does not depend solely on JS timing.
+const QUEUE_HIDE_ELEMENTS_CSS = `
   /* Hide unwanted UI elements during incremental rem review.
-     NOTE: [data-queue-rem-tags~="incremental"] is used as a direct ancestor (not via :has()
-     on the queue root) to avoid hiding these elements in sibling flashcard containers that
-     RemNote keeps coexisting in the DOM (pre-rendered / cached items). */
-  [data-queue-rem-tags~="incremental"] .rn-flashcard-insights,
-  [data-queue-rem-tags~="incremental"] [data-cy="bottom-of-card-ai-suggestions"],
-  [data-queue-rem-tags~="incremental"] div.fade-in-first-load:has(div[data-cy="bottom-of-card-suggestions"]),
-  [data-queue-rem-tags~="incremental"] div.fade-in-first-load:has(iframe[data-plugin-id="flashcard-repetition-history"]) {
+     Gated on two conditions:
+       1. The plugin iframe is present (.rn-queue:has(iframe...)) — self-deactivates when
+          the iframe is removed, guarding against the pre-fetch GetNextCard race.
+       2. The item is tagged as incremental ([data-queue-rem-tags~="incremental"]) — ensures
+          rems that are both an IncRem and a flashcard are only affected on Plugin turns. */
+  .rn-queue:has(iframe[data-plugin-id="incremental-everything"][src*="widgetName=queue"]) [data-queue-rem-tags~="incremental"] .rn-flashcard-insights,
+  .rn-queue:has(iframe[data-plugin-id="incremental-everything"][src*="widgetName=queue"]) [data-queue-rem-tags~="incremental"] [data-cy="bottom-of-card-ai-suggestions"],
+  .rn-queue:has(iframe[data-plugin-id="incremental-everything"][src*="widgetName=queue"]) [data-queue-rem-tags~="incremental"] div.fade-in-first-load:has(div[data-cy="bottom-of-card-suggestions"]),
+  .rn-queue:has(iframe[data-plugin-id="incremental-everything"][src*="widgetName=queue"]) [data-queue-rem-tags~="incremental"] div.fade-in-first-load:has(iframe[data-plugin-id="flashcard-repetition-history"]) {
     display: none !important;
   }
 `;
@@ -77,7 +93,8 @@ export const resetSessionItemCounter = () => {
         const remainingSeconds = Math.ceil((noIncRemTimerEnd - now) / 1000);
         // console.log('⚠️ TIMER IS ACTIVE - BLOCKING INCREM! Time remaining:', remainingSeconds, 'seconds');
 
-        // Removed dynamic unregistration: plugin.app.registerCSS(queueLayoutFixId, '');
+        // Timer is blocking IncRem — this turn will be a flashcard; ensure hide CSS is cleared.
+        plugin.app.registerCSS(queueHideElementsId, '');
         await plugin.app.registerCSS(queueCounterId, '');
 
         return null;
@@ -194,7 +211,7 @@ export const resetSessionItemCounter = () => {
 
         if (filtered.length === 0) {
           // console.log('⚠️ FILTERED LENGTH IS 0 - Returning null, will show a flashcard.');
-          // Removed dynamic unregistration: plugin.app.registerCSS(queueLayoutFixId, '');
+          plugin.app.registerCSS(queueHideElementsId, '');
           sessionItemCounter++;
           return null;
         }
@@ -214,14 +231,16 @@ export const resetSessionItemCounter = () => {
           filtered.shift();
           if (filtered.length === 0) {
             console.log('❌ All filtered items were invalid after verification - Returning null');
+            plugin.app.registerCSS(queueHideElementsId, '');
             return null;
           }
           first = filtered[0];
         }
-        // Removed dynamic registration: plugin.app.registerCSS(queueLayoutFixId, QUEUE_LAYOUT_FIX_CSS);
         await plugin.storage.setSession(seenRemInSessionKey, [...seenRemIds, first.remId]);
-
         await plugin.storage.setSession(incremReviewStartTimeKey, Date.now());
+
+        // Activate hide CSS now that we know we're genuinely showing a Plugin (IncRem) item.
+        plugin.app.registerCSS(queueHideElementsId, QUEUE_HIDE_ELEMENTS_CSS);
 
         // console.log('✅ SHOWING INCREM:', first, 'due', dayjs(first.nextRepDate).fromNow());
         sessionItemCounter++;
@@ -247,10 +266,11 @@ export const resetSessionItemCounter = () => {
         //       : 'N/A',
         // });
         sessionItemCounter++;
-        // Removed dynamic unregistration: plugin.app.registerCSS(queueLayoutFixId, '');
-        // Bullet-proof mid-session reset: if the previous IncRem widget unmounted
-        // unceremoniously (skipping its useEffect cleanup), ensure the flag is cleared
-        // so regular flashcards can render their widgets (like CardPriorityDisplay).
+        // Flashcard turn — deactivate hide CSS so flashcard widgets remain visible.
+        // Also clears incrementalQueueActiveKey as a bullet-proof mid-session reset:
+        // if the previous IncRem widget unmounted unceremoniously (skipping its useEffect
+        // cleanup), this ensures CardPriorityDisplay and similar widgets can render.
+        plugin.app.registerCSS(queueHideElementsId, '');
         await plugin.storage.setSession(incrementalQueueActiveKey, false);
         return null;
       }

--- a/src/register/callbacks.ts
+++ b/src/register/callbacks.ts
@@ -71,28 +71,15 @@ const QUEUE_HIDE_ELEMENTS_CSS = `
   }
 `;
 
-const HIDE_PARENT_CSS = `
-  /* Hide Parent Styles */
-  .rn-queue__content--answer-hidden .indented-rem:has(> .rn-question-rem[data-queue-rem-container-tags~="hide-parent"]) > .RichTextViewer,
-  .rn-queue__content--answer-hidden .indented-rem:has(> .rn-question-rem[data-queue-rem-container-tags~="hide-parent"]) > .rn-flashcard-delimiter,
-  .rn-queue__content--answer-hidden .indented-rem:has(> .rn-question-rem[data-queue-rem-container-tags~="hide-parent"]) > .rn-queue-rem > .RichTextViewer,
-  .rn-queue__content--answer-hidden .indented-rem:has(> .rn-question-rem[data-queue-rem-container-tags~="hide-parent"]) > .rem-bullet__document {
-    display: none !important;
+const REMOVE_FROM_QUEUE_CSS = `
+  /* Remove from Queue Styles */
+  .rn-queue__content [data-queue-rem-container-tags~="remove-from-queue"]:not(.rn-question-rem) > .rn-queue-rem {
+    display: none;
   }
 
-  .rn-queue__content--answer-hidden .indented-rem:has(> .rn-question-rem[data-queue-rem-container-tags~="hide-parent"]) > .rn-queue-rem > .rn-bullet-container,
-  .rn-queue__content--answer-hidden .indented-rem:has(> .rn-question-rem[data-queue-rem-container-tags~="hide-parent"]) > .rn-queue-rem > .rem-bullet__document {
-    position: relative;
-  }
-
-  .rn-queue__content--answer-hidden .indented-rem:has(> .rn-question-rem[data-queue-rem-container-tags~="hide-parent"]) > .rn-queue-rem > .rn-bullet-container:after,
-  .rn-queue__content--answer-hidden .indented-rem:has(> .rn-question-rem[data-queue-rem-container-tags~="hide-parent"]) > .rn-queue-rem > .rem-bullet__document:after {
-    content: "Hidden in queue";
-    opacity: .3;
-    white-space: nowrap;
-    position: absolute;
-    left: 25px;
-    top: 0;
+  .rn-queue__content [data-queue-rem-container-tags~="remove-from-queue"]:not(.rn-question-rem),
+  .rn-breadcrumb-item[data-rem-tags~="remove-from-queue"] {
+    margin-left: 0px !important; /* makes it look like its not indented to the removed parent */
   }
 `;
 
@@ -104,7 +91,7 @@ export const resetSessionItemCounter = () => {
 
   export function registerCallbacks(plugin: ReactRNPlugin) {
   plugin.app.registerCSS(queueLayoutFixId, QUEUE_LAYOUT_FIX_CSS);
-  plugin.app.registerCSS('hide-parent-css', HIDE_PARENT_CSS);
+  plugin.app.registerCSS('remove-from-queue-css', REMOVE_FROM_QUEUE_CSS);
 
   plugin.app.registerCallback<SpecialPluginCallback.GetNextCard>(
     SpecialPluginCallback.GetNextCard,

--- a/src/register/callbacks.ts
+++ b/src/register/callbacks.ts
@@ -34,11 +34,14 @@ const QUEUE_LAYOUT_FIX_CSS = `
     flex-grow: 1 !important;
   }
 
-  /* Hide unwanted UI elements during incremental rem review */
-  .rn-queue:has(iframe[data-plugin-id="incremental-everything"][src*="widgetName=queue"]):has([data-queue-rem-tags~="incremental"]) .rn-flashcard-insights,
-  .rn-queue:has(iframe[data-plugin-id="incremental-everything"][src*="widgetName=queue"]):has([data-queue-rem-tags~="incremental"]) [data-cy="bottom-of-card-ai-suggestions"],
-  .rn-queue:has(iframe[data-plugin-id="incremental-everything"][src*="widgetName=queue"]):has([data-queue-rem-tags~="incremental"]) div.fade-in-first-load:has(div[data-cy="bottom-of-card-suggestions"]),
-  .rn-queue:has(iframe[data-plugin-id="incremental-everything"][src*="widgetName=queue"]):has([data-queue-rem-tags~="incremental"]) div.fade-in-first-load:has(iframe[data-plugin-id="flashcard-repetition-history"]) {
+  /* Hide unwanted UI elements during incremental rem review.
+     NOTE: [data-queue-rem-tags~="incremental"] is used as a direct ancestor (not via :has()
+     on the queue root) to avoid hiding these elements in sibling flashcard containers that
+     RemNote keeps coexisting in the DOM (pre-rendered / cached items). */
+  [data-queue-rem-tags~="incremental"] .rn-flashcard-insights,
+  [data-queue-rem-tags~="incremental"] [data-cy="bottom-of-card-ai-suggestions"],
+  [data-queue-rem-tags~="incremental"] div.fade-in-first-load:has(div[data-cy="bottom-of-card-suggestions"]),
+  [data-queue-rem-tags~="incremental"] div.fade-in-first-load:has(iframe[data-plugin-id="flashcard-repetition-history"]) {
     display: none !important;
   }
 `;

--- a/src/register/callbacks.ts
+++ b/src/register/callbacks.ts
@@ -36,6 +36,15 @@ const QUEUE_LAYOUT_FIX_CSS = `
   .rn-queue:has(iframe[data-plugin-id="incremental-everything"][src*="widgetName=queue"]) iframe[data-plugin-id="incremental-everything"][src*="widgetName=queue"] {
     flex-grow: 1 !important;
   }
+
+  /* Ensure card_priority_display (our widget) renders above flashcard-repetition-history.
+     The parent flashcard container is already "flex flex-col", so flex order is sufficient.
+     Scoped to only activate when our card_priority_display iframe is present, so regular
+     flashcards without the plugin widget are not affected. */
+  .box-border.flex.flex-col:has(iframe[data-plugin-id="incremental-everything"][src*="widgetName=card_priority_display"])
+    .fade-in-first-load:has(iframe[data-plugin-id="flashcard-repetition-history"]) {
+    order: 1;
+  }
 `;
 
 // Registered dynamically in GetNextCard — applied ONLY when we are returning a Plugin

--- a/src/register/commands.ts
+++ b/src/register/commands.ts
@@ -226,6 +226,83 @@ export async function registerCommands(plugin: ReactRNPlugin) {
   });
 
   plugin.app.registerCommand({
+    id: 'create-cloze-deletion',
+    name: 'Create Cloze Deletion',
+    keyboardShortcut: 'opt+z',
+    action: async () => {
+      const selection = await plugin.editor.getSelection();
+      if (!selection || selection.type !== SelectionType.Text) {
+        return;
+      }
+      
+      const rem = await plugin.rem.findOne(selection.remId);
+      if (!rem) return;
+
+      const r_start = Math.min(selection.range.start, selection.range.end);
+      const r_end = Math.max(selection.range.start, selection.range.end);
+
+      const clozeId = Math.random().toString(36).substring(2, 10);
+
+      const processRichText = (richText: RichTextInterface): RichTextInterface => {
+        const newArray: any[] = [];
+        let currIdx = 0;
+        for (const item of richText) {
+          const isString = typeof item === 'string';
+          const textNode = isString ? { i: 'm' as const, text: item } : (item as any);
+          const nodeLen = textNode.i === 'm' ? (textNode.text?.length || 0) : 1;
+          const nodeStart = currIdx;
+          const nodeEnd = currIdx + nodeLen;
+          
+          if (nodeEnd <= r_start || nodeStart >= r_end) {
+            newArray.push(item);
+          } else {
+            if (textNode.i === 'm') {
+              const textStr = textNode.text || '';
+              const relStart = Math.max(0, r_start - nodeStart);
+              const relEnd = Math.min(nodeLen, r_end - nodeStart);
+              
+              if (relStart > 0) {
+                newArray.push({ ...textNode, text: textStr.substring(0, relStart) });
+              }
+              newArray.push({
+                ...textNode,
+                text: textStr.substring(relStart, relEnd),
+                [RICH_TEXT_FORMATTING.CLOZE]: clozeId,
+              });
+              if (relEnd < nodeLen) {
+                newArray.push({ ...textNode, text: textStr.substring(relEnd) });
+              }
+            } else {
+              newArray.push({
+                ...textNode,
+                [RICH_TEXT_FORMATTING.CLOZE]: clozeId,
+              });
+            }
+          }
+          currIdx += nodeLen;
+        }
+        return newArray;
+      };
+
+      let isBack = false;
+      const remText = rem.text || [];
+      const frontMiddle = await plugin.richText.substring(remText, r_start, r_end);
+      if (!(await plugin.richText.equals(selection.richText, frontMiddle))) {
+        const backMiddle = await plugin.richText.substring(rem.backText || [], r_start, r_end);
+        if (await plugin.richText.equals(selection.richText, backMiddle)) {
+          isBack = true;
+        }
+      }
+
+      if (isBack) {
+        await rem.setBackText(processRichText(rem.backText || []));
+      } else {
+        await rem.setText(processRichText(rem.text || []));
+      }
+    },
+  });
+
+  plugin.app.registerCommand({
     id: 'set-priority',
     name: 'Set Priority',
     keyboardShortcut: 'opt+p',

--- a/src/register/commands.ts
+++ b/src/register/commands.ts
@@ -78,16 +78,16 @@ export async function registerCommands(plugin: ReactRNPlugin) {
       ]);
       await extractRem.setParent(rem);
 
-      // 3. Add "hide-parent" tag
-      let hideParentTag = await plugin.rem.findByName(['hide-parent'], null);
-      if (!hideParentTag) {
-        hideParentTag = await plugin.rem.createRem();
-        if (hideParentTag) {
-          await hideParentTag.setText(['hide-parent']);
+      // 3. Add "remove-from-queue" tag to the parent
+      let removeFromQueueTag = await plugin.rem.findByName(['remove-from-queue'], null);
+      if (!removeFromQueueTag) {
+        removeFromQueueTag = await plugin.rem.createRem();
+        if (removeFromQueueTag) {
+          await removeFromQueueTag.setText(['remove-from-queue']);
         }
       }
-      if (hideParentTag) {
-        await extractRem.addTag(hideParentTag._id);
+      if (removeFromQueueTag) {
+        await rem.addTag(removeFromQueueTag._id);
       }
 
       // Make Incremental

--- a/src/register/commands.ts
+++ b/src/register/commands.ts
@@ -56,6 +56,12 @@ export async function registerCommands(plugin: ReactRNPlugin) {
     if (!selection) {
       return;
     }
+    if (selection.type === SelectionType.Text && selection.range.start === selection.range.end) {
+      // Fallback empty text selections to Rem selection behavior
+      (selection as any).type = SelectionType.Rem;
+      (selection as any).remIds = [selection.remId];
+    }
+
     // TODO: extract within extract support
     if (selection.type === SelectionType.Text) {
       // 1. Fetch the Rem
@@ -232,6 +238,10 @@ export async function registerCommands(plugin: ReactRNPlugin) {
     action: async () => {
       const selection = await plugin.editor.getSelection();
       if (!selection || selection.type !== SelectionType.Text) {
+        return;
+      }
+      if (selection.range.start === selection.range.end) {
+        await plugin.app.toast('Please select some text to create a cloze deletion.');
         return;
       }
       

--- a/src/register/commands.ts
+++ b/src/register/commands.ts
@@ -66,7 +66,10 @@ export async function registerCommands(plugin: ReactRNPlugin) {
       const extractRem = await plugin.rem.createRem();
       if (!extractRem) return;
 
-      await extractRem.setText(selection.richText);
+      await extractRem.setText([
+        ...selection.richText,
+        { i: 'q', _id: rem._id, pin: true },
+      ]);
       await extractRem.setParent(rem);
 
       // 3. Add "hide-parent" tag
@@ -97,7 +100,7 @@ export async function registerCommands(plugin: ReactRNPlugin) {
           const nodeLen = textNode.i === 'm' ? (textNode.text?.length || 0) : 1;
           const nodeStart = currIdx;
           const nodeEnd = currIdx + nodeLen;
-          
+
           if (nodeEnd <= r_start || nodeStart >= r_end) {
             newArray.push(item);
           } else {
@@ -105,7 +108,7 @@ export async function registerCommands(plugin: ReactRNPlugin) {
               const textStr = textNode.text || '';
               const relStart = Math.max(0, r_start - nodeStart);
               const relEnd = Math.min(nodeLen, r_end - nodeStart);
-              
+
               if (relStart > 0) {
                 newArray.push({ ...textNode, text: textStr.substring(0, relStart) });
               }
@@ -114,9 +117,9 @@ export async function registerCommands(plugin: ReactRNPlugin) {
                 text: textStr.substring(relStart, relEnd),
                 [RICH_TEXT_FORMATTING.HIGHLIGHT]: 6, // RemColor.Blue = 6
               });
-              
-              if (r_start < r_end && nodeStart < r_end && nodeEnd >= r_end) { 
-                  newArray.push({ i: 'q', _id: extractRem._id, pin: true });
+
+              if (r_start < r_end && nodeStart < r_end && nodeEnd >= r_end) {
+                newArray.push({ i: 'q', _id: extractRem._id, pin: true });
               }
 
               if (relEnd < nodeLen) {
@@ -127,17 +130,17 @@ export async function registerCommands(plugin: ReactRNPlugin) {
                 ...textNode,
                 [RICH_TEXT_FORMATTING.HIGHLIGHT]: 6,
               });
-              
-              if (r_start < r_end && nodeStart < r_end && nodeEnd >= r_end) { 
-                  newArray.push({ i: 'q', _id: extractRem._id, pin: true });
+
+              if (r_start < r_end && nodeStart < r_end && nodeEnd >= r_end) {
+                newArray.push({ i: 'q', _id: extractRem._id, pin: true });
               }
             }
           }
-          
+
           currIdx += nodeLen;
         }
         if (r_end > currIdx && r_start < currIdx) {
-           newArray.push({ i: 'q', _id: extractRem._id, pin: true });
+          newArray.push({ i: 'q', _id: extractRem._id, pin: true });
         }
         return newArray;
       };

--- a/src/register/commands.ts
+++ b/src/register/commands.ts
@@ -4,6 +4,8 @@ import {
   SelectionType,
   PluginRem,
   BuiltInPowerupCodes,
+  RICH_TEXT_FORMATTING,
+  RichTextInterface,
 } from '@remnote/plugin-sdk';
 import {
   powerupCode,
@@ -56,12 +58,109 @@ export async function registerCommands(plugin: ReactRNPlugin) {
     }
     // TODO: extract within extract support
     if (selection.type === SelectionType.Text) {
-      const focused = await plugin.focus.getFocusedRem();
-      if (!focused) {
-        return;
+      // 1. Fetch the Rem
+      const rem = await plugin.rem.findOne(selection.remId);
+      if (!rem) return;
+
+      // 2. Extract selected text
+      const extractRem = await plugin.rem.createRem();
+      if (!extractRem) return;
+
+      await extractRem.setText(selection.richText);
+      await extractRem.setParent(rem);
+
+      // 3. Add "hide-parent" tag
+      let hideParentTag = await plugin.rem.findByName(['hide-parent'], null);
+      if (!hideParentTag) {
+        hideParentTag = await plugin.rem.createRem();
+        if (hideParentTag) {
+          await hideParentTag.setText(['hide-parent']);
+        }
       }
-      await initIncrementalRem(plugin, focused);
-      return focused;
+      if (hideParentTag) {
+        await extractRem.addTag(hideParentTag._id);
+      }
+
+      // Make Incremental
+      await initIncrementalRem(plugin, extractRem);
+
+      // 4. Locate and Modify
+      const r_start = Math.min(selection.range.start, selection.range.end);
+      const r_end = Math.max(selection.range.start, selection.range.end);
+
+      const processRichText = (richText: RichTextInterface): RichTextInterface => {
+        const newArray: any[] = [];
+        let currIdx = 0;
+        for (const item of richText) {
+          const isString = typeof item === 'string';
+          const textNode = isString ? { i: 'm' as const, text: item } : (item as any);
+          const nodeLen = textNode.i === 'm' ? (textNode.text?.length || 0) : 1;
+          const nodeStart = currIdx;
+          const nodeEnd = currIdx + nodeLen;
+          
+          if (nodeEnd <= r_start || nodeStart >= r_end) {
+            newArray.push(item);
+          } else {
+            if (textNode.i === 'm') {
+              const textStr = textNode.text || '';
+              const relStart = Math.max(0, r_start - nodeStart);
+              const relEnd = Math.min(nodeLen, r_end - nodeStart);
+              
+              if (relStart > 0) {
+                newArray.push({ ...textNode, text: textStr.substring(0, relStart) });
+              }
+              newArray.push({
+                ...textNode,
+                text: textStr.substring(relStart, relEnd),
+                [RICH_TEXT_FORMATTING.HIGHLIGHT]: 6, // RemColor.Blue = 6
+              });
+              
+              if (r_start < r_end && nodeStart < r_end && nodeEnd >= r_end) { 
+                  newArray.push({ i: 'q', _id: extractRem._id, pin: true });
+              }
+
+              if (relEnd < nodeLen) {
+                newArray.push({ ...textNode, text: textStr.substring(relEnd) });
+              }
+            } else {
+              newArray.push({
+                ...textNode,
+                [RICH_TEXT_FORMATTING.HIGHLIGHT]: 6,
+              });
+              
+              if (r_start < r_end && nodeStart < r_end && nodeEnd >= r_end) { 
+                  newArray.push({ i: 'q', _id: extractRem._id, pin: true });
+              }
+            }
+          }
+          
+          currIdx += nodeLen;
+        }
+        if (r_end > currIdx && r_start < currIdx) {
+           newArray.push({ i: 'q', _id: extractRem._id, pin: true });
+        }
+        return newArray;
+      };
+
+      // Detect if selection is in front or back
+      let isBack = false;
+      const remText = rem.text || [];
+      const frontMiddle = await plugin.richText.substring(remText, r_start, r_end);
+      if (!(await plugin.richText.equals(selection.richText, frontMiddle))) {
+        const backMiddle = await plugin.richText.substring(rem.backText || [], r_start, r_end);
+        if (await plugin.richText.equals(selection.richText, backMiddle)) {
+          isBack = true;
+        }
+      }
+
+      // 6. Save the Changes
+      if (isBack) {
+        await rem.setBackText(processRichText(rem.backText || []));
+      } else {
+        await rem.setText(processRichText(rem.text || []));
+      }
+
+      return extractRem;
     } else if (selection.type === SelectionType.Rem) {
       const rems = (await plugin.rem.findMany(selection.remIds)) || [];
       // Single outer flag bracket for the entire batch — each initIncrementalRem

--- a/src/register/widgets.ts
+++ b/src/register/widgets.ts
@@ -43,7 +43,7 @@ export function registerWidgets(plugin: ReactRNPlugin) {
   plugin.app.registerWidget('batch_card_priority', WidgetLocation.Popup, {
     dimensions: {
       width: 1000,
-      height: 'auto',
+      height: 1100,
     },
   });
 

--- a/src/register/widgets.ts
+++ b/src/register/widgets.ts
@@ -215,7 +215,7 @@ export function registerWidgets(plugin: ReactRNPlugin) {
   plugin.app.registerWidget('weighted_shield_popup', WidgetLocation.Popup, {
     dimensions: {
       width: '560px',
-      height: 'auto',
+      height: 700,
     },
   });
 }

--- a/src/widgets/batch_card_priority.tsx
+++ b/src/widgets/batch_card_priority.tsx
@@ -377,19 +377,27 @@ function BatchCardPriority() {
       }
 
       setSuccessMessage(`✅ Applied cardPriority to ${appliedCount} rem(s)`);
+
+      // Delegate inheritance cascade to background tracker
+      if (anchorRemId) {
+        await plugin.storage.setSession('pendingInheritanceCascade', anchorRemId);
+      } else {
+        await plugin.storage.setSession('plugin_operation_active', false);
+      }
+
       setTimeout(() => plugin.widget.closePopup(), 2000);
     } catch (error) {
       console.error('Error applying priorities:', error);
       setErrorMessage('Failed to apply priorities. Check console for details.');
+      await plugin.storage.setSession('plugin_operation_active', false);
     } finally {
       setIsApplying(false);
-      await plugin.storage.setSession('plugin_operation_active', false);
     }
   };
 
   // ── styles ─────────────────────────────────────────────────────────────────
   const s = {
-    container: { padding: '16px', fontFamily: 'system-ui, -apple-system, sans-serif' },
+    container: { padding: '16px', fontFamily: 'system-ui, -apple-system, sans-serif', height: '100%', overflowY: 'auto' as const, boxSizing: 'border-box' as const },
     section: { marginBottom: '16px', padding: '12px', border: '1px solid #e5e7eb', borderRadius: '8px', backgroundColor: '#f9fafb' },
     sectionTitle: { fontSize: '14px', fontWeight: 600 as const, marginBottom: '10px', display: 'flex', alignItems: 'center', gap: '8px' },
     input: { padding: '6px 10px', border: '1px solid #d1d5db', borderRadius: '6px', fontSize: '13px', width: '80px' },
@@ -399,7 +407,7 @@ function BatchCardPriority() {
     tableWrap: { border: '1px solid #e5e7eb', borderRadius: '8px', overflow: 'hidden' },
     thead: { display: 'grid', gridTemplateColumns: '32px 1fr 90px 90px', backgroundColor: '#f3f4f6', fontWeight: 600 as const, fontSize: '12px', color: '#374151', padding: '6px 0' },
     theadCell: { padding: '4px 8px' },
-    tbody: { maxHeight: '420px', overflowY: 'auto' as const },
+    tbody: { maxHeight: '400px', overflowY: 'auto' as const },
     trow: (depth: number): React.CSSProperties => ({
       display: 'grid',
       gridTemplateColumns: '32px 1fr 90px 90px',
@@ -500,6 +508,7 @@ function BatchCardPriority() {
         <div style={{ fontSize: '13px', color: '#6b7280' }}>Anchor: <strong>{anchorName}</strong> — {scopeSubtitle}</div>
       </div>
 
+
       {/* Scope selector */}
       <div style={{ ...s.section, marginBottom: '12px' }}>
         <div style={{ ...s.sectionTitle, marginBottom: '8px' }}>Scope</div>
@@ -552,6 +561,7 @@ function BatchCardPriority() {
           </label>
         </div>
       </div>
+
 
       {/* Tree table */}
       {displayedRems.length === 0 ? (
@@ -607,8 +617,8 @@ function BatchCardPriority() {
         </div>
       )}
 
-      {/* Actions */}
-      <div style={{ marginTop: '16px', display: 'flex', alignItems: 'center', gap: '8px' }}>
+      {/* Actions — pinned to bottom */}
+      <div style={{ marginTop: '12px', paddingTop: '12px', borderTop: '1px solid #e5e7eb', display: 'flex', alignItems: 'center', gap: '8px', flexShrink: 0 }}>
         <button
           onClick={validateAndApply}
           style={{ ...s.btn, backgroundColor: '#3b82f6', color: 'white' }}
@@ -626,8 +636,8 @@ function BatchCardPriority() {
         <span style={{ fontSize: '13px', color: '#6b7280' }}>{selectedCount} selected / {displayedRems.length} shown / {allRems.length} total</span>
       </div>
 
-      {errorMessage && <div style={{ color: '#ef4444', fontSize: '13px', marginTop: '8px' }}>{errorMessage}</div>}
-      {successMessage && <div style={{ color: '#10b981', fontSize: '13px', marginTop: '8px' }}>{successMessage}</div>}
+      {errorMessage && <div style={{ color: '#ef4444', fontSize: '13px', marginTop: '6px', flexShrink: 0 }}>{errorMessage}</div>}
+      {successMessage && <div style={{ color: '#10b981', fontSize: '13px', marginTop: '6px', flexShrink: 0 }}>{successMessage}</div>}
     </div>
   );
 }

--- a/src/widgets/card_priority_display.tsx
+++ b/src/widgets/card_priority_display.tsx
@@ -349,6 +349,22 @@ export function CardPriorityDisplay() {
   // Prefer cache-based cardInfo; fall back to on-demand lightCardInfo (covers Light Mode + cache-not-ready)
   const finalCardInfo = cardInfo || lightCardInfo;
 
+  // Detect whether the stats separator `|` has flex-wrapped to a new line.
+  // CSS cannot observe line-breaks in a flex-wrap container, so we compare the
+  // vertical position of the separator span against the stats div with a ResizeObserver.
+  // The `|` stays in the DOM (opacity: 0 when hidden) so it's always measurable.
+  const statsSepRef = React.useRef<HTMLSpanElement>(null);
+  const statsContainerRef = React.useRef<HTMLDivElement>(null);
+  const [statsSepVisible, setStatsSepVisible] = React.useState(true);
+
+  React.useLayoutEffect(() => {
+    const sep = statsSepRef.current;
+    const stats = statsContainerRef.current;
+    if (!sep || !stats) return;
+    const sameRow = Math.abs(sep.getBoundingClientRect().top - stats.getBoundingClientRect().top) < 4;
+    setStatsSepVisible(sameRow);
+  }); // No deps — runs after every render so it catches the first render where refs are populated
+
   // Check isIncrementalQueueActive
   if (!rem || !finalCardInfo || isIncrementalQueueActive) {
     // console.log('[CardPriorityDisplay] Early return — rem:', !!rem, ', finalCardInfo:', !!finalCardInfo,
@@ -387,6 +403,7 @@ export function CardPriorityDisplay() {
   };
 
   return (
+    <div style={{ paddingTop: '10px', paddingBottom: '10px' }}>
     <div
       className="flex items-center justify-center gap-3 px-3 py-1.5"
       style={{
@@ -394,7 +411,6 @@ export function CardPriorityDisplay() {
         border: '1px solid var(--rn-clr-border-primary)',
         borderLeft: `4px solid ${priorityColor}`,
         borderRadius: '8px',
-        margin: '4px 0',
         transition: 'background-color 0.15s',
         flexWrap: 'wrap',
       }}
@@ -492,8 +508,16 @@ export function CardPriorityDisplay() {
       {/* Review Stats + FSRS DSR + Debug */}
       {(historyStats.reps > 0 || fsrsState) && (
         <>
-          <span style={{ color: 'var(--rn-clr-content-tertiary)', opacity: 0.4 }}>|</span>
-          <div className="flex items-center gap-3" style={{ fontSize: '11px', color: 'var(--rn-clr-content-tertiary)' }}>
+          <span
+            ref={statsSepRef}
+            style={{
+              color: 'var(--rn-clr-content-tertiary)',
+              opacity: statsSepVisible ? 0.4 : 0,
+              // Keep it in flow so the ResizeObserver can always measure its position
+              pointerEvents: 'none',
+            }}
+          >|</span>
+          <div ref={statsContainerRef} className="flex items-center gap-3" style={{ fontSize: '11px', color: 'var(--rn-clr-content-tertiary)' }}>
             <span
               title={`Total number of gradeable repetitions.\n\nThe number in red parentheses — (${historyStats.lapses}) — is the number of lapses (AGAIN ratings).\n\nThe following number is the total time spent reviewing this card.\n\nThe card age is the time elapsed since the first repetition.\n\nThe cost is the average time spent reviewing this card per year.`}
               style={{ cursor: 'help' }}
@@ -542,6 +566,7 @@ export function CardPriorityDisplay() {
           </div>
         </>
       )}
+    </div>
     </div>
   );
 }

--- a/src/widgets/card_priority_display.tsx
+++ b/src/widgets/card_priority_display.tsx
@@ -403,81 +403,81 @@ export function CardPriorityDisplay() {
   };
 
   return (
-    <div style={{ paddingTop: '10px', paddingBottom: '10px' }}>
-    <div
-      className="flex items-center justify-center gap-3 px-3 py-1.5"
-      style={{
-        backgroundColor: 'var(--rn-clr-background-secondary)',
-        border: '1px solid var(--rn-clr-border-primary)',
-        borderLeft: `4px solid ${priorityColor}`,
-        borderRadius: '8px',
-        transition: 'background-color 0.15s',
-        flexWrap: 'wrap',
-      }}
-    >
-      {/* Priority — clickable to open priority editor */}
+    <div style={{ paddingTop: '20px', paddingBottom: '10px' }}>
       <div
-        className="flex items-center gap-2"
-        onClick={handleClick}
-        style={{ cursor: 'pointer' }}
-        title="Click to set priority (Opt+P)"
-        onMouseEnter={(e) => { e.currentTarget.style.opacity = '0.75'; }}
-        onMouseLeave={(e) => { e.currentTarget.style.opacity = '1'; }}
+        className="flex items-center justify-center gap-3 px-3 py-1.5"
+        style={{
+          backgroundColor: 'var(--rn-clr-background-secondary)',
+          border: '1px solid var(--rn-clr-border-primary)',
+          borderLeft: `4px solid ${priorityColor}`,
+          borderRadius: '8px',
+          transition: 'background-color 0.15s',
+          flexWrap: 'wrap',
+        }}
       >
-        <span className="text-xs font-semibold" style={{ color: 'var(--rn-clr-content-secondary)' }}>Priority:</span>
-        <PriorityBadge priority={finalCardInfo.priority} percentile={kbPercentile} compact useAbsoluteColoring={useLightMode || !cacheReady} source={finalCardInfo.source} isCardPriority={true} />
-        {!useLightMode && cacheReady && kbPercentile !== undefined && (
-          <span className="text-xs" style={{ color: 'var(--rn-clr-content-tertiary)' }}>
-            ({kbPercentile}% KB
-            {docPercentile !== undefined && docPercentile !== null && `, ${docPercentile}% Doc`})
-          </span>
-        )}
-        {!useLightMode && cacheReady && (docPercentile === undefined || docPercentile === null) && kbPercentile !== undefined && (
-          <span
-            className="text-sm opacity-60 cursor-help"
-            title="Doc percentile will be recalculated when you start a new queue session"
-          >
-            ⟳
-          </span>
-        )}
-      </div>
-
-      {/* Shield */}
-      {displayPriorityShield && !useLightMode && cacheReady && (shieldStatus?.kb || shieldStatus?.doc) && (
-        <>
-          <span style={{ color: 'var(--rn-clr-content-tertiary)' }}>|</span>
-          <div className="flex items-center gap-2">
-            <span className="text-xs font-semibold flex items-center gap-1" style={{ color: 'var(--rn-clr-content-secondary)' }}>
-              <span style={{
-                display: 'inline-block',
-                animation: isAnyShieldActive ? 'shieldPulse 2s ease-in-out infinite' : 'none'
-              }}>🛡️</span>
-              <span>Card Shield:</span>
+        {/* Priority — clickable to open priority editor */}
+        <div
+          className="flex items-center gap-2"
+          onClick={handleClick}
+          style={{ cursor: 'pointer' }}
+          title="Click to set priority (Opt+P)"
+          onMouseEnter={(e) => { e.currentTarget.style.opacity = '0.75'; }}
+          onMouseLeave={(e) => { e.currentTarget.style.opacity = '1'; }}
+        >
+          <span className="text-xs font-semibold" style={{ color: 'var(--rn-clr-content-secondary)' }}>Priority:</span>
+          <PriorityBadge priority={finalCardInfo.priority} percentile={kbPercentile} compact useAbsoluteColoring={useLightMode || !cacheReady} source={finalCardInfo.source} isCardPriority={true} />
+          {!useLightMode && cacheReady && kbPercentile !== undefined && (
+            <span className="text-xs" style={{ color: 'var(--rn-clr-content-tertiary)' }}>
+              ({kbPercentile}% KB
+              {docPercentile !== undefined && docPercentile !== null && `, ${docPercentile}% Doc`})
             </span>
-            <div className="flex gap-3 text-xs" style={{ color: 'var(--rn-clr-content-tertiary)' }}>
-              {shieldStatus.kb && (
+          )}
+          {!useLightMode && cacheReady && (docPercentile === undefined || docPercentile === null) && kbPercentile !== undefined && (
+            <span
+              className="text-sm opacity-60 cursor-help"
+              title="Doc percentile will be recalculated when you start a new queue session"
+            >
+              ⟳
+            </span>
+          )}
+        </div>
+
+        {/* Shield */}
+        {displayPriorityShield && !useLightMode && cacheReady && (shieldStatus?.kb || shieldStatus?.doc) && (
+          <>
+            <span style={{ color: 'var(--rn-clr-content-tertiary)' }}>|</span>
+            <div className="flex items-center gap-2">
+              <span className="text-xs font-semibold flex items-center gap-1" style={{ color: 'var(--rn-clr-content-secondary)' }}>
                 <span style={{
-                  animation: isKbShieldActive ? 'shieldTextGlow 2s ease-in-out infinite' : 'none',
-                  fontWeight: isKbShieldActive ? 700 : 'inherit',
-                  color: isKbShieldActive ? 'var(--rn-clr-blue)' : 'inherit'
-                }}>
-                  KB: <PriorityBadge priority={shieldStatus.kb.absolute} percentile={shieldStatus.kb.percentile} compact />
-                  {shieldStatus.kb.percentile !== undefined && ` (${shieldStatus.kb.percentile.toFixed(1)}%)`}
-                </span>
-              )}
-              {shieldStatus.doc && (
-                <span style={{
-                  animation: isDocShieldActive ? 'shieldTextGlow 2s ease-in-out infinite' : 'none',
-                  fontWeight: isDocShieldActive ? 700 : 'inherit',
-                  color: isDocShieldActive ? 'var(--rn-clr-blue)' : 'inherit'
-                }}>
-                  Doc: <PriorityBadge priority={shieldStatus.doc.absolute} percentile={shieldStatus.doc.percentile} compact />
-                  {shieldStatus.doc.percentile !== undefined && ` (${shieldStatus.doc.percentile.toFixed(1)}%)`}
-                </span>
-              )}
+                  display: 'inline-block',
+                  animation: isAnyShieldActive ? 'shieldPulse 2s ease-in-out infinite' : 'none'
+                }}>🛡️</span>
+                <span>Card Shield:</span>
+              </span>
+              <div className="flex gap-3 text-xs" style={{ color: 'var(--rn-clr-content-tertiary)' }}>
+                {shieldStatus.kb && (
+                  <span style={{
+                    animation: isKbShieldActive ? 'shieldTextGlow 2s ease-in-out infinite' : 'none',
+                    fontWeight: isKbShieldActive ? 700 : 'inherit',
+                    color: isKbShieldActive ? 'var(--rn-clr-blue)' : 'inherit'
+                  }}>
+                    KB: <PriorityBadge priority={shieldStatus.kb.absolute} percentile={shieldStatus.kb.percentile} compact />
+                    {shieldStatus.kb.percentile !== undefined && ` (${shieldStatus.kb.percentile.toFixed(1)}%)`}
+                  </span>
+                )}
+                {shieldStatus.doc && (
+                  <span style={{
+                    animation: isDocShieldActive ? 'shieldTextGlow 2s ease-in-out infinite' : 'none',
+                    fontWeight: isDocShieldActive ? 700 : 'inherit',
+                    color: isDocShieldActive ? 'var(--rn-clr-blue)' : 'inherit'
+                  }}>
+                    Doc: <PriorityBadge priority={shieldStatus.doc.absolute} percentile={shieldStatus.doc.percentile} compact />
+                    {shieldStatus.doc.percentile !== undefined && ` (${shieldStatus.doc.percentile.toFixed(1)}%)`}
+                  </span>
+                )}
+              </div>
             </div>
-          </div>
-          <style>{`
+            <style>{`
             @keyframes shieldPulse {
               0%, 100% { transform: scale(1); filter: drop-shadow(0 0 0px rgba(59, 130, 246, 0)); }
               50% { transform: scale(1.15); filter: drop-shadow(0 0 4px rgba(59, 130, 246, 0.6)); }
@@ -487,85 +487,85 @@ export function CardPriorityDisplay() {
               50% { filter: brightness(1.3); text-shadow: 0 0 4px rgba(59, 130, 246, 0.3); }
             }
           `}</style>
-        </>
-      )}
+          </>
+        )}
 
-      {/* Weighted Shield */}
-      {displayWeightedShield && !useLightMode && cacheReady && weightedShieldStatus && allPrioritizedCardInfo && (
-        <>
-          <span style={{ color: 'var(--rn-clr-content-tertiary)' }}>|</span>
-          <WeightedShieldTooltip
-            kbValue={weightedShieldStatus.kb}
-            docValue={weightedShieldStatus.doc}
-            allItems={allPrioritizedCardInfo}
-            isDuePredicate={weightedIsDuePredicate}
-            docItems={weightedShieldStatus.docItems}
-            itemLabel="Cards"
-          />
-        </>
-      )}
+        {/* Weighted Shield */}
+        {displayWeightedShield && !useLightMode && cacheReady && weightedShieldStatus && allPrioritizedCardInfo && (
+          <>
+            <span style={{ color: 'var(--rn-clr-content-tertiary)' }}>|</span>
+            <WeightedShieldTooltip
+              kbValue={weightedShieldStatus.kb}
+              docValue={weightedShieldStatus.doc}
+              allItems={allPrioritizedCardInfo}
+              isDuePredicate={weightedIsDuePredicate}
+              docItems={weightedShieldStatus.docItems}
+              itemLabel="Cards"
+            />
+          </>
+        )}
 
-      {/* Review Stats + FSRS DSR + Debug */}
-      {(historyStats.reps > 0 || fsrsState) && (
-        <>
-          <span
-            ref={statsSepRef}
-            style={{
-              color: 'var(--rn-clr-content-tertiary)',
-              opacity: statsSepVisible ? 1 : 0,
-              pointerEvents: 'none',
-            }}
-          >|</span>
-          <div ref={statsContainerRef} className="flex items-center gap-3" style={{ fontSize: '11px', color: 'var(--rn-clr-content-tertiary)' }}>
+        {/* Review Stats + FSRS DSR + Debug */}
+        {(historyStats.reps > 0 || fsrsState) && (
+          <>
             <span
-              title={`Total number of gradeable repetitions.\n\nThe number in red parentheses — (${historyStats.lapses}) — is the number of lapses (AGAIN ratings).\n\nThe following number is the total time spent reviewing this card.\n\nThe card age is the time elapsed since the first repetition.\n\nThe cost is the average time spent reviewing this card per year.`}
-              style={{ cursor: 'help' }}
-            >
-              <strong>{historyStats.reps}</strong> Reps <span style={{ color: '#ef4444' }}>({historyStats.lapses})</span>, ⏳ <strong>{historyStats.totalMinutes}</strong> min, <strong>{historyStats.cardAgeText}</strong> age{historyStats.costText && <>, 💰 <strong>{historyStats.costText}</strong></>}
-            </span>
-
-            {showFsrsDsr && fsrsState && (
-              <>
-                <span style={{ opacity: 0.4 }}>|</span>
-                <span title={`FSRS v6 — Difficulty: how hard this card is to remember (1=easy, 10=hard).\nStability: expected interval in days at target retention.\nRetrievability: probability of recall right now.\n\nThe number inside the parenthesis after Stability tells you how much time has passed since your last review of this card.\n\nBased on ${fsrsState.reviewCount} reviews.\n\nNext Difficulty:\nAgain: ${fsrsState.nextD.again.toFixed(2)}\nHard: ${fsrsState.nextD.hard.toFixed(2)}\nGood: ${fsrsState.nextD.good.toFixed(2)}\nEasy: ${fsrsState.nextD.easy.toFixed(2)}`}>
-                  D: <strong>{fsrsState.d.toFixed(2)}</strong>
-                  {' · '}
-                  S: <strong>{formatStabilityDays(fsrsState.s)}</strong> ({formatStabilityDays(fsrsState.daysSinceLastReview)} passed)
-                  {' · '}
-                  R: <strong style={{ color: getRetrievabilityColor(fsrsState.r) }}>
-                    {(fsrsState.r * 100).toFixed(1)}%
-                  </strong>
-                </span>
-                {' · '}
-                <span title={`SInc (Stability Increase) — how much your memory stability grows after answering.\n\nHard: ×${fsrsState.sInc.hard.toFixed(2)} → ${formatStabilityDays(fsrsState.s * fsrsState.sInc.hard)}\nGood: ×${fsrsState.sInc.good.toFixed(2)} → ${formatStabilityDays(fsrsState.s * fsrsState.sInc.good)}\nEasy: ×${fsrsState.sInc.easy.toFixed(2)} → ${formatStabilityDays(fsrsState.s * fsrsState.sInc.easy)}\n\nHigher = faster learning. A value of 1.0 means no growth.`}
-                  style={{ cursor: 'help' }}
-                >
-                  SInc: <strong>{fsrsState.sInc.good.toFixed(2)}×</strong>
-                </span>
-              </>
-            )}
-
-            <span
-              role="button"
+              ref={statsSepRef}
               style={{
-                cursor: 'pointer',
-                fontSize: '13px',
-                opacity: 0.5,
-                padding: '2px 4px',
-                borderRadius: '4px',
-                transition: 'opacity 0.15s, background-color 0.15s',
+                color: 'var(--rn-clr-content-tertiary)',
+                opacity: statsSepVisible ? 1 : 0,
+                pointerEvents: 'none',
               }}
-              onClick={handleDebugClick}
-              onMouseEnter={(e) => { e.currentTarget.style.opacity = '1'; e.currentTarget.style.backgroundColor = 'var(--rn-clr-background-tertiary)'; }}
-              onMouseLeave={(e) => { e.currentTarget.style.opacity = '0.5'; e.currentTarget.style.backgroundColor = 'transparent'; }}
-              title="Inspect full repetition history"
-            >
-              🔬
-            </span>
-          </div>
-        </>
-      )}
-    </div>
+            >|</span>
+            <div ref={statsContainerRef} className="flex items-center gap-3" style={{ fontSize: '11px', color: 'var(--rn-clr-content-tertiary)' }}>
+              <span
+                title={`Total number of gradeable repetitions.\n\nThe number in red parentheses — (${historyStats.lapses}) — is the number of lapses (AGAIN ratings).\n\nThe following number is the total time spent reviewing this card.\n\nThe card age is the time elapsed since the first repetition.\n\nThe cost is the average time spent reviewing this card per year.`}
+                style={{ cursor: 'help' }}
+              >
+                <strong>{historyStats.reps}</strong> Reps <span style={{ color: '#ef4444' }}>({historyStats.lapses})</span>, ⏳ <strong>{historyStats.totalMinutes}</strong> min, <strong>{historyStats.cardAgeText}</strong> age{historyStats.costText && <>, 💰 <strong>{historyStats.costText}</strong></>}
+              </span>
+
+              {showFsrsDsr && fsrsState && (
+                <>
+                  <span style={{ opacity: 0.4 }}>|</span>
+                  <span title={`FSRS v6 — Difficulty: how hard this card is to remember (1=easy, 10=hard).\nStability: expected interval in days at target retention.\nRetrievability: probability of recall right now.\n\nThe number inside the parenthesis after Stability tells you how much time has passed since your last review of this card.\n\nBased on ${fsrsState.reviewCount} reviews.\n\nNext Difficulty:\nAgain: ${fsrsState.nextD.again.toFixed(2)}\nHard: ${fsrsState.nextD.hard.toFixed(2)}\nGood: ${fsrsState.nextD.good.toFixed(2)}\nEasy: ${fsrsState.nextD.easy.toFixed(2)}`}>
+                    D: <strong>{fsrsState.d.toFixed(2)}</strong>
+                    {' · '}
+                    S: <strong>{formatStabilityDays(fsrsState.s)}</strong> ({formatStabilityDays(fsrsState.daysSinceLastReview)} passed)
+                    {' · '}
+                    R: <strong style={{ color: getRetrievabilityColor(fsrsState.r) }}>
+                      {(fsrsState.r * 100).toFixed(1)}%
+                    </strong>
+                  </span>
+                  {' · '}
+                  <span title={`SInc (Stability Increase) — how much your memory stability grows after answering.\n\nHard: ×${fsrsState.sInc.hard.toFixed(2)} → ${formatStabilityDays(fsrsState.s * fsrsState.sInc.hard)}\nGood: ×${fsrsState.sInc.good.toFixed(2)} → ${formatStabilityDays(fsrsState.s * fsrsState.sInc.good)}\nEasy: ×${fsrsState.sInc.easy.toFixed(2)} → ${formatStabilityDays(fsrsState.s * fsrsState.sInc.easy)}\n\nHigher = faster learning. A value of 1.0 means no growth.`}
+                    style={{ cursor: 'help' }}
+                  >
+                    SInc: <strong>{fsrsState.sInc.good.toFixed(2)}×</strong>
+                  </span>
+                </>
+              )}
+
+              <span
+                role="button"
+                style={{
+                  cursor: 'pointer',
+                  fontSize: '13px',
+                  opacity: 0.5,
+                  padding: '2px 4px',
+                  borderRadius: '4px',
+                  transition: 'opacity 0.15s, background-color 0.15s',
+                }}
+                onClick={handleDebugClick}
+                onMouseEnter={(e) => { e.currentTarget.style.opacity = '1'; e.currentTarget.style.backgroundColor = 'var(--rn-clr-background-tertiary)'; }}
+                onMouseLeave={(e) => { e.currentTarget.style.opacity = '0.5'; e.currentTarget.style.backgroundColor = 'transparent'; }}
+                title="Inspect full repetition history"
+              >
+                🔬
+              </span>
+            </div>
+          </>
+        )}
+      </div>
     </div>
   );
 }

--- a/src/widgets/card_priority_display.tsx
+++ b/src/widgets/card_priority_display.tsx
@@ -512,8 +512,7 @@ export function CardPriorityDisplay() {
             ref={statsSepRef}
             style={{
               color: 'var(--rn-clr-content-tertiary)',
-              opacity: statsSepVisible ? 0.4 : 0,
-              // Keep it in flow so the ResizeObserver can always measure its position
+              opacity: statsSepVisible ? 1 : 0,
               pointerEvents: 'none',
             }}
           >|</span>

--- a/src/widgets/parent_selector.tsx
+++ b/src/widgets/parent_selector.tsx
@@ -679,9 +679,10 @@ function ParentSelectorWidget() {
           return;
         }
 
-        // Set the text and parent
+        // Set the text, parent, and font size (H3 so it appears as a section header)
         await newRem.setText([childName]);
         await newRem.setParent(creatingChildForNodeId);
+        await newRem.setFontSize('H3');
 
         console.log('[ParentSelector:Widget] Child rem created:', newRem._id);
 

--- a/src/widgets/parent_selector.tsx
+++ b/src/widgets/parent_selector.tsx
@@ -462,23 +462,23 @@ function ParentSelectorWidget() {
   // Scroll to selected item whenever selectedIndex changes or after initialization
   useEffect(() => {
     if (!isInitialized || itemRefs.current.length === 0) return;
-    
+
     let attempts = 0;
     const maxAttempts = 20; // Allow up to 1 second of retries to outlast UI animations
-    
+
     // We use a retry mechanism because inside the sandboxed iframe, the DOM layout 
     // might not have non-zero dimensions immediately after the render commit.
     const tryScroll = () => {
       const selectedEl = itemRefs.current[selectedIndex];
       const container = listContainerRef.current;
-      
-      console.log(`[ParentSelector:Scroll] attempt ${attempts} at index ${selectedIndex}`, { 
-        hasScrolled: hasInitiallyScrolled.current, 
-        elFound: !!selectedEl, 
+
+      console.log(`[ParentSelector:Scroll] attempt ${attempts} at index ${selectedIndex}`, {
+        hasScrolled: hasInitiallyScrolled.current,
+        elFound: !!selectedEl,
         containerFound: !!container,
         clientHeight: selectedEl?.clientHeight,
       });
-      
+
       if (selectedEl && container) {
         // If layout hasn't populated, wait for next paint
         if (selectedEl.clientHeight === 0 && attempts < maxAttempts) {
@@ -491,7 +491,7 @@ function ParentSelectorWidget() {
           // Manual nearest block logic for keyboard navigation
           const elRect = selectedEl.getBoundingClientRect();
           const containerRect = container.getBoundingClientRect();
-          
+
           if (elRect.top < containerRect.top) {
             container.scrollTop -= (containerRect.top - elRect.top);
           } else if (elRect.bottom > containerRect.bottom) {
@@ -502,13 +502,13 @@ function ParentSelectorWidget() {
           // We use offsetTop because getBoundingClientRect gives incorrect warped 
           // coordinates while the popup is scaling/animating into view natively.
           const scrollOffset = selectedEl.offsetTop - container.clientHeight / 2 + selectedEl.clientHeight / 2;
-          
+
           console.log(`[ParentSelector:Scroll] Initial load centering:`, {
-             offsetTop: selectedEl.offsetTop,
-             containerHeight: container.clientHeight,
-             calcScrollOffset: scrollOffset
+            offsetTop: selectedEl.offsetTop,
+            containerHeight: container.clientHeight,
+            calcScrollOffset: scrollOffset
           });
-          
+
           container.scrollTop = scrollOffset;
           hasInitiallyScrolled.current = true;
         }
@@ -517,10 +517,10 @@ function ParentSelectorWidget() {
         setTimeout(tryScroll, 50);
       }
     };
-    
+
     // Wait slightly bit initially to allow DOM to attach inside the plugin iframe
     const initialTimer = setTimeout(tryScroll, 100);
-    
+
     return () => clearTimeout(initialTimer);
   }, [selectedIndex, isInitialized, displayList.length]);
 
@@ -679,12 +679,18 @@ function ParentSelectorWidget() {
           return;
         }
 
-        // Set the text, parent, and font size (H3 so it appears as a section header)
+        // Set the text and parent
         await newRem.setText([childName]);
         await newRem.setParent(creatingChildForNodeId);
-        await newRem.setFontSize('H3');
 
-        console.log('[ParentSelector:Widget] Child rem created:', newRem._id);
+        // Pick a heading level that respects the parent's heading hierarchy:
+        // H1 parent → H2 child; anything else → H3.
+        const parentRem = await plugin.rem.findOne(creatingChildForNodeId);
+        const parentFontSize = await parentRem?.getFontSize();
+        const headingLevel = parentFontSize === 'H1' ? 'H2' : 'H3';
+        await newRem.setFontSize(headingLevel);
+
+        console.log(`[ParentSelector:Widget] Child rem created: ${newRem._id} (${headingLevel}, parent was ${parentFontSize ?? 'normal'})`);
 
         // Create a tree node for the new child using the helper function
         // Note: We need to fetch the rem again to get the full PluginRem object

--- a/src/widgets/priority_editor.tsx
+++ b/src/widgets/priority_editor.tsx
@@ -154,6 +154,9 @@ export function PriorityEditor() {
     if (updatedIncRem) {
       await updateIncrementalRemCache(plugin, updatedIncRem);
     }
+    
+    // Trigger inheritance cascade in the background tracker
+    await plugin.storage.setSession('pendingInheritanceCascade', rem._id);
   }, [incRemInfo, rem, plugin]);
 
   const quickUpdateCardPriority = useCallback(async (delta: number) => {
@@ -163,6 +166,9 @@ export function PriorityEditor() {
 
     await setCardPriority(plugin, rem, newPriority, 'manual');
     await updateCardPriorityCache(plugin, rem._id);
+
+    // Trigger inheritance cascade in the background tracker
+    await plugin.storage.setSession('pendingInheritanceCascade', rem._id);
   }, [rem, cardInfo, plugin]);
 
   // Memoize whether card priority is manual (for visual indicator)

--- a/src/widgets/weighted_shield_popup.tsx
+++ b/src/widgets/weighted_shield_popup.tsx
@@ -195,7 +195,9 @@ function WeightedShieldPopup() {
       fontSize: '13px',
       color: 'var(--rn-clr-content-primary)',
       background: 'var(--rn-clr-background-primary)',
-      minHeight: '100%',
+      height: '100%',
+      overflowY: 'auto',
+      boxSizing: 'border-box',
     }}>
       {/* Title */}
       <div style={{


### PR DESCRIPTION
## v0.2.169 - April 11th, 2026

### ✨ New: SuperMemo-style Extract & Cloze Logic

We've introduced a major enhancement to the text-processing workflow, bringing full **SuperMemo-like Incremental Reading** capabilities directly to the editor.

#### 📝 Extract Selection (`Opt+X` / `Opt+Shift+X`)

You can now extract specific sub-sections of text into new Incremental Rems with a single keystroke. When you select text and trigger the extract command:
- **Automatic Highlighting:** The source text in your document is automatically formatted with a **blue highlight** to mark its extraction.
- **Reference Pin:** A clickable **Rem Reference Pin** is inserted immediately after the highlighted text, pointing directly to the new extract.
- **Smart Formatting:** The new extract Rem contains your selected text plus a **back-reference pin** to its parent, and is initialized as an Incremental Rem. The **parent Rem** is automatically tagged with `#remove-from-queue`.
- **Priority Sync:** For `Opt+Shift+X`, the **Priority & Interval** popup opens instantly for the new extract.
- **Intelligent Fallback:** If no text is selected, the command safely falls back to making the active Rem itself Incremental.

![Extract Selection Demo](./assets/extract-selected-text.gif)

#### ✂️ Create Cloze Deletion (`Opt+Z`)

A new dedicated command to quickly generate **Cloze Deletions** on any selected text. 
- **Workflow-Native:** Mimics the standard SuperMemo shortcut for fast card creation during incremental reading.
- **Instant Validation:** Includes built-in checks to prevent the creation of "ghost" cards from empty selections, with helpful toast notifications.

#### 🛡️ Built-in "Remove From Queue" Styling

The plugin now natively includes the CSS required for the `#remove-from-queue` tag. This ensures that the parent document of an extract doesn't show up in the queue alongside the extract, keeping your queue uncluttered and your focus on the extracted snippet.

### 🔧 Fixes

#### 🔄 Priority Inheritance Cascade

- **Reliable Updates:** Fixed an issue where priority inheritance cascades were not being triggered during "Quick Update" actions in the Priority Editor or during Batch Card Priority assignments. All priority changes now correctly signal the background tracker to recalculate and propagate values to all descendants, ensuring data consistency.

---


### 🐛 Bug Fix: Flashcard Insights & AI Widgets Hidden During Regular Flashcard Review

This release resolves a persistent bug where the **Flashcard Insights**, **Bottom-of-card AI Suggestions**, and **Flashcard Repetition History** widgets were incorrectly hidden while reviewing regular flashcards, when they should only be suppressed during Incremental Rem review turns.

#### Root Cause: Three Compounding Problems

The fix required untangling three separate but interacting issues:

**1. Global CSS with insufficient scoping (v0.2.167)**

The first attempt scoped the `display: none` rules to `.rn-queue:has([data-queue-rem-tags~="incremental"])`. The logic was sound on paper — hide those widgets only when a queue element tagged `"incremental"` is present. However, `:has()` is a *presence* check on the entire subtree. RemNote keeps multiple queue items coexisting in the DOM simultaneously (pre-rendering the next card, caching the previous one), so the `data-queue-rem-tags~="incremental"` attribute from a *cached* Incremental Rem item was visible to `:has()` even when the currently *displayed* item was a regular flashcard. The rule matched the entire queue and hid the widgets across all items.

**2. Direct ancestor scoping was still insufficient**

The second attempt used `[data-queue-rem-tags~="incremental"]` as a **direct ancestor** of the elements to hide, rather than checking it via `:has()` at the queue root. This correctly prevented cached sibling items from triggering the rule. However, it introduced a new edge case: a Rem that is **both an Incremental Rem and a flashcard** carries `data-queue-rem-tags~="incremental"` on its container for *all* its queue appearances — both its Plugin turn and its flashcard turn. The direct ancestor selector had no way to distinguish which turn was currently active, so the widgets were still hidden during flashcard turns for those dual-type rems.

**3. The pre-fetch `GetNextCard` race condition**

The correct architectural solution — dynamically registering the hide CSS only when `GetNextCard` explicitly returns a `QueueItemType.Plugin` item — is exposed to the same class of pre-fetch race that caused the original layout-fix CSS to be reverted (commit `afb496d`, v0.2.141). RemNote fires a background `GetNextCard` call to pre-fetch the *next* card while the current one is still displayed. If that pre-fetch returns `null` (a flashcard), it calls `registerCSS(hideId, '')`, clearing the hide CSS mid-display of the current Incremental Rem — causing a brief flicker where the suppressed widgets reappear.

#### The Final Fix: Dynamic Registration with a DOM-Level Self-Guard

The fix combines a JavaScript layer and a CSS layer, mirroring the pattern used for the static layout-fix CSS:

*   **JS layer (dynamic registration in `GetNextCard`):** The hide CSS is registered only when `GetNextCard` genuinely returns a `QueueItemType.Plugin` item, and explicitly cleared in every path that returns `null` — including the no-timer block, the empty-filtered-list path, the all-items-invalid-after-verification path, and the normal flashcard turn. This correctly handles the dual IncRem+flashcard case: even for a rem that carries `data-queue-rem-tags~="incremental"`, the CSS is simply absent during its flashcard turns.

*   **CSS layer (DOM self-guard):** All four hide selectors are additionally rooted at `.rn-queue:has(iframe[data-plugin-id="incremental-everything"][src*="widgetName=queue"])`. This means the rules only match when the plugin's queue iframe is actually present in the DOM. If a concurrent pre-fetch `GetNextCard` null-return fires `registerCSS('')` a few milliseconds late, the CSS self-deactivates at the DOM level the instant RemNote removes the plugin iframe — the rules stop matching regardless of JS timing.

The two layers are complementary: the JS layer is the primary gate (correct in the common case), and the CSS iframe condition is the safety net for the race-condition edge case.

### 🎨 UI Polish: Card Priority Display Now Appears Above Flashcard Repetition History

The **Card Priority Display** widget (shown below flashcards in the queue) was previously rendered *below* the **Flashcard Repetition History** widget, because RemNote injects third-party plugin iframes before our own in the DOM order.

**Fix:** The flashcard content container is already a `flex flex-col` element, so a single `order: 1` rule on the `flashcard-repetition-history` wrapper is enough to push it after all default-ordered items — no DOM manipulation needed. The rule is scoped to only activate when our `card_priority_display` iframe is present in the same container, leaving all other flashcard layouts unaffected.
