### PR TITLE
PDF split-pane scrolling in the Editor and more

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -7,7 +7,7 @@
   "version": {
     "major": 0,
     "minor": 2,
-    "patch": 184
+    "patch": 185
   },
   "unlisted": false,
   "theme": [],

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -7,7 +7,7 @@
   "version": {
     "major": 0,
     "minor": 2,
-    "patch": 186
+    "patch": 187
   },
   "unlisted": false,
   "theme": [],

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -7,7 +7,7 @@
   "version": {
     "major": 0,
     "minor": 2,
-    "patch": 187
+    "patch": 188
   },
   "unlisted": false,
   "theme": [],

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -7,7 +7,7 @@
   "version": {
     "major": 0,
     "minor": 2,
-    "patch": 185
+    "patch": 186
   },
   "unlisted": false,
   "theme": [],

--- a/src/lib/card_priority/cache.ts
+++ b/src/lib/card_priority/cache.ts
@@ -4,7 +4,7 @@ import { CardPriorityInfo, PrioritySource } from './types';
 import { getCardPriority, autoAssignCardPriority } from './index';
 import * as _ from 'remeda';
 
-let cacheUpdateTimer: NodeJS.Timeout | null = null;
+let cacheUpdateTimer: ReturnType<typeof setTimeout> | null = null;
 let pendingUpdates = new Map<RemId, { info: CardPriorityInfo | null; isLight: boolean }>();
 const lightModeOptimisticOverrides = new Map<RemId, { info: CardPriorityInfo; expiresAt: number }>();
 
@@ -422,6 +422,7 @@ async function processDeferredCardPriorityCache(plugin: RNPlugin, untaggedRemIds
         });
 
         await plugin.storage.setSession(allCardPriorityInfoKey, enrichedCache);
+        await plugin.storage.setSession(cardPriorityCacheRefreshKey, Date.now());
       }
 
       if (

--- a/src/lib/card_priority/index.ts
+++ b/src/lib/card_priority/index.ts
@@ -176,9 +176,12 @@ export async function autoAssignCardPriority(plugin: RNPlugin, rem: PluginRem): 
 
   if (ancestorPriority) {
     // Skip write if already up-to-date (prevents infinite GlobalRemChanged loop).
-    // lastUpdated > 0 means the powerup tag exists; untagged rems must always be written
-    // even when their computed priority matches, so they receive the actual tag.
-    if (existingPriority && existingPriority.lastUpdated > 0 && existingPriority.source === 'inherited' && existingPriority.priority === ancestorPriority.priority) {
+    // Untagged rems with matching inherited priority intentionally stay untagged: the
+    // widget already falls back to getCardPriority() (which returns the inherited value
+    // with lastUpdated: 0) when there's no cache entry, and the deferred batch still
+    // pushes them into the cache by remId regardless of tag status. Force-tagging on
+    // every ambient edit causes a write storm in the GlobalRemChanged listener.
+    if (existingPriority && existingPriority.source === 'inherited' && existingPriority.priority === ancestorPriority.priority) {
       return ancestorPriority.priority;
     }
     await setCardPriority(plugin, rem, ancestorPriority.priority, 'inherited');
@@ -191,8 +194,10 @@ export async function autoAssignCardPriority(plugin: RNPlugin, rem: PluginRem): 
 
   const defaultPriority = (await plugin.settings.getSetting<number>('defaultCardPriority')) || 50;
   // Skip write if already up-to-date (prevents infinite GlobalRemChanged loop).
-  // lastUpdated === 0 means the powerup tag does not exist yet; always write so the rem gets tagged.
-  if (existingPriority && existingPriority.lastUpdated > 0 && existingPriority.source === 'default' && existingPriority.priority === defaultPriority) {
+  // Untagged rems with matching default priority intentionally stay untagged: the widget
+  // falls back to getCardPriority() and the deferred batch still pushes them into the
+  // cache by remId regardless of tag status.
+  if (existingPriority && existingPriority.source === 'default' && existingPriority.priority === defaultPriority) {
     return defaultPriority;
   }
   await setCardPriority(plugin, rem, defaultPriority, 'default');

--- a/src/lib/card_priority/index.ts
+++ b/src/lib/card_priority/index.ts
@@ -175,8 +175,10 @@ export async function autoAssignCardPriority(plugin: RNPlugin, rem: PluginRem): 
   const ancestorPriority = await findClosestAncestorWithPriority(plugin, rem);
 
   if (ancestorPriority) {
-    // Skip write if already up-to-date (prevents infinite GlobalRemChanged loop)
-    if (existingPriority && existingPriority.source === 'inherited' && existingPriority.priority === ancestorPriority.priority) {
+    // Skip write if already up-to-date (prevents infinite GlobalRemChanged loop).
+    // lastUpdated > 0 means the powerup tag exists; untagged rems must always be written
+    // even when their computed priority matches, so they receive the actual tag.
+    if (existingPriority && existingPriority.lastUpdated > 0 && existingPriority.source === 'inherited' && existingPriority.priority === ancestorPriority.priority) {
       return ancestorPriority.priority;
     }
     await setCardPriority(plugin, rem, ancestorPriority.priority, 'inherited');
@@ -188,8 +190,9 @@ export async function autoAssignCardPriority(plugin: RNPlugin, rem: PluginRem): 
   }
 
   const defaultPriority = (await plugin.settings.getSetting<number>('defaultCardPriority')) || 50;
-  // Skip write if already up-to-date (prevents infinite GlobalRemChanged loop)
-  if (existingPriority && existingPriority.source === 'default' && existingPriority.priority === defaultPriority) {
+  // Skip write if already up-to-date (prevents infinite GlobalRemChanged loop).
+  // lastUpdated === 0 means the powerup tag does not exist yet; always write so the rem gets tagged.
+  if (existingPriority && existingPriority.lastUpdated > 0 && existingPriority.source === 'default' && existingPriority.priority === defaultPriority) {
     return defaultPriority;
   }
   await setCardPriority(plugin, rem, defaultPriority, 'default');

--- a/src/lib/incremental_rem/index.ts
+++ b/src/lib/incremental_rem/index.ts
@@ -24,7 +24,7 @@ import { tryParseJson, getDailyDocReferenceForDate, sleep } from '../utils';
 import { getInitialPriority } from '../priority_inheritance';
 import { updateIncrementalRemCache } from './cache';
 import { mergeHistoryFromDismissed } from '../dismissed';
-import { findPDFinRem, registerRemsAsPdfKnown } from '../pdfUtils';
+import { registerRemsAsPdfKnown } from '../pdfUtils';
 
 type ReviewOverrideOptions = {
   /**
@@ -354,9 +354,20 @@ export async function initIncrementalRem(plugin: ReactRNPlugin, rem: PluginRem, 
       // even when the session cache (allIncrementalRemKey) is not yet loaded
       // (e.g., WebBrowser / Light Mode).
       try {
-        const pdfSource = await findPDFinRem(plugin as any, rem);
-        if (pdfSource) {
-          await registerRemsAsPdfKnown(plugin as any, pdfSource._id, [rem._id]);
+        const sources = await rem.getSources();
+        const allSources = [rem, ...sources];
+        for (const candidate of allSources) {
+          const isPdf = await candidate.hasPowerup(BuiltInPowerupCodes.UploadedFile);
+          if (isPdf) {
+            try {
+              const url = await candidate.getPowerupProperty(BuiltInPowerupCodes.UploadedFile, 'URL');
+              if (typeof url === 'string' && url.toLowerCase().endsWith('.pdf')) {
+                await registerRemsAsPdfKnown(plugin as any, candidate._id, [rem._id]);
+              }
+            } catch {
+              // Skip candidates where URL can't be read
+            }
+          }
         }
       } catch (e) {
         console.error('[initIncrementalRem] Error registering in known_pdf_rems_:', e);

--- a/src/lib/pdfUtils.ts
+++ b/src/lib/pdfUtils.ts
@@ -279,11 +279,30 @@ export const addPageToHistory = async (
 
   const history = await getPageHistory(plugin, incrementalRemId, pdfRemId);
 
+  // Bookmark preservation: when no highlightId is supplied (e.g. queue "Next",
+  // session-end timers, manual page save) but the most-recent same-page entry
+  // carries one, inherit it. Otherwise, that anonymous entry would shadow a
+  // just-saved highlight bookmark under the "last entry only" detection used
+  // by the Scroll-to-Position buttons. Same physical page, same bookmark intent.
+  let effectiveHighlightId = highlightId;
+  if (!effectiveHighlightId) {
+    for (let i = history.length - 1; i >= 0; i--) {
+      const prev = history[i];
+      if (prev.highlightId && prev.page === page) {
+        effectiveHighlightId = prev.highlightId;
+        console.log(`[addPageToHistory] Preserving bookmark highlightId from prior same-page entry: ${effectiveHighlightId}`);
+        break;
+      }
+      // Stop scanning past a different-page entry — the bookmark intent ended there.
+      if (prev.page !== page) break;
+    }
+  }
+
   const entry: PageHistoryEntry = {
     page,
     timestamp: Date.now(),
     sessionDuration,
-    highlightId
+    highlightId: effectiveHighlightId
   };
 
   history.push(entry);

--- a/src/lib/remHelpers.ts
+++ b/src/lib/remHelpers.ts
@@ -1,4 +1,60 @@
 import { RNPlugin } from '@remnote/plugin-sdk';
+import type { PaneRemWindowTree, RemIdWindowTree } from '@remnote/plugin-sdk/dist/interfaces';
+
+/**
+ * Open a rem in a separate pane to the right of the current layout, or focus
+ * the existing pane if one already shows that rem. Preserves whatever the user
+ * has in the current pane (e.g. the IncRem they were viewing in the editor).
+ *
+ * Uses the SDK's window-tree API: getCurrentWindowTree → strip paneIds → wrap
+ * as {direction:'row', first: existing, second: new remId} → setRemWindowTree.
+ */
+export const openRemInNewPane = async (
+  plugin: RNPlugin,
+  remId: string
+): Promise<void> => {
+  // If the rem is already open in some pane, just focus that pane.
+  try {
+    const openRemIds = await plugin.window.getOpenPaneRemIds();
+    if (openRemIds.includes(remId)) {
+      const paneIds = await plugin.window.getOpenPaneIds();
+      for (const paneId of paneIds) {
+        const paneRemId = await plugin.window.getOpenPaneRemId(paneId);
+        if (paneRemId === remId) {
+          await plugin.window.setFocusedPaneId(paneId);
+          return;
+        }
+      }
+    }
+  } catch (e) {
+    // Fall through to split-pane creation if querying fails.
+    console.warn('[openRemInNewPane] Pre-check failed, will split:', e);
+  }
+
+  const currentTree = await plugin.window.getCurrentWindowTree();
+
+  const stripPaneIds = (node: PaneRemWindowTree): RemIdWindowTree => {
+    if ('remId' in node && 'paneId' in node) {
+      return (node as any).remId;
+    }
+    const parent = node as any;
+    return {
+      direction: parent.direction,
+      first: stripPaneIds(parent.first),
+      second: stripPaneIds(parent.second),
+      splitPercentage: parent.splitPercentage,
+    };
+  };
+
+  const existing = stripPaneIds(currentTree);
+  const newTree: RemIdWindowTree = {
+    direction: 'row',
+    first: existing,
+    second: remId,
+    splitPercentage: 50,
+  };
+  await plugin.window.setRemWindowTree(newTree);
+};
 
 /**
  * Jumps to a specific Rem by its ID, opening it in RemNote.

--- a/src/lib/ui_helpers.ts
+++ b/src/lib/ui_helpers.ts
@@ -98,6 +98,46 @@ export async function registerPdfHighlightCSS(plugin: ReactRNPlugin) {
   await plugin.app.registerCSS('pdf-inc-highlight-styling', css);
 }
 
+export async function registerClozeExtractCSS(plugin: ReactRNPlugin) {
+  const css = `
+    /* Badge: violet ↑ pill before the bullet */
+    [data-queue-rem-tags~="clozeextract"].rn-queue-rem:not(.rem-bullet__document) .rn-bullet-container,
+    [data-queue-rem-tags~="cloze-extract"].rn-queue-rem:not(.rem-bullet__document) .rn-bullet-container {
+      position: relative;
+    }
+    [data-queue-rem-tags~="clozeextract"].rn-queue-rem:not(.rem-bullet__document) .rn-bullet-container::before,
+    [data-queue-rem-tags~="cloze-extract"].rn-queue-rem:not(.rem-bullet__document) .rn-bullet-container::before {
+      content: '↑';
+      background: #7c3aed;
+      color: #fff;
+      font-size: 10px;
+      font-weight: 700;
+      line-height: 1.4;
+      padding: 1px 5px;
+      border-radius: 3px;
+      margin-right: 4px;
+    }
+    /* Tooltip shown when hovering the bullet container */
+    [data-queue-rem-tags~="clozeextract"].rn-queue-rem:not(.rem-bullet__document) .rn-bullet-container:hover::after,
+    [data-queue-rem-tags~="cloze-extract"].rn-queue-rem:not(.rem-bullet__document) .rn-bullet-container:hover::after {
+      content: 'Cloze child — created from a parent rem via Create Cloze Deletion';
+      position: absolute;
+      top: -30px;
+      left: 0;
+      background: rgba(0, 0, 0, 0.85);
+      color: #fff;
+      font-size: 11px;
+      font-weight: 400;
+      padding: 3px 8px;
+      border-radius: 4px;
+      white-space: nowrap;
+      z-index: 100;
+      pointer-events: none;
+    }
+  `;
+  await plugin.app.registerCSS('cloze-extract-badge', css);
+}
+
 /**
  * Clears all queue-specific UI elements (menu items and CSS).
  * Called when the user navigates away from the flashcards view.

--- a/src/register/callbacks.ts
+++ b/src/register/callbacks.ts
@@ -75,11 +75,14 @@ const QUEUE_HIDE_ELEMENTS_CSS = `
 
 const REMOVE_FROM_QUEUE_CSS = `
   /* Remove from Queue Styles */
+  .rn-queue__content [data-queue-rem-container-tags~="removefromqueue"]:not(.rn-question-rem) > .rn-queue-rem,
   .rn-queue__content [data-queue-rem-container-tags~="remove-from-queue"]:not(.rn-question-rem) > .rn-queue-rem {
     display: none;
   }
 
+  .rn-queue__content [data-queue-rem-container-tags~="removefromqueue"]:not(.rn-question-rem),
   .rn-queue__content [data-queue-rem-container-tags~="remove-from-queue"]:not(.rn-question-rem),
+  .rn-breadcrumb-item[data-rem-tags~="removefromqueue"],
   .rn-breadcrumb-item[data-rem-tags~="remove-from-queue"] {
     margin-left: 0px !important; /* makes it look like its not indented to the removed parent */
   }

--- a/src/register/commands.ts
+++ b/src/register/commands.ts
@@ -1895,6 +1895,176 @@ export async function registerCommands(plugin: ReactRNPlugin) {
         await plugin.widget.openPopup('mastery_drill');
       },
     });
+
+    plugin.app.registerCommand({
+      id: 'debug_audit_mastery_drill',
+      name: 'Debug: Audit Mastery Drill Inconsistencies',
+      action: async () => {
+        type DrillItem = string | { cardId: string; kbId?: string; addedAt?: number };
+        const allDrillIds = ((await plugin.storage.getSynced('finalDrillIds')) as DrillItem[]) || [];
+
+        const currentKb = await plugin.kb.getCurrentKnowledgeBaseData();
+        const isPrimary = await plugin.kb.isPrimaryKnowledgeBase();
+        const currentKbId = currentKb?._id;
+
+        const finalDrillIds = allDrillIds.filter(item =>
+          typeof item === 'string' ? isPrimary : item.kbId === currentKbId
+        );
+        const skippedOtherKb = allDrillIds.length - finalDrillIds.length;
+
+        if (finalDrillIds.length === 0) {
+          await plugin.app.toast(
+            skippedOtherKb > 0
+              ? `No drill items for this KB (${skippedOtherKb} belong to other KBs).`
+              : 'Mastery Drill queue is empty.'
+          );
+          return;
+        }
+
+        const scoreName = (score: number): string => {
+          const map: Record<number, string> = {
+            0: 'AGAIN',
+            0.01: 'TOO_EARLY',
+            0.5: 'HARD',
+            1: 'GOOD',
+            1.5: 'EASY',
+            2: 'VIEWED_AS_LEECH',
+            3: 'RESET',
+            4: 'MANUAL_DATE',
+            5: 'MANUAL_EASE',
+          };
+          return map[score] ?? `UNKNOWN(${score})`;
+        };
+
+        const inconsistencies: string[] = [];
+        let inconsistencyCount = 0;
+
+        for (const item of finalDrillIds) {
+          const cardId = typeof item === 'string' ? item : item.cardId;
+          const addedAt = typeof item === 'object' && item.addedAt
+            ? new Date(item.addedAt).toISOString()
+            : 'unknown';
+
+          const card = await plugin.card.findOne(cardId);
+          if (!card) {
+            inconsistencies.push(`[MISSING_CARD] cardId=${cardId} addedAt=${addedAt}`);
+            inconsistencyCount++;
+            continue;
+          }
+
+          const history = card.repetitionHistory ?? [];
+          const meaningful = history.filter(r => r.score !== QueueInteractionScore.TOO_EARLY);
+
+          if (meaningful.length === 0) {
+            inconsistencies.push(
+              `[NO_HISTORY] cardId=${cardId} remId=${card.remId} — ${history.length === 0 ? 'no reps at all' : 'only TOO_EARLY reps'} (addedAt=${addedAt})`
+            );
+            inconsistencyCount++;
+            continue;
+          }
+
+          const last = meaningful[meaningful.length - 1];
+          const isExpected =
+            last.score === QueueInteractionScore.AGAIN ||
+            last.score === QueueInteractionScore.HARD;
+
+          if (!isExpected) {
+            const cramFlag = last.isCram ? ' [CRAM]' : '';
+            const everHard = meaningful.some(r => r.score === QueueInteractionScore.HARD);
+            const everAgain = meaningful.some(r => r.score === QueueInteractionScore.AGAIN);
+            const poorRatings = [everAgain ? 'AGAIN' : null, everHard ? 'HARD' : null].filter(Boolean).join('/');
+            const everPoorFlag = poorRatings ? ` everPoor=${poorRatings}` : ' everPoor=NEVER';
+            inconsistencies.push(
+              `[UNEXPECTED_SCORE] cardId=${cardId} remId=${card.remId} — last=${scoreName(last.score)}${cramFlag} ratedAt=${new Date(last.date).toISOString()} addedAt=${addedAt}${everPoorFlag}`
+            );
+            inconsistencyCount++;
+            history.forEach((rep, i) => {
+              const cram = rep.isCram ? ' [CRAM]' : '';
+              const scheduled = rep.scheduled ? ` scheduled=${new Date(rep.scheduled).toISOString()}` : '';
+              inconsistencies.push(
+                `      [${i + 1}/${history.length}] ${new Date(rep.date).toISOString()} ${scoreName(rep.score)}${cram}${scheduled}`
+              );
+            });
+          }
+        }
+
+        const scopeLabel = `KB=${isPrimary ? 'primary' : currentKbId} (${skippedOtherKb} items skipped from other KBs)`;
+        if (inconsistencyCount === 0) {
+          console.log(`[MasteryDrillAudit] ${scopeLabel} — all ${finalDrillIds.length} cards OK (last rating is AGAIN or HARD).`);
+          await plugin.app.toast(`All ${finalDrillIds.length} drill cards OK.`);
+        } else {
+          console.log(`[MasteryDrillAudit] ${scopeLabel} — ${inconsistencyCount} inconsistencies out of ${finalDrillIds.length} cards:`);
+          for (const msg of inconsistencies) {
+            console.log('  ' + msg);
+          }
+          await plugin.app.toast(`Found ${inconsistencyCount} inconsistent drill cards — check console.`);
+        }
+      },
+    });
+
+    plugin.app.registerCommand({
+      id: 'cleanup_mastery_drill',
+      name: 'Mastery Drill: Remove cards whose last rating was Good or Easy',
+      action: async () => {
+        type DrillItem = string | { cardId: string; kbId?: string; addedAt?: number };
+        const allDrillIds = ((await plugin.storage.getSynced('finalDrillIds')) as DrillItem[]) || [];
+
+        const currentKb = await plugin.kb.getCurrentKnowledgeBaseData();
+        const isPrimary = await plugin.kb.isPrimaryKnowledgeBase();
+        const currentKbId = currentKb?._id;
+        const getCardId = (item: DrillItem) => typeof item === 'string' ? item : item.cardId;
+        const isInCurrentKb = (item: DrillItem) =>
+          typeof item === 'string' ? isPrimary : item.kbId === currentKbId;
+
+        const toRemoveIds = new Set<string>();
+        let missingCount = 0;
+        let noHistoryCount = 0;
+
+        for (const item of allDrillIds) {
+          if (!isInCurrentKb(item)) continue;
+          const cardId = getCardId(item);
+          const card = await plugin.card.findOne(cardId);
+          if (!card) {
+            toRemoveIds.add(cardId);
+            missingCount++;
+            continue;
+          }
+          const history = card.repetitionHistory ?? [];
+          const meaningful = history.filter(r => r.score !== QueueInteractionScore.TOO_EARLY);
+          if (meaningful.length === 0) {
+            toRemoveIds.add(cardId);
+            noHistoryCount++;
+            continue;
+          }
+          const last = meaningful[meaningful.length - 1];
+          const isExpected =
+            last.score === QueueInteractionScore.AGAIN ||
+            last.score === QueueInteractionScore.HARD;
+          if (!isExpected) {
+            toRemoveIds.add(cardId);
+          }
+        }
+
+        if (toRemoveIds.size === 0) {
+          await plugin.app.toast('No cards to remove — the drill is already clean for this KB.');
+          return;
+        }
+
+        const kept = allDrillIds.filter(item => {
+          if (!isInCurrentKb(item)) return true;
+          return !toRemoveIds.has(getCardId(item));
+        });
+        await plugin.storage.setSynced('finalDrillIds', kept);
+
+        const unexpectedCount = toRemoveIds.size - missingCount - noHistoryCount;
+        console.log(
+          `[MasteryDrillCleanup] Removed ${toRemoveIds.size} cards from current KB ` +
+          `(missing=${missingCount}, noHistory=${noHistoryCount}, lastRatingWasGoodOrEasy=${unexpectedCount}). ` +
+          `${kept.length} items remain in finalDrillIds (across all KBs).`
+        );
+        await plugin.app.toast(`Removed ${toRemoveIds.size} cards from drill.`);
+      },
+    });
   }
 
   plugin.app.registerCommand({
@@ -1906,173 +2076,4 @@ export async function registerCommands(plugin: ReactRNPlugin) {
     },
   });
 
-  plugin.app.registerCommand({
-    id: 'debug_audit_mastery_drill',
-    name: 'Debug: Audit Mastery Drill Inconsistencies',
-    action: async () => {
-      type DrillItem = string | { cardId: string; kbId?: string; addedAt?: number };
-      const allDrillIds = ((await plugin.storage.getSynced('finalDrillIds')) as DrillItem[]) || [];
-
-      const currentKb = await plugin.kb.getCurrentKnowledgeBaseData();
-      const isPrimary = await plugin.kb.isPrimaryKnowledgeBase();
-      const currentKbId = currentKb?._id;
-
-      const finalDrillIds = allDrillIds.filter(item =>
-        typeof item === 'string' ? isPrimary : item.kbId === currentKbId
-      );
-      const skippedOtherKb = allDrillIds.length - finalDrillIds.length;
-
-      if (finalDrillIds.length === 0) {
-        await plugin.app.toast(
-          skippedOtherKb > 0
-            ? `No drill items for this KB (${skippedOtherKb} belong to other KBs).`
-            : 'Mastery Drill queue is empty.'
-        );
-        return;
-      }
-
-      const scoreName = (score: number): string => {
-        const map: Record<number, string> = {
-          0: 'AGAIN',
-          0.01: 'TOO_EARLY',
-          0.5: 'HARD',
-          1: 'GOOD',
-          1.5: 'EASY',
-          2: 'VIEWED_AS_LEECH',
-          3: 'RESET',
-          4: 'MANUAL_DATE',
-          5: 'MANUAL_EASE',
-        };
-        return map[score] ?? `UNKNOWN(${score})`;
-      };
-
-      const inconsistencies: string[] = [];
-      let inconsistencyCount = 0;
-
-      for (const item of finalDrillIds) {
-        const cardId = typeof item === 'string' ? item : item.cardId;
-        const addedAt = typeof item === 'object' && item.addedAt
-          ? new Date(item.addedAt).toISOString()
-          : 'unknown';
-
-        const card = await plugin.card.findOne(cardId);
-        if (!card) {
-          inconsistencies.push(`[MISSING_CARD] cardId=${cardId} addedAt=${addedAt}`);
-          inconsistencyCount++;
-          continue;
-        }
-
-        const history = card.repetitionHistory ?? [];
-        const meaningful = history.filter(r => r.score !== QueueInteractionScore.TOO_EARLY);
-
-        if (meaningful.length === 0) {
-          inconsistencies.push(
-            `[NO_HISTORY] cardId=${cardId} remId=${card.remId} — ${history.length === 0 ? 'no reps at all' : 'only TOO_EARLY reps'} (addedAt=${addedAt})`
-          );
-          inconsistencyCount++;
-          continue;
-        }
-
-        const last = meaningful[meaningful.length - 1];
-        const isExpected =
-          last.score === QueueInteractionScore.AGAIN ||
-          last.score === QueueInteractionScore.HARD;
-
-        if (!isExpected) {
-          const cramFlag = last.isCram ? ' [CRAM]' : '';
-          const everHard = meaningful.some(r => r.score === QueueInteractionScore.HARD);
-          const everAgain = meaningful.some(r => r.score === QueueInteractionScore.AGAIN);
-          const poorRatings = [everAgain ? 'AGAIN' : null, everHard ? 'HARD' : null].filter(Boolean).join('/');
-          const everPoorFlag = poorRatings ? ` everPoor=${poorRatings}` : ' everPoor=NEVER';
-          inconsistencies.push(
-            `[UNEXPECTED_SCORE] cardId=${cardId} remId=${card.remId} — last=${scoreName(last.score)}${cramFlag} ratedAt=${new Date(last.date).toISOString()} addedAt=${addedAt}${everPoorFlag}`
-          );
-          inconsistencyCount++;
-          history.forEach((rep, i) => {
-            const cram = rep.isCram ? ' [CRAM]' : '';
-            const scheduled = rep.scheduled ? ` scheduled=${new Date(rep.scheduled).toISOString()}` : '';
-            inconsistencies.push(
-              `      [${i + 1}/${history.length}] ${new Date(rep.date).toISOString()} ${scoreName(rep.score)}${cram}${scheduled}`
-            );
-          });
-        }
-      }
-
-      const scopeLabel = `KB=${isPrimary ? 'primary' : currentKbId} (${skippedOtherKb} items skipped from other KBs)`;
-      if (inconsistencyCount === 0) {
-        console.log(`[MasteryDrillAudit] ${scopeLabel} — all ${finalDrillIds.length} cards OK (last rating is AGAIN or HARD).`);
-        await plugin.app.toast(`All ${finalDrillIds.length} drill cards OK.`);
-      } else {
-        console.log(`[MasteryDrillAudit] ${scopeLabel} — ${inconsistencyCount} inconsistencies out of ${finalDrillIds.length} cards:`);
-        for (const msg of inconsistencies) {
-          console.log('  ' + msg);
-        }
-        await plugin.app.toast(`Found ${inconsistencyCount} inconsistent drill cards — check console.`);
-      }
-    },
-  });
-
-  plugin.app.registerCommand({
-    id: 'cleanup_mastery_drill',
-    name: 'Mastery Drill: Remove cards whose last rating was Good or Easy',
-    action: async () => {
-      type DrillItem = string | { cardId: string; kbId?: string; addedAt?: number };
-      const allDrillIds = ((await plugin.storage.getSynced('finalDrillIds')) as DrillItem[]) || [];
-
-      const currentKb = await plugin.kb.getCurrentKnowledgeBaseData();
-      const isPrimary = await plugin.kb.isPrimaryKnowledgeBase();
-      const currentKbId = currentKb?._id;
-      const getCardId = (item: DrillItem) => typeof item === 'string' ? item : item.cardId;
-      const isInCurrentKb = (item: DrillItem) =>
-        typeof item === 'string' ? isPrimary : item.kbId === currentKbId;
-
-      const toRemoveIds = new Set<string>();
-      let missingCount = 0;
-      let noHistoryCount = 0;
-
-      for (const item of allDrillIds) {
-        if (!isInCurrentKb(item)) continue;
-        const cardId = getCardId(item);
-        const card = await plugin.card.findOne(cardId);
-        if (!card) {
-          toRemoveIds.add(cardId);
-          missingCount++;
-          continue;
-        }
-        const history = card.repetitionHistory ?? [];
-        const meaningful = history.filter(r => r.score !== QueueInteractionScore.TOO_EARLY);
-        if (meaningful.length === 0) {
-          toRemoveIds.add(cardId);
-          noHistoryCount++;
-          continue;
-        }
-        const last = meaningful[meaningful.length - 1];
-        const isExpected =
-          last.score === QueueInteractionScore.AGAIN ||
-          last.score === QueueInteractionScore.HARD;
-        if (!isExpected) {
-          toRemoveIds.add(cardId);
-        }
-      }
-
-      if (toRemoveIds.size === 0) {
-        await plugin.app.toast('No cards to remove — the drill is already clean for this KB.');
-        return;
-      }
-
-      const kept = allDrillIds.filter(item => {
-        if (!isInCurrentKb(item)) return true;
-        return !toRemoveIds.has(getCardId(item));
-      });
-      await plugin.storage.setSynced('finalDrillIds', kept);
-
-      const unexpectedCount = toRemoveIds.size - missingCount - noHistoryCount;
-      console.log(
-        `[MasteryDrillCleanup] Removed ${toRemoveIds.size} cards from current KB ` +
-        `(missing=${missingCount}, noHistory=${noHistoryCount}, lastRatingWasGoodOrEasy=${unexpectedCount}). ` +
-        `${kept.length} items remain in finalDrillIds (across all KBs).`
-      );
-      await plugin.app.toast(`Removed ${toRemoveIds.size} cards from drill.`);
-    },
-  });
 }

--- a/src/register/commands.ts
+++ b/src/register/commands.ts
@@ -6,6 +6,7 @@ import {
   BuiltInPowerupCodes,
   RICH_TEXT_FORMATTING,
   RichTextInterface,
+  RemType,
 } from '@remnote/plugin-sdk';
 import {
   powerupCode,
@@ -331,8 +332,11 @@ export async function registerCommands(plugin: ReactRNPlugin) {
     name: 'Create Cloze Deletion',
     keyboardShortcut: 'opt+z',
     action: async () => {
+      console.log('[ClozeCmd] ── triggered ──────────────────────────');
       const selection = await plugin.editor.getSelection();
+      console.log('[ClozeCmd] selection:', JSON.stringify(selection));
       if (!selection || selection.type !== SelectionType.Text) {
+        console.log('[ClozeCmd] abort: no text selection');
         return;
       }
       if (selection.range.start === selection.range.end) {
@@ -341,69 +345,255 @@ export async function registerCommands(plugin: ReactRNPlugin) {
       }
 
       const rem = await plugin.rem.findOne(selection.remId);
-      if (!rem) return;
+      if (!rem) { console.log('[ClozeCmd] abort: rem not found'); return; }
+
+      console.log('[ClozeCmd] rem._id:', rem._id);
+      console.log('[ClozeCmd] rem.text (raw):', JSON.stringify(rem.text));
+      console.log('[ClozeCmd] rem.backText (raw):', JSON.stringify(rem.backText));
 
       const r_start = Math.min(selection.range.start, selection.range.end);
       const r_end = Math.max(selection.range.start, selection.range.end);
+      console.log('[ClozeCmd] r_start:', r_start, '  r_end:', r_end);
+
+      const frontText = rem.text || [];
+      const backText = rem.backText || [];
+      const hasBackText = backText.length > 0;
+
+      // Plain-text character length of a rich text array.
+      // NOTE: r_start/r_end use global character positions (front+delimiter+back).
+      // Non-text nodes (i≠'m', i≠'s') count as 1 char in the editor's position model.
+      const rtCharLen = (rt: RichTextInterface): number => {
+        let n = 0;
+        for (const item of rt) {
+          if (typeof item === 'string') n += (item as string).length;
+          else { const x = item as any; n += x.i === 'm' ? (x.text?.length || 0) : 1; }
+        }
+        return n;
+      };
+
+      // Plain string from rich text (text nodes only, non-text nodes → '').
+      const rtPlainStr = (rt: RichTextInterface): string =>
+        rt.map((item: any) => typeof item === 'string' ? item : (item.i === 'm' ? (item.text || '') : '')).join('');
+
+      const frontLen = rtCharLen(frontText);
+      console.log('[ClozeCmd] frontLen:', frontLen, '  hasBackText:', hasBackText);
+
+      // Determine which section contains the selection.
+      // r_start/r_end are global positions; the front section spans [0, frontLen).
+      // The delimiter + back section starts at frontLen in the global coord.
+      let isBack = false;
+      let sect_r_start = r_start;  // position relative to the containing section
+      let sect_r_end   = r_end;
+
+      if (hasBackText && r_start >= frontLen) {
+        isBack = true;
+        // Compute section-relative offset by finding the selected text within backText.
+        // global r_start = frontLen + separatorLen + posInBack
+        // Since separatorLen is unknown, we locate the selection by string-matching.
+        const selStr  = rtPlainStr(selection.richText as RichTextInterface);
+        const backStr = rtPlainStr(backText);
+        console.log('[ClozeCmd] selStr:', JSON.stringify(selStr), '  backStr:', JSON.stringify(backStr));
+        const posInBack = backStr.indexOf(selStr);
+        if (posInBack >= 0) {
+          sect_r_start = posInBack;
+          sect_r_end   = posInBack + selStr.length;
+        } else {
+          // Fallback: subtract frontLen (may be off by separatorLen, but better than nothing)
+          sect_r_start = r_start - frontLen;
+          sect_r_end   = r_end   - frontLen;
+          console.log('[ClozeCmd] WARN: selected text not found in backStr – using offset fallback');
+        }
+      }
+      // When isBack=false, front text starts at global pos 0, so r_start IS the section-relative offset.
+
+      console.log('[ClozeCmd] isBack:', isBack, '  sect_r_start:', sect_r_start, '  sect_r_end:', sect_r_end);
 
       const clozeId = Math.random().toString(36).substring(2, 10);
+      console.log('[ClozeCmd] clozeId:', clozeId);
 
-      const processRichText = (richText: RichTextInterface): RichTextInterface => {
-        const newArray: any[] = [];
+      // Determine arrow character from the rem's practice direction.
+      const practiceDir = hasBackText ? await rem.getPracticeDirection() : 'none';
+      const arrowChar = practiceDir === 'forward' ? '⇒'
+                      : practiceDir === 'backward' ? '⇐'
+                      : practiceDir === 'both' ? '⇔'
+                      : '⇔'; // fallback
+      console.log('[ClozeCmd] practiceDir:', practiceDir, '  arrowChar:', arrowChar);
+
+      // Detect rem type to apply matching front-text formatting in the child.
+      const remType = rem.type;
+      console.log('[ClozeCmd] remType:', remType, '(CONCEPT=1, DESCRIPTOR=2, DEFAULT=0)');
+
+      // Process one rich text section. localStart/localEnd are section-relative character positions.
+      // - Delimiter nodes (i:'s') → replaced by arrowChar.
+      // - Existing cloze marks outside the selection → stripped, yellow highlight + red font applied.
+      // - Text inside [localStart, localEnd) → new clozeId applied.
+      const processSection = (
+        richText: RichTextInterface,
+        applySelection: boolean,
+        localStart: number,
+        localEnd: number
+      ): any[] => {
+        const arr: any[] = [];
         let currIdx = 0;
         for (const item of richText) {
-          const isString = typeof item === 'string';
-          const textNode = isString ? { i: 'm' as const, text: item } : (item as any);
-          const nodeLen = textNode.i === 'm' ? (textNode.text?.length || 0) : 1;
+          const isStr  = typeof item === 'string';
+          const node   = isStr ? { i: 'm' as const, text: item as string } : (item as any);
+          const nodeLen = node.i === 'm' ? (node.text?.length || 0) : 1;
           const nodeStart = currIdx;
-          const nodeEnd = currIdx + nodeLen;
+          const nodeEnd   = currIdx + nodeLen;
+          const inSel = applySelection && nodeStart < localEnd && nodeEnd > localStart;
 
-          if (nodeEnd <= r_start || nodeStart >= r_end) {
-            newArray.push(item);
-          } else {
-            if (textNode.i === 'm') {
-              const textStr = textNode.text || '';
-              const relStart = Math.max(0, r_start - nodeStart);
-              const relEnd = Math.min(nodeLen, r_end - nodeStart);
+          if (node.i === 's') {
+            arr.push(inSel
+              ? { i: 'm' as const, text: arrowChar, [RICH_TEXT_FORMATTING.CLOZE]: clozeId }
+              : { i: 'm' as const, text: arrowChar }
+            );
+          } else if (node.i === 'm') {
+            const textStr  = node.text || '';
+            const baseNode: any = { ...node };
+            const hadCloze = RICH_TEXT_FORMATTING.CLOZE in baseNode;
+            delete baseNode[RICH_TEXT_FORMATTING.CLOZE];
 
-              if (relStart > 0) {
-                newArray.push({ ...textNode, text: textStr.substring(0, relStart) });
-              }
-              newArray.push({
-                ...textNode,
-                text: textStr.substring(relStart, relEnd),
-                [RICH_TEXT_FORMATTING.CLOZE]: clozeId,
-              });
-              if (relEnd < nodeLen) {
-                newArray.push({ ...textNode, text: textStr.substring(relEnd) });
+            if (!inSel) {
+              if (hadCloze) {
+                arr.push(isStr
+                  ? { i: 'm' as const, text: textStr, [RICH_TEXT_FORMATTING.HIGHLIGHT]: 3, [RICH_TEXT_FORMATTING.TEXT_COLOR]: 1 }
+                  : { ...baseNode, [RICH_TEXT_FORMATTING.HIGHLIGHT]: 3, [RICH_TEXT_FORMATTING.TEXT_COLOR]: 1 });
+              } else {
+                arr.push(isStr ? textStr : baseNode);
               }
             } else {
-              newArray.push({
-                ...textNode,
-                [RICH_TEXT_FORMATTING.CLOZE]: clozeId,
-              });
+              const relStart = Math.max(0, localStart - nodeStart);
+              const relEnd   = Math.min(nodeLen, localEnd - nodeStart);
+              if (relStart > 0) {
+                const pre = textStr.substring(0, relStart);
+                arr.push(hadCloze
+                  ? { ...baseNode, text: pre, [RICH_TEXT_FORMATTING.HIGHLIGHT]: 3, [RICH_TEXT_FORMATTING.TEXT_COLOR]: 1 }
+                  : (isStr ? pre : { ...baseNode, text: pre }));
+              }
+              arr.push({ ...baseNode, text: textStr.substring(relStart, relEnd), [RICH_TEXT_FORMATTING.CLOZE]: clozeId });
+              if (relEnd < nodeLen) {
+                const post = textStr.substring(relEnd);
+                arr.push(hadCloze
+                  ? { ...baseNode, text: post, [RICH_TEXT_FORMATTING.HIGHLIGHT]: 3, [RICH_TEXT_FORMATTING.TEXT_COLOR]: 1 }
+                  : (isStr ? post : { ...baseNode, text: post }));
+              }
+            }
+          } else {
+            const baseNode: any = { ...node };
+            const hadCloze = RICH_TEXT_FORMATTING.CLOZE in baseNode;
+            delete baseNode[RICH_TEXT_FORMATTING.CLOZE];
+            if (inSel) {
+              arr.push({ ...baseNode, [RICH_TEXT_FORMATTING.CLOZE]: clozeId });
+            } else if (hadCloze) {
+              arr.push({ ...baseNode, [RICH_TEXT_FORMATTING.HIGHLIGHT]: 3, [RICH_TEXT_FORMATTING.TEXT_COLOR]: 1 });
+            } else {
+              arr.push(baseNode);
             }
           }
           currIdx += nodeLen;
         }
-        return newArray;
+        return arr;
       };
 
-      let isBack = false;
-      const remText = rem.text || [];
-      const frontMiddle = await plugin.richText.substring(remText, r_start, r_end);
-      if (!(await plugin.richText.equals(selection.richText, frontMiddle))) {
-        const backMiddle = await plugin.richText.substring(rem.backText || [], r_start, r_end);
-        if (await plugin.richText.equals(selection.richText, backMiddle)) {
-          isBack = true;
+      // Apply bold (concept) or italic (descriptor) to all text nodes in a node array,
+      // matching how RemNote renders the front of concept/descriptor rems.
+      const applyTypeFormatting = (nodes: any[]): any[] => {
+        if (remType !== RemType.CONCEPT && remType !== RemType.DESCRIPTOR) return nodes;
+        const prop = remType === RemType.CONCEPT ? RICH_TEXT_FORMATTING.BOLD : RICH_TEXT_FORMATTING.ITALIC;
+        return nodes.map((node: any) => {
+          if (typeof node === 'string') return { i: 'm' as const, text: node, [prop]: true };
+          if (node.i === 'm') return { ...node, [prop]: true };
+          return node;
+        });
+      };
+
+      // Build child text: processed front + (arrow separator if needed) + processed back + parent pin.
+      const buildChildText = (): RichTextInterface => {
+        const rawFrontPart = processSection(frontText, !isBack, sect_r_start, sect_r_end);
+        const frontPart = applyTypeFormatting(rawFrontPart);
+        console.log('[ClozeCmd] frontPart:', JSON.stringify(frontPart));
+        const result: any[] = [...frontPart];
+        if (hasBackText) {
+          // If the front text has an explicit i:'s' delimiter node, processSection already
+          // replaced it with arrowChar. Otherwise insert the arrow + spacing manually.
+          const hasExplicitDelim = frontText.some((item: any) => typeof item !== 'string' && item?.i === 's');
+          if (!hasExplicitDelim) {
+            result.push({ i: 'm' as const, text: ' ' + arrowChar + ' ' });
+          }
+          const backPart = processSection(backText, isBack, sect_r_start, sect_r_end);
+          console.log('[ClozeCmd] backPart:', JSON.stringify(backPart));
+          result.push(...backPart);
+        }
+        result.push({ i: 'q', _id: rem._id, pin: true });
+        console.log('[ClozeCmd] final childText:', JSON.stringify(result));
+        return result;
+      };
+
+      // 1. Create child rem
+      const clozeRem = await plugin.rem.createRem();
+      if (!clozeRem) { console.log('[ClozeCmd] abort: createRem failed'); return; }
+      console.log('[ClozeCmd] clozeRem._id:', clozeRem._id);
+
+      await clozeRem.setText(buildChildText());
+      await clozeRem.setParent(rem);
+      console.log('[ClozeCmd] child rem created and parented');
+
+      // 2. Add remove-from-queue tag to parent
+      let removeFromQueueTag = await plugin.rem.findByName(['remove-from-queue'], null);
+      if (!removeFromQueueTag) {
+        removeFromQueueTag = await plugin.rem.createRem();
+        if (removeFromQueueTag) {
+          await removeFromQueueTag.setText(['remove-from-queue']);
         }
       }
+      if (removeFromQueueTag) {
+        await rem.addTag(removeFromQueueTag._id);
+      }
+
+      // 3. Mark selected text in parent with yellow highlight + red font.
+      // Uses the same section-relative positions (sect_r_start/sect_r_end).
+      const processParentSection = (richText: RichTextInterface, localStart: number, localEnd: number): RichTextInterface => {
+        const arr: any[] = [];
+        let currIdx = 0;
+        for (const item of richText) {
+          const isStr  = typeof item === 'string';
+          const node   = isStr ? { i: 'm' as const, text: item as string } : (item as any);
+          const nodeLen = node.i === 'm' ? (node.text?.length || 0) : 1;
+          const nodeStart = currIdx;
+          const nodeEnd   = currIdx + nodeLen;
+
+          if (nodeEnd <= localStart || nodeStart >= localEnd) {
+            arr.push(item);
+          } else if (node.i === 'm') {
+            const textStr  = node.text || '';
+            const relStart = Math.max(0, localStart - nodeStart);
+            const relEnd   = Math.min(nodeLen, localEnd - nodeStart);
+            if (relStart > 0) {
+              arr.push(isStr ? textStr.substring(0, relStart) : { ...node, text: textStr.substring(0, relStart) });
+            }
+            arr.push({ ...node, text: textStr.substring(relStart, relEnd), [RICH_TEXT_FORMATTING.HIGHLIGHT]: 3, [RICH_TEXT_FORMATTING.TEXT_COLOR]: 1 });
+            if (relEnd < nodeLen) {
+              arr.push(isStr ? textStr.substring(relEnd) : { ...node, text: textStr.substring(relEnd) });
+            }
+          } else {
+            arr.push({ ...node, [RICH_TEXT_FORMATTING.HIGHLIGHT]: 3, [RICH_TEXT_FORMATTING.TEXT_COLOR]: 1 });
+          }
+          currIdx += nodeLen;
+        }
+        return arr;
+      };
 
       if (isBack) {
-        await rem.setBackText(processRichText(rem.backText || []));
+        const result = processParentSection(backText, sect_r_start, sect_r_end);
+        console.log('[ClozeCmd] parent backText result:', JSON.stringify(result));
+        await rem.setBackText(result);
       } else {
-        await rem.setText(processRichText(rem.text || []));
+        const result = processParentSection(frontText, sect_r_start, sect_r_end);
+        console.log('[ClozeCmd] parent frontText result:', JSON.stringify(result));
+        await rem.setText(result);
       }
+      console.log('[ClozeCmd] ── done ──────────────────────────────');
     },
   });
 

--- a/src/register/commands.ts
+++ b/src/register/commands.ts
@@ -332,28 +332,18 @@ export async function registerCommands(plugin: ReactRNPlugin) {
     name: 'Create Cloze Deletion',
     keyboardShortcut: 'opt+z',
     action: async () => {
-      console.log('[ClozeCmd] ── triggered ──────────────────────────');
       const selection = await plugin.editor.getSelection();
-      console.log('[ClozeCmd] selection:', JSON.stringify(selection));
-      if (!selection || selection.type !== SelectionType.Text) {
-        console.log('[ClozeCmd] abort: no text selection');
-        return;
-      }
+      if (!selection || selection.type !== SelectionType.Text) return;
       if (selection.range.start === selection.range.end) {
         await plugin.app.toast('Please select some text to create a cloze deletion.');
         return;
       }
 
       const rem = await plugin.rem.findOne(selection.remId);
-      if (!rem) { console.log('[ClozeCmd] abort: rem not found'); return; }
-
-      console.log('[ClozeCmd] rem._id:', rem._id);
-      console.log('[ClozeCmd] rem.text (raw):', JSON.stringify(rem.text));
-      console.log('[ClozeCmd] rem.backText (raw):', JSON.stringify(rem.backText));
+      if (!rem) return;
 
       const r_start = Math.min(selection.range.start, selection.range.end);
       const r_end = Math.max(selection.range.start, selection.range.end);
-      console.log('[ClozeCmd] r_start:', r_start, '  r_end:', r_end);
 
       const frontText = rem.text || [];
       const backText = rem.backText || [];
@@ -376,7 +366,6 @@ export async function registerCommands(plugin: ReactRNPlugin) {
         rt.map((item: any) => typeof item === 'string' ? item : (item.i === 'm' ? (item.text || '') : '')).join('');
 
       const frontLen = rtCharLen(frontText);
-      console.log('[ClozeCmd] frontLen:', frontLen, '  hasBackText:', hasBackText);
 
       // Determine which section contains the selection.
       // r_start/r_end are global positions; the front section spans [0, frontLen).
@@ -392,24 +381,18 @@ export async function registerCommands(plugin: ReactRNPlugin) {
         // Since separatorLen is unknown, we locate the selection by string-matching.
         const selStr  = rtPlainStr(selection.richText as RichTextInterface);
         const backStr = rtPlainStr(backText);
-        console.log('[ClozeCmd] selStr:', JSON.stringify(selStr), '  backStr:', JSON.stringify(backStr));
         const posInBack = backStr.indexOf(selStr);
         if (posInBack >= 0) {
           sect_r_start = posInBack;
           sect_r_end   = posInBack + selStr.length;
         } else {
-          // Fallback: subtract frontLen (may be off by separatorLen, but better than nothing)
           sect_r_start = r_start - frontLen;
           sect_r_end   = r_end   - frontLen;
-          console.log('[ClozeCmd] WARN: selected text not found in backStr – using offset fallback');
         }
       }
       // When isBack=false, front text starts at global pos 0, so r_start IS the section-relative offset.
 
-      console.log('[ClozeCmd] isBack:', isBack, '  sect_r_start:', sect_r_start, '  sect_r_end:', sect_r_end);
-
       const clozeId = Math.random().toString(36).substring(2, 10);
-      console.log('[ClozeCmd] clozeId:', clozeId);
 
       // Determine arrow character from the rem's practice direction.
       const practiceDir = hasBackText ? await rem.getPracticeDirection() : 'none';
@@ -417,11 +400,7 @@ export async function registerCommands(plugin: ReactRNPlugin) {
                       : practiceDir === 'backward' ? '⇐'
                       : practiceDir === 'both' ? '⇔'
                       : '⇔'; // fallback
-      console.log('[ClozeCmd] practiceDir:', practiceDir, '  arrowChar:', arrowChar);
-
-      // Detect rem type to apply matching front-text formatting in the child.
       const remType = rem.type;
-      console.log('[ClozeCmd] remType:', remType, '(CONCEPT=1, DESCRIPTOR=2, DEFAULT=0)');
 
       // Process one rich text section. localStart/localEnd are section-relative character positions.
       // - Delimiter nodes (i:'s') → replaced by arrowChar.
@@ -512,41 +491,32 @@ export async function registerCommands(plugin: ReactRNPlugin) {
       const buildChildText = (): RichTextInterface => {
         const rawFrontPart = processSection(frontText, !isBack, sect_r_start, sect_r_end);
         const frontPart = applyTypeFormatting(rawFrontPart);
-        console.log('[ClozeCmd] frontPart:', JSON.stringify(frontPart));
         const result: any[] = [...frontPart];
         if (hasBackText) {
-          // If the front text has an explicit i:'s' delimiter node, processSection already
-          // replaced it with arrowChar. Otherwise insert the arrow + spacing manually.
           const hasExplicitDelim = frontText.some((item: any) => typeof item !== 'string' && item?.i === 's');
           if (!hasExplicitDelim) {
             result.push({ i: 'm' as const, text: ' ' + arrowChar + ' ' });
           }
           const backPart = processSection(backText, isBack, sect_r_start, sect_r_end);
-          console.log('[ClozeCmd] backPart:', JSON.stringify(backPart));
           result.push(...backPart);
         }
         result.push({ i: 'q', _id: rem._id, pin: true });
-        console.log('[ClozeCmd] final childText:', JSON.stringify(result));
         return result;
       };
 
       // 1. Create child rem
       const clozeRem = await plugin.rem.createRem();
-      if (!clozeRem) { console.log('[ClozeCmd] abort: createRem failed'); return; }
-      console.log('[ClozeCmd] clozeRem._id:', clozeRem._id);
+      if (!clozeRem) return;
 
       await clozeRem.setText(buildChildText());
       await clozeRem.setParent(rem);
 
-      // Tag child rem so the CSS badge is visible in the queue
       let clozeExtractTag = await plugin.rem.findByName(['cloze-extract'], null);
       if (!clozeExtractTag) {
         clozeExtractTag = await plugin.rem.createRem();
         if (clozeExtractTag) await clozeExtractTag.setText(['cloze-extract']);
       }
       if (clozeExtractTag) await clozeRem.addTag(clozeExtractTag._id);
-
-      console.log('[ClozeCmd] child rem created and parented');
 
       // 2. Add remove-from-queue tag to parent
       let removeFromQueueTag = await plugin.rem.findByName(['remove-from-queue'], null);
@@ -594,15 +564,10 @@ export async function registerCommands(plugin: ReactRNPlugin) {
       };
 
       if (isBack) {
-        const result = processParentSection(backText, sect_r_start, sect_r_end);
-        console.log('[ClozeCmd] parent backText result:', JSON.stringify(result));
-        await rem.setBackText(result);
+        await rem.setBackText(processParentSection(backText, sect_r_start, sect_r_end));
       } else {
-        const result = processParentSection(frontText, sect_r_start, sect_r_end);
-        console.log('[ClozeCmd] parent frontText result:', JSON.stringify(result));
-        await rem.setText(result);
+        await rem.setText(processParentSection(frontText, sect_r_start, sect_r_end));
       }
-      console.log('[ClozeCmd] ── done ──────────────────────────────');
     },
   });
 

--- a/src/register/commands.ts
+++ b/src/register/commands.ts
@@ -537,6 +537,15 @@ export async function registerCommands(plugin: ReactRNPlugin) {
 
       await clozeRem.setText(buildChildText());
       await clozeRem.setParent(rem);
+
+      // Tag child rem so the CSS badge is visible in the queue
+      let clozeExtractTag = await plugin.rem.findByName(['cloze-extract'], null);
+      if (!clozeExtractTag) {
+        clozeExtractTag = await plugin.rem.createRem();
+        if (clozeExtractTag) await clozeExtractTag.setText(['cloze-extract']);
+      }
+      if (clozeExtractTag) await clozeRem.addTag(clozeExtractTag._id);
+
       console.log('[ClozeCmd] child rem created and parented');
 
       // 2. Add remove-from-queue tag to parent

--- a/src/register/commands.ts
+++ b/src/register/commands.ts
@@ -368,54 +368,41 @@ export async function registerCommands(plugin: ReactRNPlugin) {
       if (!rem) return;
 
       const r_start = Math.min(selection.range.start, selection.range.end);
-      const r_end = Math.max(selection.range.start, selection.range.end);
 
       const frontText = rem.text || [];
       const backText = rem.backText || [];
       const hasBackText = backText.length > 0;
 
-      // Plain-text character length of a rich text array.
-      // NOTE: r_start/r_end use global character positions (front+delimiter+back).
-      // Non-text nodes (i≠'m', i≠'s') count as 1 char in the editor's position model.
-      const rtCharLen = (rt: RichTextInterface): number => {
-        let n = 0;
-        for (const item of rt) {
-          if (typeof item === 'string') n += (item as string).length;
-          else { const x = item as any; n += x.i === 'm' ? (x.text?.length || 0) : 1; }
-        }
-        return n;
-      };
-
       // Plain string from rich text (text nodes only, non-text nodes → '').
+      // Used for text-only position matching — immune to RemNote's i:'q' cursor-width (2 chars).
       const rtPlainStr = (rt: RichTextInterface): string =>
         rt.map((item: any) => typeof item === 'string' ? item : (item.i === 'm' ? (item.text || '') : '')).join('');
 
-      const frontLen = rtCharLen(frontText);
+      const selStr   = rtPlainStr(selection.richText as RichTextInterface);
+      const selLen   = selStr.length;
+      const frontStr = rtPlainStr(frontText);
+      const backStr  = rtPlainStr(backText);
 
-      // Determine which section contains the selection.
-      // r_start/r_end are global positions; the front section spans [0, frontLen).
-      // The delimiter + back section starts at frontLen in the global coord.
+      // Detect section via string-matching (text-only positions avoid RemNote cursor-model issues).
+      const posInFront = frontStr.indexOf(selStr);
+      const posInBack  = hasBackText ? backStr.indexOf(selStr) : -1;
+
       let isBack = false;
-      let sect_r_start = r_start;  // position relative to the containing section
-      let sect_r_end   = r_end;
+      let sect_r_start = 0;
 
-      if (hasBackText && r_start >= frontLen) {
+      if (posInFront >= 0 && (posInBack < 0 || r_start < frontStr.length)) {
+        isBack = false;
+        sect_r_start = posInFront;
+      } else if (posInBack >= 0) {
         isBack = true;
-        // Compute section-relative offset by finding the selected text within backText.
-        // global r_start = frontLen + separatorLen + posInBack
-        // Since separatorLen is unknown, we locate the selection by string-matching.
-        const selStr  = rtPlainStr(selection.richText as RichTextInterface);
-        const backStr = rtPlainStr(backText);
-        const posInBack = backStr.indexOf(selStr);
-        if (posInBack >= 0) {
-          sect_r_start = posInBack;
-          sect_r_end   = posInBack + selStr.length;
-        } else {
-          sect_r_start = r_start - frontLen;
-          sect_r_end   = r_end   - frontLen;
-        }
+        sect_r_start = posInBack;
+      } else {
+        // Fallback: use r_start directly (may be off if pins precede the selection)
+        isBack = false;
+        sect_r_start = r_start;
       }
-      // When isBack=false, front text starts at global pos 0, so r_start IS the section-relative offset.
+
+      const sect_r_end = sect_r_start + selLen;
 
       const clozeId = Math.random().toString(36).substring(2, 10);
 
@@ -442,10 +429,16 @@ export async function registerCommands(plugin: ReactRNPlugin) {
         for (const item of richText) {
           const isStr  = typeof item === 'string';
           const node   = isStr ? { i: 'm' as const, text: item as string } : (item as any);
-          const nodeLen = node.i === 'm' ? (node.text?.length || 0) : 1;
+          // Text-only positions: non-'m' nodes have length 0 (immune to RemNote's i:'q' cursor-width).
+          const nodeLen = node.i === 'm' ? (node.text?.length || 0) : 0;
           const nodeStart = currIdx;
           const nodeEnd   = currIdx + nodeLen;
-          const inSel = applySelection && nodeStart < localEnd && nodeEnd > localStart;
+          // For zero-length nodes use a point check; for text nodes use the range overlap check.
+          const inSel = applySelection && (
+            nodeLen > 0
+              ? (nodeStart < localEnd && nodeEnd > localStart)
+              : (currIdx > localStart && currIdx < localEnd)
+          );
 
           if (node.i === 's') {
             arr.push(inSel
@@ -563,27 +556,30 @@ export async function registerCommands(plugin: ReactRNPlugin) {
         for (const item of richText) {
           const isStr  = typeof item === 'string';
           const node   = isStr ? { i: 'm' as const, text: item as string } : (item as any);
-          const nodeLen = node.i === 'm' ? (node.text?.length || 0) : 1;
-          const nodeStart = currIdx;
-          const nodeEnd   = currIdx + nodeLen;
+          // Text-only positions: non-'m' nodes pass through unchanged.
+          const nodeLen = node.i === 'm' ? (node.text?.length || 0) : 0;
 
-          if (nodeEnd <= localStart || nodeStart >= localEnd) {
+          if (nodeLen === 0) {
             arr.push(item);
-          } else if (node.i === 'm') {
-            const textStr  = node.text || '';
-            const relStart = Math.max(0, localStart - nodeStart);
-            const relEnd   = Math.min(nodeLen, localEnd - nodeStart);
-            if (relStart > 0) {
-              arr.push(isStr ? textStr.substring(0, relStart) : { ...node, text: textStr.substring(0, relStart) });
-            }
-            arr.push({ ...node, text: textStr.substring(relStart, relEnd), [RICH_TEXT_FORMATTING.HIGHLIGHT]: 3, [RICH_TEXT_FORMATTING.TEXT_COLOR]: 1 });
-            if (relEnd < nodeLen) {
-              arr.push(isStr ? textStr.substring(relEnd) : { ...node, text: textStr.substring(relEnd) });
-            }
           } else {
-            arr.push({ ...node, [RICH_TEXT_FORMATTING.HIGHLIGHT]: 3, [RICH_TEXT_FORMATTING.TEXT_COLOR]: 1 });
+            const nodeStart = currIdx;
+            const nodeEnd   = currIdx + nodeLen;
+            if (nodeEnd <= localStart || nodeStart >= localEnd) {
+              arr.push(item);
+            } else {
+              const textStr  = node.text || '';
+              const relStart = Math.max(0, localStart - nodeStart);
+              const relEnd   = Math.min(nodeLen, localEnd - nodeStart);
+              if (relStart > 0) {
+                arr.push(isStr ? textStr.substring(0, relStart) : { ...node, text: textStr.substring(0, relStart) });
+              }
+              arr.push({ ...node, text: textStr.substring(relStart, relEnd), [RICH_TEXT_FORMATTING.HIGHLIGHT]: 3, [RICH_TEXT_FORMATTING.TEXT_COLOR]: 1 });
+              if (relEnd < nodeLen) {
+                arr.push(isStr ? textStr.substring(relEnd) : { ...node, text: textStr.substring(relEnd) });
+              }
+            }
+            currIdx += nodeLen;
           }
-          currIdx += nodeLen;
         }
         return arr;
       };

--- a/src/register/commands.ts
+++ b/src/register/commands.ts
@@ -7,6 +7,7 @@ import {
   RICH_TEXT_FORMATTING,
   RichTextInterface,
   RemType,
+  QueueInteractionScore,
 } from '@remnote/plugin-sdk';
 import {
   powerupCode,
@@ -1902,6 +1903,176 @@ export async function registerCommands(plugin: ReactRNPlugin) {
     action: async () => {
       await plugin.storage.setSynced('flashcardHistoryData', []);
       await plugin.app.toast('Flashcard History cleared!');
+    },
+  });
+
+  plugin.app.registerCommand({
+    id: 'debug_audit_mastery_drill',
+    name: 'Debug: Audit Mastery Drill Inconsistencies',
+    action: async () => {
+      type DrillItem = string | { cardId: string; kbId?: string; addedAt?: number };
+      const allDrillIds = ((await plugin.storage.getSynced('finalDrillIds')) as DrillItem[]) || [];
+
+      const currentKb = await plugin.kb.getCurrentKnowledgeBaseData();
+      const isPrimary = await plugin.kb.isPrimaryKnowledgeBase();
+      const currentKbId = currentKb?._id;
+
+      const finalDrillIds = allDrillIds.filter(item =>
+        typeof item === 'string' ? isPrimary : item.kbId === currentKbId
+      );
+      const skippedOtherKb = allDrillIds.length - finalDrillIds.length;
+
+      if (finalDrillIds.length === 0) {
+        await plugin.app.toast(
+          skippedOtherKb > 0
+            ? `No drill items for this KB (${skippedOtherKb} belong to other KBs).`
+            : 'Mastery Drill queue is empty.'
+        );
+        return;
+      }
+
+      const scoreName = (score: number): string => {
+        const map: Record<number, string> = {
+          0: 'AGAIN',
+          0.01: 'TOO_EARLY',
+          0.5: 'HARD',
+          1: 'GOOD',
+          1.5: 'EASY',
+          2: 'VIEWED_AS_LEECH',
+          3: 'RESET',
+          4: 'MANUAL_DATE',
+          5: 'MANUAL_EASE',
+        };
+        return map[score] ?? `UNKNOWN(${score})`;
+      };
+
+      const inconsistencies: string[] = [];
+      let inconsistencyCount = 0;
+
+      for (const item of finalDrillIds) {
+        const cardId = typeof item === 'string' ? item : item.cardId;
+        const addedAt = typeof item === 'object' && item.addedAt
+          ? new Date(item.addedAt).toISOString()
+          : 'unknown';
+
+        const card = await plugin.card.findOne(cardId);
+        if (!card) {
+          inconsistencies.push(`[MISSING_CARD] cardId=${cardId} addedAt=${addedAt}`);
+          inconsistencyCount++;
+          continue;
+        }
+
+        const history = card.repetitionHistory ?? [];
+        const meaningful = history.filter(r => r.score !== QueueInteractionScore.TOO_EARLY);
+
+        if (meaningful.length === 0) {
+          inconsistencies.push(
+            `[NO_HISTORY] cardId=${cardId} remId=${card.remId} — ${history.length === 0 ? 'no reps at all' : 'only TOO_EARLY reps'} (addedAt=${addedAt})`
+          );
+          inconsistencyCount++;
+          continue;
+        }
+
+        const last = meaningful[meaningful.length - 1];
+        const isExpected =
+          last.score === QueueInteractionScore.AGAIN ||
+          last.score === QueueInteractionScore.HARD;
+
+        if (!isExpected) {
+          const cramFlag = last.isCram ? ' [CRAM]' : '';
+          const everHard = meaningful.some(r => r.score === QueueInteractionScore.HARD);
+          const everAgain = meaningful.some(r => r.score === QueueInteractionScore.AGAIN);
+          const poorRatings = [everAgain ? 'AGAIN' : null, everHard ? 'HARD' : null].filter(Boolean).join('/');
+          const everPoorFlag = poorRatings ? ` everPoor=${poorRatings}` : ' everPoor=NEVER';
+          inconsistencies.push(
+            `[UNEXPECTED_SCORE] cardId=${cardId} remId=${card.remId} — last=${scoreName(last.score)}${cramFlag} ratedAt=${new Date(last.date).toISOString()} addedAt=${addedAt}${everPoorFlag}`
+          );
+          inconsistencyCount++;
+          history.forEach((rep, i) => {
+            const cram = rep.isCram ? ' [CRAM]' : '';
+            const scheduled = rep.scheduled ? ` scheduled=${new Date(rep.scheduled).toISOString()}` : '';
+            inconsistencies.push(
+              `      [${i + 1}/${history.length}] ${new Date(rep.date).toISOString()} ${scoreName(rep.score)}${cram}${scheduled}`
+            );
+          });
+        }
+      }
+
+      const scopeLabel = `KB=${isPrimary ? 'primary' : currentKbId} (${skippedOtherKb} items skipped from other KBs)`;
+      if (inconsistencyCount === 0) {
+        console.log(`[MasteryDrillAudit] ${scopeLabel} — all ${finalDrillIds.length} cards OK (last rating is AGAIN or HARD).`);
+        await plugin.app.toast(`All ${finalDrillIds.length} drill cards OK.`);
+      } else {
+        console.log(`[MasteryDrillAudit] ${scopeLabel} — ${inconsistencyCount} inconsistencies out of ${finalDrillIds.length} cards:`);
+        for (const msg of inconsistencies) {
+          console.log('  ' + msg);
+        }
+        await plugin.app.toast(`Found ${inconsistencyCount} inconsistent drill cards — check console.`);
+      }
+    },
+  });
+
+  plugin.app.registerCommand({
+    id: 'cleanup_mastery_drill',
+    name: 'Mastery Drill: Remove cards whose last rating was Good or Easy',
+    action: async () => {
+      type DrillItem = string | { cardId: string; kbId?: string; addedAt?: number };
+      const allDrillIds = ((await plugin.storage.getSynced('finalDrillIds')) as DrillItem[]) || [];
+
+      const currentKb = await plugin.kb.getCurrentKnowledgeBaseData();
+      const isPrimary = await plugin.kb.isPrimaryKnowledgeBase();
+      const currentKbId = currentKb?._id;
+      const getCardId = (item: DrillItem) => typeof item === 'string' ? item : item.cardId;
+      const isInCurrentKb = (item: DrillItem) =>
+        typeof item === 'string' ? isPrimary : item.kbId === currentKbId;
+
+      const toRemoveIds = new Set<string>();
+      let missingCount = 0;
+      let noHistoryCount = 0;
+
+      for (const item of allDrillIds) {
+        if (!isInCurrentKb(item)) continue;
+        const cardId = getCardId(item);
+        const card = await plugin.card.findOne(cardId);
+        if (!card) {
+          toRemoveIds.add(cardId);
+          missingCount++;
+          continue;
+        }
+        const history = card.repetitionHistory ?? [];
+        const meaningful = history.filter(r => r.score !== QueueInteractionScore.TOO_EARLY);
+        if (meaningful.length === 0) {
+          toRemoveIds.add(cardId);
+          noHistoryCount++;
+          continue;
+        }
+        const last = meaningful[meaningful.length - 1];
+        const isExpected =
+          last.score === QueueInteractionScore.AGAIN ||
+          last.score === QueueInteractionScore.HARD;
+        if (!isExpected) {
+          toRemoveIds.add(cardId);
+        }
+      }
+
+      if (toRemoveIds.size === 0) {
+        await plugin.app.toast('No cards to remove — the drill is already clean for this KB.');
+        return;
+      }
+
+      const kept = allDrillIds.filter(item => {
+        if (!isInCurrentKb(item)) return true;
+        return !toRemoveIds.has(getCardId(item));
+      });
+      await plugin.storage.setSynced('finalDrillIds', kept);
+
+      const unexpectedCount = toRemoveIds.size - missingCount - noHistoryCount;
+      console.log(
+        `[MasteryDrillCleanup] Removed ${toRemoveIds.size} cards from current KB ` +
+        `(missing=${missingCount}, noHistory=${noHistoryCount}, lastRatingWasGoodOrEasy=${unexpectedCount}). ` +
+        `${kept.length} items remain in finalDrillIds (across all KBs).`
+      );
+      await plugin.app.toast(`Removed ${toRemoveIds.size} cards from drill.`);
     },
   });
 }

--- a/src/register/commands.ts
+++ b/src/register/commands.ts
@@ -186,25 +186,72 @@ export async function registerCommands(plugin: ReactRNPlugin) {
       await initIncrementalRem(plugin, extractRem, { explicitParentId: rem._id });
       // 4. Locate and Modify
       const r_start = Math.min(selection.range.start, selection.range.end);
-      const r_end = Math.max(selection.range.start, selection.range.end);
 
-      const processRichText = (richText: RichTextInterface): RichTextInterface => {
+      const frontText = rem.text || [];
+      const backText  = rem.backText || [];
+
+      // Plain text extractor — non-text nodes (i:'q' pins etc.) contribute empty string.
+      // This gives us text-only positions that are immune to RemNote's reference node
+      // cursor-width (which counts i:'q' as 2 chars, not 1).
+      const rtPlainStr = (rt: RichTextInterface): string =>
+        rt.map((item: any) => typeof item === 'string' ? item : (item.i === 'm' ? (item.text || '') : '')).join('');
+
+      const frontStr = rtPlainStr(frontText);
+      const backStr  = rtPlainStr(backText);
+      const selStr   = rtPlainStr(selection.richText as RichTextInterface);
+      const selLen   = selStr.length;
+      const hasBackText = backText.length > 0;
+
+      // Detect which section contains the selection via string-matching (text-only positions).
+      // Prefer front; fall back to back; fall back to r_start heuristic.
+      let isBack = false;
+      let sect_r_start = 0;
+
+      const posInFront = frontStr.indexOf(selStr);
+      const posInBack  = hasBackText ? backStr.indexOf(selStr) : -1;
+
+      if (posInFront >= 0 && (posInBack < 0 || r_start < frontStr.length)) {
+        isBack = false;
+        sect_r_start = posInFront;
+      } else if (posInBack >= 0) {
+        isBack = true;
+        sect_r_start = posInBack;
+      } else {
+        // Last resort: use r_start directly (may still be slightly off for rems with pins)
+        isBack = false;
+        sect_r_start = r_start;
+      }
+
+      const sect_r_end = sect_r_start + selLen;
+
+      // Process rich text using text-only positions (non-text nodes have length 0 and pass
+      // through unchanged). This avoids any mismatch with RemNote's cursor model for pins.
+      const processRichText = (richText: RichTextInterface, localStart: number, localEnd: number): RichTextInterface => {
         const newArray: any[] = [];
         let currIdx = 0;
+        let pinInserted = false;
         for (const item of richText) {
           const isString = typeof item === 'string';
           const textNode = isString ? { i: 'm' as const, text: item } : (item as any);
-          const nodeLen = textNode.i === 'm' ? (textNode.text?.length || 0) : 1;
-          const nodeStart = currIdx;
-          const nodeEnd = currIdx + nodeLen;
+          const nodeLen = textNode.i === 'm' ? (textNode.text?.length || 0) : 0;
 
-          if (nodeEnd <= r_start || nodeStart >= r_end) {
+          if (nodeLen === 0) {
+            // Non-text node: insert the new pin here if the selection ends exactly at this point
+            if (!pinInserted && currIdx >= localEnd && localEnd > localStart) {
+              newArray.push({ i: 'q', _id: extractRem._id, pin: true });
+              pinInserted = true;
+            }
             newArray.push(item);
           } else {
-            if (textNode.i === 'm') {
-              const textStr = textNode.text || '';
-              const relStart = Math.max(0, r_start - nodeStart);
-              const relEnd = Math.min(nodeLen, r_end - nodeStart);
+            const nodeStart = currIdx;
+            const nodeEnd   = currIdx + nodeLen;
+
+            if (nodeEnd <= localStart || nodeStart >= localEnd) {
+              newArray.push(item);
+            } else {
+              const textStr  = textNode.text || '';
+              const relStart = Math.max(0, localStart - nodeStart);
+              const relEnd   = Math.min(nodeLen, localEnd - nodeStart);
 
               if (relStart > 0) {
                 newArray.push({ ...textNode, text: textStr.substring(0, relStart) });
@@ -214,50 +261,28 @@ export async function registerCommands(plugin: ReactRNPlugin) {
                 text: textStr.substring(relStart, relEnd),
                 [RICH_TEXT_FORMATTING.HIGHLIGHT]: 6, // RemColor.Blue = 6
               });
-
-              if (r_start < r_end && nodeStart < r_end && nodeEnd >= r_end) {
+              if (nodeEnd >= localEnd) {
                 newArray.push({ i: 'q', _id: extractRem._id, pin: true });
+                pinInserted = true;
               }
-
               if (relEnd < nodeLen) {
                 newArray.push({ ...textNode, text: textStr.substring(relEnd) });
               }
-            } else {
-              newArray.push({
-                ...textNode,
-                [RICH_TEXT_FORMATTING.HIGHLIGHT]: 6,
-              });
-
-              if (r_start < r_end && nodeStart < r_end && nodeEnd >= r_end) {
-                newArray.push({ i: 'q', _id: extractRem._id, pin: true });
-              }
             }
+            currIdx += nodeLen;
           }
-
-          currIdx += nodeLen;
         }
-        if (r_end > currIdx && r_start < currIdx) {
+        if (!pinInserted && localEnd <= currIdx && localStart < currIdx) {
           newArray.push({ i: 'q', _id: extractRem._id, pin: true });
         }
         return newArray;
       };
 
-      // Detect if selection is in front or back
-      let isBack = false;
-      const remText = rem.text || [];
-      const frontMiddle = await plugin.richText.substring(remText, r_start, r_end);
-      if (!(await plugin.richText.equals(selection.richText, frontMiddle))) {
-        const backMiddle = await plugin.richText.substring(rem.backText || [], r_start, r_end);
-        if (await plugin.richText.equals(selection.richText, backMiddle)) {
-          isBack = true;
-        }
-      }
-
       // 6. Save the Changes
       if (isBack) {
-        await rem.setBackText(processRichText(rem.backText || []));
+        await rem.setBackText(processRichText(backText, sect_r_start, sect_r_end));
       } else {
-        await rem.setText(processRichText(rem.text || []));
+        await rem.setText(processRichText(frontText, sect_r_start, sect_r_end));
       }
 
       return extractRem;

--- a/src/register/events.ts
+++ b/src/register/events.ts
@@ -492,10 +492,7 @@ export function registerQueueCompleteCardListener(plugin: ReactRNPlugin) {
         return;
       }
 
-      // console.log('🎴 CARD COMPLETED (Full Mode):', data);
-
       if (!data || !data.cardId) {
-        // console.error('LISTENER: Event fired but did not contain a cardId. Aborting.');
         return;
       }
 
@@ -665,13 +662,121 @@ export function registerGlobalRemChangedListener(plugin: ReactRNPlugin) {
     undefined,
     async (data) => {
       const isBatchActive = await plugin.storage.getSession<boolean>('plugin_operation_active');
-      if (isBatchActive) return;
+      if (isBatchActive) {
+        return;
+      }
 
       const existingTimer = remChangeDebounceTimers.get(data.remId);
       if (existingTimer) clearTimeout(existingTimer);
 
       const rem = await plugin.rem.findOne(data.remId);
       if (!rem) return;
+
+      // --- Cluster card drill detection ---
+      // QueueCompleteCard does not fire for cluster card ratings. GlobalRemChanged fires instead,
+      // but with the cluster PARENT rem's ID — not the individual child card rem IDs. The bridge
+      // is clusterVisibleCardId: card_priority_display writes the sibling's cardId there before
+      // the user can rate it, and GlobalRemChanged fires before QueueLoadCard clears it for the
+      // next card. So at the time this runs, clusterVisibleCardId == the sibling just rated.
+      //
+      // Coordination with QueueCompleteCard: for non-cluster cards, QueueCompleteCard fires first
+      // and adds the rem's ID to recentlyProcessedCards. GlobalRemChanged then fires for that same
+      // remId, hits the recentlyProcessedCards guard, and skips. For cluster cards, QueueCompleteCard
+      // never fires, so the parent remId is never in recentlyProcessedCards — we proceed.
+      {
+        const skipMasteryDrill = Boolean(await plugin.settings.getSetting('skip_mastery_drill'));
+        if (!skipMasteryDrill && !recentlyProcessedCards.has(data.remId)) {
+          // Claim this remId synchronously before the first await so concurrent GlobalRemChanged
+          // fires for the same cluster rating don't both pass this guard and double-write.
+          // We use a finally block (not a fixed TTL) to release the claim: the async work takes
+          // < 1 second, which is well under the ~2s between sibling transitions, so the next
+          // sibling's GlobalRemChanged will always find the set clear.
+          recentlyProcessedCards.add(data.remId);
+          try {
+            const clusterCardId = await plugin.storage.getSession<string>('clusterVisibleCardId');
+
+            if (clusterCardId) {
+              const card = await plugin.card.findOne(clusterCardId);
+              const history = card?.repetitionHistory;
+              const now = Date.now();
+              const FRESH_RATING_WINDOW_MS = 10_000;
+              const lastEntry = history && history.length > 0 ? history[history.length - 1] : undefined;
+
+              if (
+                lastEntry?.date &&
+                now - lastEntry.date <= FRESH_RATING_WINDOW_MS &&
+                lastEntry.score !== QueueInteractionScore.TOO_EARLY
+              ) {
+                const score = lastEntry.score;
+                const kbData = await plugin.kb.getCurrentKnowledgeBaseData();
+                const currentKbId = kbData?._id;
+
+                type FinalDrillItem = string | { cardId: string; kbId?: string; addedAt?: number };
+                let finalDrillIds =
+                  ((await plugin.storage.getSynced('finalDrillIds')) as FinalDrillItem[]) || [];
+                const getCardId = (item: FinalDrillItem) =>
+                  typeof item === 'string' ? item : item.cardId;
+
+                if (score === QueueInteractionScore.AGAIN || score === QueueInteractionScore.HARD) {
+                  if (!finalDrillIds.some((item) => getCardId(item) === clusterCardId)) {
+                    finalDrillIds = [
+                      ...finalDrillIds,
+                      { cardId: clusterCardId, kbId: currentKbId, addedAt: Date.now() },
+                    ];
+                    await plugin.storage.setSynced('finalDrillIds', finalDrillIds);
+                  }
+                } else if (score >= QueueInteractionScore.GOOD) {
+                  const filtered = finalDrillIds.filter((item) => getCardId(item) !== clusterCardId);
+                  if (filtered.length !== finalDrillIds.length) {
+                    await plugin.storage.setSynced('finalDrillIds', filtered);
+                  }
+                }
+
+                // Flashcard History: record cluster card rating (QueueCompleteCard doesn't fire for clusters)
+                try {
+                  const historyData =
+                    ((await plugin.storage.getSynced('flashcardHistoryData')) as FlashcardHistoryData[]) || [];
+                  if (historyData[0]?.cardId !== clusterCardId) {
+                    const clusterRem = card?.remId ? await plugin.rem.findOne(card.remId) : undefined;
+                    let frontText = '';
+                    let backText = '';
+                    try {
+                      const frontRaw = clusterRem?.text ? await safeRemTextToString(plugin, clusterRem.text) : '';
+                      const backRaw = clusterRem?.backText ? await safeRemTextToString(plugin, clusterRem.backText) : '';
+                      frontText = typeof frontRaw === 'string' && frontRaw !== 'Untitled' ? frontRaw.substring(0, 1000) : '';
+                      backText = typeof backRaw === 'string' && backRaw !== 'Untitled' ? backRaw.substring(0, 1000) : '';
+                    } catch (_e) {
+                      frontText = '[Complex Media Rem]';
+                    }
+                    const text = `${frontText} ${backText}`.trim();
+                    const deduped = historyData.filter((entry) => entry.cardId !== clusterCardId);
+                    await plugin.storage.setSynced('flashcardHistoryData', [
+                      {
+                        key: Math.random(),
+                        remId: card?.remId,
+                        cardId: clusterCardId,
+                        open: false,
+                        time: new Date().getTime(),
+                        kbId: currentKbId,
+                        text,
+                        _v: 1,
+                      },
+                      ...deduped.slice(0, 999),
+                    ]);
+                  }
+                } catch (error) {
+                  console.error('Failed to record flashcard history for cluster card:', error);
+                }
+              }
+            }
+          } catch (error) {
+            console.error('Failed to update Mastery Drill for cluster card:', error);
+          } finally {
+            recentlyProcessedCards.delete(data.remId);
+          }
+        }
+      }
+      // --- End cluster card drill detection ---
 
       // IMPORTANT: Capture history NOW, before debounce
       //
@@ -939,6 +1044,112 @@ export function registerGlobalOpenRemListener(plugin: ReactRNPlugin) {
   });
 }
 
+/**
+ * Handles Mastery Drill add/remove for cards that are presented inside the drill popup
+ * but whose ratings produce no QueueCompleteCard event (cluster cards) and whose
+ * clusterVisibleCardId signal is unavailable (card_priority_display is not mounted there).
+ *
+ * Strategy: on each QueueLoadCard (next card loaded → previous card was just rated) and on
+ * QueueExit (last card in drill), check the previous card's latest repetition history entry.
+ * If the entry's date is ≥ the time that card was loaded (i.e., it happened during this
+ * drill presentation), update finalDrillIds accordingly.
+ *
+ * Gated on finalDrillActive so this only runs inside the mastery drill, not the regular queue.
+ */
+function registerDrillCardRatingListener(plugin: ReactRNPlugin) {
+  let prevDrillCardId: string | undefined;
+  let prevDrillCardLoadTime: number | undefined;
+
+  const processPreviousCard = async () => {
+    if (!prevDrillCardId || !prevDrillCardLoadTime) return;
+
+    const isFinalDrillActive = await plugin.storage.getSession<boolean>('finalDrillActive');
+    if (!isFinalDrillActive) return;
+
+    const skipMasteryDrill = Boolean(await plugin.settings.getSetting('skip_mastery_drill'));
+    if (skipMasteryDrill) return;
+
+    const card = await plugin.card.findOne(prevDrillCardId);
+    const history = card?.repetitionHistory;
+    if (!history || history.length === 0) return;
+
+    const lastEntry = history[history.length - 1];
+    if (!lastEntry?.date || lastEntry.date < prevDrillCardLoadTime) return;
+    if (lastEntry.score === QueueInteractionScore.TOO_EARLY) return;
+
+    const score = lastEntry.score;
+    const cardId = prevDrillCardId;
+    const kbData = await plugin.kb.getCurrentKnowledgeBaseData();
+    const currentKbId = kbData?._id;
+
+    type FinalDrillItem = string | { cardId: string; kbId?: string; addedAt?: number };
+    let finalDrillIds =
+      ((await plugin.storage.getSynced('finalDrillIds')) as FinalDrillItem[]) || [];
+    const getCardId = (item: FinalDrillItem) =>
+      typeof item === 'string' ? item : item.cardId;
+
+    if (score === QueueInteractionScore.AGAIN || score === QueueInteractionScore.HARD) {
+      if (!finalDrillIds.some((item) => getCardId(item) === cardId)) {
+        finalDrillIds = [...finalDrillIds, { cardId, kbId: currentKbId, addedAt: Date.now() }];
+        await plugin.storage.setSynced('finalDrillIds', finalDrillIds);
+      }
+    } else if (score >= QueueInteractionScore.GOOD) {
+      const filtered = finalDrillIds.filter((item) => getCardId(item) !== cardId);
+      if (filtered.length !== finalDrillIds.length) {
+        await plugin.storage.setSynced('finalDrillIds', filtered);
+      }
+    }
+
+    // Flashcard History: record drill card rating (QueueCompleteCard doesn't fire in the drill popup)
+    try {
+      const historyData =
+        ((await plugin.storage.getSynced('flashcardHistoryData')) as FlashcardHistoryData[]) || [];
+      if (historyData[0]?.cardId !== cardId) {
+        const drillRem = card?.remId ? await plugin.rem.findOne(card.remId) : undefined;
+        let frontText = '';
+        let backText = '';
+        try {
+          const frontRaw = drillRem?.text ? await safeRemTextToString(plugin, drillRem.text) : '';
+          const backRaw = drillRem?.backText ? await safeRemTextToString(plugin, drillRem.backText) : '';
+          frontText = typeof frontRaw === 'string' && frontRaw !== 'Untitled' ? frontRaw.substring(0, 1000) : '';
+          backText = typeof backRaw === 'string' && backRaw !== 'Untitled' ? backRaw.substring(0, 1000) : '';
+        } catch (_e) {
+          frontText = '[Complex Media Rem]';
+        }
+        const text = `${frontText} ${backText}`.trim();
+        const deduped = historyData.filter((entry) => entry.cardId !== cardId);
+        await plugin.storage.setSynced('flashcardHistoryData', [
+          {
+            key: Math.random(),
+            remId: card?.remId,
+            cardId,
+            open: false,
+            time: new Date().getTime(),
+            kbId: currentKbId,
+            text,
+            _v: 1,
+          },
+          ...deduped.slice(0, 999),
+        ]);
+      }
+    } catch (error) {
+      console.error('Failed to record flashcard history for drill card:', error);
+    }
+  };
+
+  plugin.event.addListener(AppEvents.QueueLoadCard, undefined, async (data: any) => {
+    await processPreviousCard();
+    prevDrillCardId = data?.cardId;
+    prevDrillCardLoadTime = data?.cardId ? Date.now() : undefined;
+  });
+
+  plugin.event.addListener(AppEvents.QueueExit, undefined, async () => {
+    await processPreviousCard();
+    prevDrillCardId = undefined;
+    prevDrillCardLoadTime = undefined;
+  });
+}
+
 export function registerEventListeners(
   plugin: ReactRNPlugin,
   resetSessionItemCounter: ResetSessionItemCounter
@@ -950,4 +1161,5 @@ export function registerEventListeners(
   registerGlobalRemChangedListener(plugin);
   registerGlobalOpenRemListener(plugin);
   registerQueueSessionTracking(plugin);
+  registerDrillCardRatingListener(plugin);
 }

--- a/src/register/events.ts
+++ b/src/register/events.ts
@@ -538,9 +538,19 @@ export function registerQueueCompleteCardListener(plugin: ReactRNPlugin) {
         // its own QueueCompleteCard listener, and clear order across listeners is not
         // guaranteed. Staleness is instead prevented by queue_session.ts clearing it at the
         // start of each QueueLoadCard.
-        const clusterVisibleCardId =
+        //
+        // Guard: clusterVisibleCardId may be stale from a previously-rendered sibling when
+        // events fire across card transitions. Only trust it if it belongs to the same rem
+        // as data.cardId. Otherwise it's contamination from an unrelated card.
+        const rawClusterVisibleCardId =
           (await plugin.storage.getSession<string>('clusterVisibleCardId')) || undefined;
-        const effectiveCardId = clusterVisibleCardId || data.cardId;
+        let effectiveCardId = data.cardId;
+        if (rawClusterVisibleCardId && rawClusterVisibleCardId !== data.cardId) {
+          const clusterCard = await plugin.card.findOne(rawClusterVisibleCardId);
+          if (clusterCard?.remId === remId) {
+            effectiveCardId = rawClusterVisibleCardId;
+          }
+        }
 
         // Flashcard History: record the completed card for the sidebar widget.
         // Acts as fallback when card_priority_display fails to mount.

--- a/src/register/events.ts
+++ b/src/register/events.ts
@@ -683,7 +683,11 @@ export function registerGlobalRemChangedListener(plugin: ReactRNPlugin) {
       // and adds the rem's ID to recentlyProcessedCards. GlobalRemChanged then fires for that same
       // remId, hits the recentlyProcessedCards guard, and skips. For cluster cards, QueueCompleteCard
       // never fires, so the parent remId is never in recentlyProcessedCards — we proceed.
-      {
+      // Short-circuit: clusterVisibleCardId is only set during cluster card review.
+      // Reading it first lets every other GlobalRemChanged (the common case) skip the
+      // settings read and the recentlyProcessedCards bookkeeping below.
+      const clusterCardId = await plugin.storage.getSession<string>('clusterVisibleCardId');
+      if (clusterCardId) {
         const skipMasteryDrill = Boolean(await plugin.settings.getSetting('skip_mastery_drill'));
         if (!skipMasteryDrill && !recentlyProcessedCards.has(data.remId)) {
           // Claim this remId synchronously before the first await so concurrent GlobalRemChanged
@@ -693,80 +697,76 @@ export function registerGlobalRemChangedListener(plugin: ReactRNPlugin) {
           // sibling's GlobalRemChanged will always find the set clear.
           recentlyProcessedCards.add(data.remId);
           try {
-            const clusterCardId = await plugin.storage.getSession<string>('clusterVisibleCardId');
+            const card = await plugin.card.findOne(clusterCardId);
+            const history = card?.repetitionHistory;
+            const now = Date.now();
+            const FRESH_RATING_WINDOW_MS = 10_000;
+            const lastEntry = history && history.length > 0 ? history[history.length - 1] : undefined;
 
-            if (clusterCardId) {
-              const card = await plugin.card.findOne(clusterCardId);
-              const history = card?.repetitionHistory;
-              const now = Date.now();
-              const FRESH_RATING_WINDOW_MS = 10_000;
-              const lastEntry = history && history.length > 0 ? history[history.length - 1] : undefined;
+            if (
+              lastEntry?.date &&
+              now - lastEntry.date <= FRESH_RATING_WINDOW_MS &&
+              lastEntry.score !== QueueInteractionScore.TOO_EARLY
+            ) {
+              const score = lastEntry.score;
+              const kbData = await plugin.kb.getCurrentKnowledgeBaseData();
+              const currentKbId = kbData?._id;
 
-              if (
-                lastEntry?.date &&
-                now - lastEntry.date <= FRESH_RATING_WINDOW_MS &&
-                lastEntry.score !== QueueInteractionScore.TOO_EARLY
-              ) {
-                const score = lastEntry.score;
-                const kbData = await plugin.kb.getCurrentKnowledgeBaseData();
-                const currentKbId = kbData?._id;
+              type FinalDrillItem = string | { cardId: string; kbId?: string; addedAt?: number };
+              let finalDrillIds =
+                ((await plugin.storage.getSynced('finalDrillIds')) as FinalDrillItem[]) || [];
+              const getCardId = (item: FinalDrillItem) =>
+                typeof item === 'string' ? item : item.cardId;
 
-                type FinalDrillItem = string | { cardId: string; kbId?: string; addedAt?: number };
-                let finalDrillIds =
-                  ((await plugin.storage.getSynced('finalDrillIds')) as FinalDrillItem[]) || [];
-                const getCardId = (item: FinalDrillItem) =>
-                  typeof item === 'string' ? item : item.cardId;
-
-                if (score === QueueInteractionScore.AGAIN || score === QueueInteractionScore.HARD) {
-                  if (!finalDrillIds.some((item) => getCardId(item) === clusterCardId)) {
-                    finalDrillIds = [
-                      ...finalDrillIds,
-                      { cardId: clusterCardId, kbId: currentKbId, addedAt: Date.now() },
-                    ];
-                    await plugin.storage.setSynced('finalDrillIds', finalDrillIds);
-                  }
-                } else if (score >= QueueInteractionScore.GOOD) {
-                  const filtered = finalDrillIds.filter((item) => getCardId(item) !== clusterCardId);
-                  if (filtered.length !== finalDrillIds.length) {
-                    await plugin.storage.setSynced('finalDrillIds', filtered);
-                  }
+              if (score === QueueInteractionScore.AGAIN || score === QueueInteractionScore.HARD) {
+                if (!finalDrillIds.some((item) => getCardId(item) === clusterCardId)) {
+                  finalDrillIds = [
+                    ...finalDrillIds,
+                    { cardId: clusterCardId, kbId: currentKbId, addedAt: Date.now() },
+                  ];
+                  await plugin.storage.setSynced('finalDrillIds', finalDrillIds);
                 }
-
-                // Flashcard History: record cluster card rating (QueueCompleteCard doesn't fire for clusters)
-                try {
-                  const historyData =
-                    ((await plugin.storage.getSynced('flashcardHistoryData')) as FlashcardHistoryData[]) || [];
-                  if (historyData[0]?.cardId !== clusterCardId) {
-                    const clusterRem = card?.remId ? await plugin.rem.findOne(card.remId) : undefined;
-                    let frontText = '';
-                    let backText = '';
-                    try {
-                      const frontRaw = clusterRem?.text ? await safeRemTextToString(plugin, clusterRem.text) : '';
-                      const backRaw = clusterRem?.backText ? await safeRemTextToString(plugin, clusterRem.backText) : '';
-                      frontText = typeof frontRaw === 'string' && frontRaw !== 'Untitled' ? frontRaw.substring(0, 1000) : '';
-                      backText = typeof backRaw === 'string' && backRaw !== 'Untitled' ? backRaw.substring(0, 1000) : '';
-                    } catch (_e) {
-                      frontText = '[Complex Media Rem]';
-                    }
-                    const text = `${frontText} ${backText}`.trim();
-                    const deduped = historyData.filter((entry) => entry.cardId !== clusterCardId);
-                    await plugin.storage.setSynced('flashcardHistoryData', [
-                      {
-                        key: Math.random(),
-                        remId: card?.remId,
-                        cardId: clusterCardId,
-                        open: false,
-                        time: new Date().getTime(),
-                        kbId: currentKbId,
-                        text,
-                        _v: 1,
-                      },
-                      ...deduped.slice(0, 999),
-                    ]);
-                  }
-                } catch (error) {
-                  console.error('Failed to record flashcard history for cluster card:', error);
+              } else if (score >= QueueInteractionScore.GOOD) {
+                const filtered = finalDrillIds.filter((item) => getCardId(item) !== clusterCardId);
+                if (filtered.length !== finalDrillIds.length) {
+                  await plugin.storage.setSynced('finalDrillIds', filtered);
                 }
+              }
+
+              // Flashcard History: record cluster card rating (QueueCompleteCard doesn't fire for clusters)
+              try {
+                const historyData =
+                  ((await plugin.storage.getSynced('flashcardHistoryData')) as FlashcardHistoryData[]) || [];
+                if (historyData[0]?.cardId !== clusterCardId) {
+                  const clusterRem = card?.remId ? await plugin.rem.findOne(card.remId) : undefined;
+                  let frontText = '';
+                  let backText = '';
+                  try {
+                    const frontRaw = clusterRem?.text ? await safeRemTextToString(plugin, clusterRem.text) : '';
+                    const backRaw = clusterRem?.backText ? await safeRemTextToString(plugin, clusterRem.backText) : '';
+                    frontText = typeof frontRaw === 'string' && frontRaw !== 'Untitled' ? frontRaw.substring(0, 1000) : '';
+                    backText = typeof backRaw === 'string' && backRaw !== 'Untitled' ? backRaw.substring(0, 1000) : '';
+                  } catch (_e) {
+                    frontText = '[Complex Media Rem]';
+                  }
+                  const text = `${frontText} ${backText}`.trim();
+                  const deduped = historyData.filter((entry) => entry.cardId !== clusterCardId);
+                  await plugin.storage.setSynced('flashcardHistoryData', [
+                    {
+                      key: Math.random(),
+                      remId: card?.remId,
+                      cardId: clusterCardId,
+                      open: false,
+                      time: new Date().getTime(),
+                      kbId: currentKbId,
+                      text,
+                      _v: 1,
+                    },
+                    ...deduped.slice(0, 999),
+                  ]);
+                }
+              } catch (error) {
+                console.error('Failed to record flashcard history for cluster card:', error);
               }
             }
           } catch (error) {

--- a/src/widgets/card_priority_display.tsx
+++ b/src/widgets/card_priority_display.tsx
@@ -144,32 +144,23 @@ export function CardPriorityDisplay() {
   // Only `ctx.cardId` advances per sibling — and `plugin.queue.getCurrentCard()` is
   // stuck on the cluster's anchor card. So we poll the widget context for cardId,
   // then resolve the card to recover the sibling's real remId.
-  //
-  // We commit cardId + remId + the resolved Rem together in one state update so the
-  // widget's gating `if (!rem || ...)` doesn't flicker a hidden-frame between the
-  // cardId arriving and the rem arriving (that extra render was the perceived lag).
-  const [currentIds, setCurrentIds] = React.useState<{ remId?: string; cardId?: string; rem?: any }>({});
+  const [currentIds, setCurrentIds] = React.useState<{ remId?: string; cardId?: string }>({});
 
   React.useEffect(() => {
     let isMounted = true;
     // Track the last cardId we've already resolved so the interval skips redundant work.
     let lastAppliedCardId: string | undefined;
 
-    // Resolve cardId → card → rem in one await chain and push into state atomically.
-    // Kicking off rem.findOne in parallel with the state commit would require splitting
-    // state updates; keeping them sequential here trades ~1 IPC of latency for guaranteed
-    // single-render mount (avoids the blank-frame flicker).
+    // Resolve cardId → remId and push into state. One IPC (card.findOne) per transition.
     const applyCardId = async (cardId: string) => {
       if (!isMounted || cardId === lastAppliedCardId) return;
       lastAppliedCardId = cardId;
       const card = await plugin.card.findOne(cardId);
       if (!isMounted) return;
       const resolvedRemId = card?.remId;
-      const resolvedRem = resolvedRemId ? await plugin.rem.findOne(resolvedRemId) : null;
-      if (!isMounted) return;
       setCurrentIds((prev) => {
         if (prev.cardId === cardId && prev.remId === resolvedRemId) return prev;
-        return { remId: resolvedRemId, cardId, rem: resolvedRem ?? null };
+        return { remId: resolvedRemId, cardId };
       });
     };
 
@@ -241,9 +232,10 @@ export function CardPriorityDisplay() {
     })();
   }, [plugin, currentIds.cardId, currentIds.remId]);
 
-  // Use the Rem resolved alongside cardId in `applyCardId` — avoids the extra render
-  // cycle a separate tracker would introduce (gating returns null until rem resolves).
-  const rem = currentIds.rem ?? null;
+  const rem = useTrackerPlugin(async (rp) => {
+    if (!currentIds.remId) return null;
+    return (await rp.rem.findOne(currentIds.remId)) ?? null;
+  }, [currentIds.remId]);
 
   const scopeRemIds = useTrackerPlugin(
     (rp) => rp.storage.getSession<string[] | null>(priorityCalcScopeRemIdsKey),
@@ -440,7 +432,7 @@ export function CardPriorityDisplay() {
     return await getCardPriority(rp, rem);
   }, [useLightMode, rem, refreshSignal, cardInfo]);
 
-  const isIncRem = useTrackerPlugin(async (rp) => {
+  const isIncRem = useTrackerPlugin(async (_rp) => {
     if (!rem) return false;
     return await rem.hasPowerup(powerupCode);
   }, [rem]);

--- a/src/widgets/create_inc_rem_toolbar.tsx
+++ b/src/widgets/create_inc_rem_toolbar.tsx
@@ -1,7 +1,7 @@
 import { renderWidget, usePlugin, WidgetLocation } from '@remnote/plugin-sdk';
 import React, { useState } from 'react';
 import { createRemFromHighlight } from '../lib/highlightActions';
-import { powerupCode, incrementalQueueActiveKey, currentIncRemKey } from '../lib/consts';
+import { powerupCode, incrementalQueueActiveKey, currentIncRemKey, editorReviewTimerRemIdKey } from '../lib/consts';
 import {
   getPdfInfoFromHighlight,
   findPDFinRem,
@@ -41,6 +41,21 @@ export function CreateIncRemToolbar() {
         const foundPdf = currentQueueRem ? await findPDFinRem(plugin as any, currentQueueRem, docId) : null;
         if (foundPdf && foundPdf._id === docId) {
           contextRemId = currentQueueRemId;
+        }
+      }
+    }
+
+    // 2b. Editor Review Timer context: when the user is reviewing an IncRem in
+    // the editor, the URLChange listener has already cleared currentIncRemKey
+    // and incrementalQueueActiveKey, so the queue check above misses it.
+    // Confirm the timer's IncRem owns this PDF, same safety check as the queue.
+    if (!contextRemId && docId) {
+      const editorTimerRemId = await plugin.storage.getSession<string>(editorReviewTimerRemIdKey);
+      if (editorTimerRemId) {
+        const editorTimerRem = await plugin.rem.findOne(editorTimerRemId);
+        const foundPdf = editorTimerRem ? await findPDFinRem(plugin as any, editorTimerRem, docId) : null;
+        if (foundPdf && foundPdf._id === docId) {
+          contextRemId = editorTimerRemId;
         }
       }
     }

--- a/src/widgets/editor_review.tsx
+++ b/src/widgets/editor_review.tsx
@@ -209,15 +209,20 @@ const EditorReviewInput: React.FC<{ plugin: RNPlugin; remId: string }> = ({ plug
     await plugin.storage.setSession('editor-review-timer-rem-name', remName);
 
     await plugin.app.toast(`⏱️ Timer started for: ${remName}`);
-    await plugin.widget.closePopup();
 
     // Open the PDF (if any) and resume at the last bookmarked highlight.
     // Mirrors the priority_editor Scroll-to-Position behavior: scrollToReaderHighlight
     // is a no-op unless a PDF reader is mounted, so we explicitly open the PDF rem
     // first. For non-PDF rems, fall back to the original opening logic.
+    //
+    // IMPORTANT: closePopup() must come AFTER all SDK calls. Closing the popup
+    // tears down the widget sandbox, so any plugin.* call after that will time out.
     try {
       const rem = await plugin.rem.findOne(remId);
-      if (!rem) return;
+      if (!rem) {
+        await plugin.widget.closePopup();
+        return;
+      }
 
       const pdfRem = await findPDFinRem(plugin, rem);
       const incRemType = await determineIncRemType(plugin, rem);
@@ -255,6 +260,9 @@ const EditorReviewInput: React.FC<{ plugin: RNPlugin; remId: string }> = ({ plug
     } catch (e) {
       console.error('[EditorReview.handleStartTimer] Failed to open & scroll', e);
     }
+
+    // Close the popup LAST — after all SDK work is done.
+    await plugin.widget.closePopup();
   };
 
   return (

--- a/src/widgets/editor_review.tsx
+++ b/src/widgets/editor_review.tsx
@@ -226,13 +226,11 @@ const EditorReviewInput: React.FC<{ plugin: RNPlugin; remId: string }> = ({ plug
 
       const pdfRem = await findPDFinRem(plugin, rem);
       const incRemType = await determineIncRemType(plugin, rem);
-      console.log('[EditorReview.handleStartTimer] rem:', remId, 'pdfRem:', pdfRem?._id ?? null, 'incRemType:', incRemType);
 
       if (pdfRem) {
         // Mount the PDF reader in a NEW pane (right of the current layout) so
         // the IncRem the user was viewing in the editor stays visible.
         await openRemInNewPane(plugin, pdfRem._id);
-        console.log('[EditorReview.handleStartTimer] Opened PDF rem in new pane:', pdfRem._id);
       } else if (incRemType === 'pdf-note') {
         await rem.openRemAsPage();
       } else {
@@ -243,17 +241,15 @@ const EditorReviewInput: React.FC<{ plugin: RNPlugin; remId: string }> = ({ plug
         const history = await getPageHistory(plugin, remId, pdfRem._id);
         const lastEntry = history[history.length - 1];
         const bookmarkHighlightId = lastEntry?.highlightId;
-        console.log('[EditorReview.handleStartTimer] history length:', history.length, 'last highlightId:', bookmarkHighlightId ?? null);
         if (bookmarkHighlightId) {
           const bookmarkRem = await plugin.rem.findOne(bookmarkHighlightId);
           if (bookmarkRem && typeof bookmarkRem.scrollToReaderHighlight === 'function') {
             // Delay so the reader has time to mount before we ask it to scroll.
             setTimeout(() => {
               bookmarkRem.scrollToReaderHighlight();
-              console.log('[EditorReview.handleStartTimer] scrollToReaderHighlight called for', bookmarkHighlightId);
             }, 400);
           } else {
-            console.warn('[EditorReview.handleStartTimer] bookmark rem missing or has no scrollToReaderHighlight', bookmarkHighlightId);
+
           }
         }
       }

--- a/src/widgets/editor_review.tsx
+++ b/src/widgets/editor_review.tsx
@@ -16,6 +16,7 @@ import { findClosestIncrementalAncestor } from '../lib/priority_inheritance';
 import { safeRemTextToString, findPDFinRem, getIncrementalReadingPosition, addPageToHistory, getPageHistory, getIncrementalPageRange, clearIncrementalPDFData, PageRangeContext } from '../lib/pdfUtils';
 import { addToIncrementalHistory } from '../lib/history_utils';
 import { determineIncRemType } from '../lib/incRemHelpers';
+import { openRemInNewPane } from '../lib/remHelpers';
 import { PageControls } from '../components/reader/ui';
 import { usePdfPageControls } from '../components/reader/usePdfPageControls';
 
@@ -223,9 +224,10 @@ const EditorReviewInput: React.FC<{ plugin: RNPlugin; remId: string }> = ({ plug
       console.log('[EditorReview.handleStartTimer] rem:', remId, 'pdfRem:', pdfRem?._id ?? null, 'incRemType:', incRemType);
 
       if (pdfRem) {
-        // Mount the PDF reader by opening the PDF rem as a page.
-        await pdfRem.openRemAsPage();
-        console.log('[EditorReview.handleStartTimer] Opened PDF rem as page:', pdfRem._id);
+        // Mount the PDF reader in a NEW pane (right of the current layout) so
+        // the IncRem the user was viewing in the editor stays visible.
+        await openRemInNewPane(plugin, pdfRem._id);
+        console.log('[EditorReview.handleStartTimer] Opened PDF rem in new pane:', pdfRem._id);
       } else if (incRemType === 'pdf-note') {
         await rem.openRemAsPage();
       } else {

--- a/src/widgets/editor_review.tsx
+++ b/src/widgets/editor_review.tsx
@@ -13,8 +13,9 @@ import { powerupCode, prioritySlotCode, pageRangeWidgetId } from '../lib/consts'
 import { IncrementalRep } from '../lib/incremental_rem';
 import dayjs from 'dayjs';
 import { findClosestIncrementalAncestor } from '../lib/priority_inheritance';
-import { safeRemTextToString, findPDFinRem, getIncrementalReadingPosition, addPageToHistory, getIncrementalPageRange, clearIncrementalPDFData, PageRangeContext } from '../lib/pdfUtils';
+import { safeRemTextToString, findPDFinRem, getIncrementalReadingPosition, addPageToHistory, getPageHistory, getIncrementalPageRange, clearIncrementalPDFData, PageRangeContext } from '../lib/pdfUtils';
 import { addToIncrementalHistory } from '../lib/history_utils';
+import { determineIncRemType } from '../lib/incRemHelpers';
 import { PageControls } from '../components/reader/ui';
 import { usePdfPageControls } from '../components/reader/usePdfPageControls';
 
@@ -208,6 +209,50 @@ const EditorReviewInput: React.FC<{ plugin: RNPlugin; remId: string }> = ({ plug
 
     await plugin.app.toast(`⏱️ Timer started for: ${remName}`);
     await plugin.widget.closePopup();
+
+    // Open the PDF (if any) and resume at the last bookmarked highlight.
+    // Mirrors the priority_editor Scroll-to-Position behavior: scrollToReaderHighlight
+    // is a no-op unless a PDF reader is mounted, so we explicitly open the PDF rem
+    // first. For non-PDF rems, fall back to the original opening logic.
+    try {
+      const rem = await plugin.rem.findOne(remId);
+      if (!rem) return;
+
+      const pdfRem = await findPDFinRem(plugin, rem);
+      const incRemType = await determineIncRemType(plugin, rem);
+      console.log('[EditorReview.handleStartTimer] rem:', remId, 'pdfRem:', pdfRem?._id ?? null, 'incRemType:', incRemType);
+
+      if (pdfRem) {
+        // Mount the PDF reader by opening the PDF rem as a page.
+        await pdfRem.openRemAsPage();
+        console.log('[EditorReview.handleStartTimer] Opened PDF rem as page:', pdfRem._id);
+      } else if (incRemType === 'pdf-note') {
+        await rem.openRemAsPage();
+      } else {
+        await plugin.window.openRem(rem);
+      }
+
+      if (pdfRem) {
+        const history = await getPageHistory(plugin, remId, pdfRem._id);
+        const lastEntry = history[history.length - 1];
+        const bookmarkHighlightId = lastEntry?.highlightId;
+        console.log('[EditorReview.handleStartTimer] history length:', history.length, 'last highlightId:', bookmarkHighlightId ?? null);
+        if (bookmarkHighlightId) {
+          const bookmarkRem = await plugin.rem.findOne(bookmarkHighlightId);
+          if (bookmarkRem && typeof bookmarkRem.scrollToReaderHighlight === 'function') {
+            // Delay so the reader has time to mount before we ask it to scroll.
+            setTimeout(() => {
+              bookmarkRem.scrollToReaderHighlight();
+              console.log('[EditorReview.handleStartTimer] scrollToReaderHighlight called for', bookmarkHighlightId);
+            }, 400);
+          } else {
+            console.warn('[EditorReview.handleStartTimer] bookmark rem missing or has no scrollToReaderHighlight', bookmarkHighlightId);
+          }
+        }
+      }
+    } catch (e) {
+      console.error('[EditorReview.handleStartTimer] Failed to open & scroll', e);
+    }
   };
 
   return (

--- a/src/widgets/editor_review_timer.tsx
+++ b/src/widgets/editor_review_timer.tsx
@@ -540,7 +540,6 @@ function EditorReviewTimer() {
                 if (bookmarkRem && typeof bookmarkRem.scrollToReaderHighlight === 'function') {
                   setTimeout(() => {
                     bookmarkRem.scrollToReaderHighlight();
-                    console.log('[EditorReviewTimer] scrollToReaderHighlight called for', bookmarkHighlightId);
                   }, 400);
                 }
               }}

--- a/src/widgets/editor_review_timer.tsx
+++ b/src/widgets/editor_review_timer.tsx
@@ -13,7 +13,8 @@ import { handleCardPriorityInheritance } from '../lib/card_priority/card_priorit
 import { addToIncrementalHistory } from '../lib/history_utils';
 import { IncrementalRep } from '../lib/incremental_rem';
 import { determineIncRemType } from '../lib/incRemHelpers';
-import { findPDFinRem, clearIncrementalPDFData, PageRangeContext, addPageToHistory, safeRemTextToString } from '../lib/pdfUtils';
+import { findPDFinRem, clearIncrementalPDFData, PageRangeContext, addPageToHistory, getPageHistory, safeRemTextToString } from '../lib/pdfUtils';
+import { openRemInNewPane } from '../lib/remHelpers';
 import { PageControls } from '../components/reader/ui';
 import { usePdfPageControls } from '../components/reader/usePdfPageControls';
 import dayjs from 'dayjs';
@@ -26,6 +27,7 @@ function EditorReviewTimer() {
   const [currentTime, setCurrentTime] = useState(Date.now());
   const [pdfRemId, setPdfRemId] = useState<string | null>(null);
   const [isPdfNote, setIsPdfNote] = useState(false);
+  const [bookmarkHighlightId, setBookmarkHighlightId] = useState<string | null>(null);
 
   const timerData = useTrackerPlugin(
     async (rp) => {
@@ -81,8 +83,14 @@ function EditorReviewTimer() {
       if (pdfRem) {
         setIsPdfNote(true);
         setPdfRemId(pdfRem._id);
+
+        // Check for a bookmark highlight in the last history entry
+        const history = await getPageHistory(plugin, timerData.remId, pdfRem._id);
+        const lastEntry = history[history.length - 1];
+        setBookmarkHighlightId(lastEntry?.highlightId ?? null);
       } else {
         setIsPdfNote(false);
+        setBookmarkHighlightId(null);
       }
     };
     loadPdfData();
@@ -517,12 +525,49 @@ function EditorReviewTimer() {
       </div>
 
       {isPdfNote && pdfRemId && (
-        <div style={{ marginRight: '8px', paddingRight: '12px', borderRight: '1px solid #93c5fd' }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '8px', marginRight: '8px', paddingRight: '12px', borderRight: '1px solid #93c5fd' }}>
           <PageControls
             incrementalRemId={timerData.remId as any}
             {...pdfControls}
             totalPages={0}
           />
+          {bookmarkHighlightId && (
+            <button
+              onClick={async () => {
+                // Open the PDF in a new pane (or focus existing) and scroll to bookmark
+                await openRemInNewPane(plugin, pdfRemId);
+                const bookmarkRem = await plugin.rem.findOne(bookmarkHighlightId);
+                if (bookmarkRem && typeof bookmarkRem.scrollToReaderHighlight === 'function') {
+                  setTimeout(() => {
+                    bookmarkRem.scrollToReaderHighlight();
+                    console.log('[EditorReviewTimer] scrollToReaderHighlight called for', bookmarkHighlightId);
+                  }, 400);
+                }
+              }}
+              style={{
+                padding: '4px 10px',
+                fontSize: '12px',
+                fontWeight: 600,
+                backgroundColor: 'transparent',
+                color: '#3b82f6',
+                border: '2px solid #3b82f6',
+                borderRadius: '4px',
+                cursor: 'pointer',
+                whiteSpace: 'nowrap',
+              }}
+              onMouseEnter={(e) => {
+                e.currentTarget.style.backgroundColor = '#3b82f6';
+                e.currentTarget.style.color = 'white';
+              }}
+              onMouseLeave={(e) => {
+                e.currentTarget.style.backgroundColor = 'transparent';
+                e.currentTarget.style.color = '#3b82f6';
+              }}
+              title="Open PDF and scroll to your last bookmark position"
+            >
+              🔖 Scroll
+            </button>
+          )}
         </div>
       )}
 

--- a/src/widgets/index.tsx
+++ b/src/widgets/index.tsx
@@ -15,7 +15,7 @@ import { registerCommands } from '../register/commands';
 import { registerCallbacks, resetSessionItemCounter } from '../register/callbacks';
 import { registerIncrementalRemTracker } from '../register/tracker';
 import { registerJumpToRemHelper } from '../register/window';
-import { registerPluginHidingCSS, registerPdfHighlightCSS } from '../lib/ui_helpers';
+import { registerPluginHidingCSS, registerPdfHighlightCSS, registerClozeExtractCSS } from '../lib/ui_helpers';
 
 async function onActivate(plugin: ReactRNPlugin) {
   //Debug
@@ -42,6 +42,7 @@ async function onActivate(plugin: ReactRNPlugin) {
   // Register CSS rules
   await registerPdfHighlightCSS(plugin);
   await registerPluginHidingCSS(plugin);
+  await registerClozeExtractCSS(plugin);
 
   await registerCommands(plugin);
   await registerMenus(plugin);

--- a/src/widgets/pdf_bookmark_popup.tsx
+++ b/src/widgets/pdf_bookmark_popup.tsx
@@ -1,7 +1,7 @@
 import { renderWidget, usePlugin, WidgetLocation, ReactRNPlugin } from '@remnote/plugin-sdk';
 import React, { useState, useEffect } from 'react';
-import { getPdfInfoFromHighlight, findAllRemsForPDF, addPageToHistory, getPageHistory, PageHistoryEntry, PageRangeContext, setIncrementalReadingPosition, getIncrementalPageRange, safeRemTextToString } from '../lib/pdfUtils';
-import { incrementalQueueActiveKey, currentIncRemKey } from '../lib/consts';
+import { getPdfInfoFromHighlight, findAllRemsForPDF, findPDFinRem, addPageToHistory, getPageHistory, PageHistoryEntry, PageRangeContext, setIncrementalReadingPosition, getIncrementalPageRange, safeRemTextToString } from '../lib/pdfUtils';
+import { incrementalQueueActiveKey, currentIncRemKey, editorReviewTimerRemIdKey } from '../lib/consts';
 
 export function PdfBookmarkPopup() {
   const plugin = usePlugin() as ReactRNPlugin;
@@ -11,6 +11,9 @@ export function PdfBookmarkPopup() {
 
   const [activeQueueContext, setActiveQueueContext] = useState<PageRangeContext | null>(null);
   const [activeQueueRemName, setActiveQueueRemName] = useState<string>('');
+  // Whether the active context came from the queue or the editor-review timer.
+  // The fast-path UI is identical; only the labels change.
+  const [activeContextSource, setActiveContextSource] = useState<'queue' | 'editor-timer'>('queue');
   const [associatedRems, setAssociatedRems] = useState<any[]>([]);
   const [historicalBookmarks, setHistoricalBookmarks] = useState<{ remId: string, name: string, history: PageHistoryEntry[] }[]>([]);
 
@@ -63,36 +66,57 @@ export function PdfBookmarkPopup() {
           // on every queue turn.
           const isQueueActive = await plugin.storage.getSession<boolean>(incrementalQueueActiveKey);
           const currentIncRem = await plugin.storage.getSession<string>(currentIncRemKey);
-          const currentQueueRemId = (isQueueActive || currentIncRem) ? currentIncRem : undefined;
+          let activeRemId: string | undefined = (isQueueActive || currentIncRem) ? currentIncRem : undefined;
+          let activeSource: 'queue' | 'editor-timer' = 'queue';
 
-          if (currentQueueRemId) {
-            // ⚡ FAST PATH: We know the IncRem from the queue session.
-            // Skip findAllRemsForPDF entirely — it is not needed and is expensive.
-            const currentQueueRem = await plugin.rem.findOne(currentQueueRemId);
+          // Editor-Review-Timer fallback: when reviewing in the editor, the
+          // URLChange listener clears currentIncRemKey/incrementalQueueActiveKey,
+          // so the queue check above misses it. Confirm the timer's rem owns
+          // this PDF before trusting it (same safety check as create_inc_rem_toolbar).
+          if (!activeRemId) {
+            const editorTimerRemId = await plugin.storage.getSession<string>(editorReviewTimerRemIdKey);
+            if (editorTimerRemId) {
+              const editorTimerRem = await plugin.rem.findOne(editorTimerRemId);
+              const foundPdf = editorTimerRem ? await findPDFinRem(plugin, editorTimerRem, docId) : null;
+              if (foundPdf && foundPdf._id === docId) {
+                activeRemId = editorTimerRemId;
+                activeSource = 'editor-timer';
+              }
+            }
+          }
+
+          console.log('[PdfBookmarkPopup] context detection',
+            { docId, isQueueActive, currentIncRem, activeRemId, activeSource });
+
+          if (activeRemId) {
+            // ⚡ FAST PATH: We know the IncRem from the active session (queue
+            // or editor-review timer). Skip findAllRemsForPDF entirely.
+            const activeRem = await plugin.rem.findOne(activeRemId);
             let remName = '';
-            if (currentQueueRem?.text) {
-              remName = await safeRemTextToString(plugin, currentQueueRem.text);
+            if (activeRem?.text) {
+              remName = await safeRemTextToString(plugin, activeRem.text);
               setActiveQueueRemName(remName);
             }
+            setActiveContextSource(activeSource);
             setActiveQueueContext({
-              incrementalRemId: currentQueueRemId as any,
+              incrementalRemId: activeRemId as any,
               pdfRemId: docId as any,
               totalPages: 0,
               currentPage: 1
             });
 
             // Only fetch reading history for this specific rem (1 call, not N)
-            const history = await getPageHistory(plugin, currentQueueRemId, docId);
+            const history = await getPageHistory(plugin, activeRemId, docId);
             // Most recent first
             const withHighlights = history
               .filter(h => h.highlightId)
               .sort((a, b) => b.timestamp - a.timestamp);
             if (withHighlights.length > 0) {
-              setHistoricalBookmarks([{ remId: currentQueueRemId, name: remName, history: withHighlights }]);
+              setHistoricalBookmarks([{ remId: activeRemId, name: remName, history: withHighlights }]);
               // Resolve highlight rem texts for display
               resolveHighlightTexts(withHighlights).then(setHighlightTexts);
             }
-            // associatedRems stays [] — not rendered in queue mode anyway
+            // associatedRems stays [] — not rendered in fast-path mode anyway
 
           } else {
             // 🐌 FULL PATH (non-queue): find all IncRems that read this PDF
@@ -172,6 +196,8 @@ export function PdfBookmarkPopup() {
 
   const saveBookmark = async (incrementalRemId: string) => {
     if (!pdfRemId || pageIndex === null || !highlightRemId) return;
+    console.log('[PdfBookmarkPopup] saveBookmark',
+      { incrementalRemId, pdfRemId, pageIndex, highlightRemId });
     try {
       await addPageToHistory(plugin, incrementalRemId, pdfRemId, pageIndex, undefined, highlightRemId);
       await setIncrementalReadingPosition(plugin, incrementalRemId, pdfRemId, pageIndex);
@@ -221,7 +247,9 @@ export function PdfBookmarkPopup() {
             }}
             onClick={async () => { await saveBookmark(activeQueueContext.incrementalRemId); plugin.widget.closePopup(); }}
           >
-            Update Current Queue Reading
+            {activeContextSource === 'editor-timer'
+              ? 'Update Current Editor Review Reading'
+              : 'Update Current Queue Reading'}
           </button>
           {activeQueueRemName && (
              <div style={{ textAlign: 'center', fontSize: '11px', color: 'var(--rn-clr-content-tertiary)', marginTop: '6px', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
@@ -297,7 +325,9 @@ export function PdfBookmarkPopup() {
                 {activeHistoryItems.length > 0 && (
                   <div style={{ marginBottom: otherHistoryItems.length > 0 ? '16px' : '0' }}>
                     <div style={{ fontSize: '13px', fontWeight: 600, color: 'var(--rn-clr-content-primary)', marginBottom: '8px' }}>
-                      {activeId ? "Queue Reading Bookmarks:" : "Your Saved Bookmarks:"}
+                      {activeId
+                        ? (activeContextSource === 'editor-timer' ? 'Editor Review Bookmarks:' : 'Queue Reading Bookmarks:')
+                        : 'Your Saved Bookmarks:'}
                     </div>
                     {activeHistoryItems.map(h => (
                       <div key={h.remId} style={{ marginBottom: '8px' }}>

--- a/src/widgets/pdf_bookmark_popup.tsx
+++ b/src/widgets/pdf_bookmark_popup.tsx
@@ -85,8 +85,6 @@ export function PdfBookmarkPopup() {
             }
           }
 
-          console.log('[PdfBookmarkPopup] context detection',
-            { docId, isQueueActive, currentIncRem, activeRemId, activeSource });
 
           if (activeRemId) {
             // ⚡ FAST PATH: We know the IncRem from the active session (queue
@@ -196,8 +194,6 @@ export function PdfBookmarkPopup() {
 
   const saveBookmark = async (incrementalRemId: string) => {
     if (!pdfRemId || pageIndex === null || !highlightRemId) return;
-    console.log('[PdfBookmarkPopup] saveBookmark',
-      { incrementalRemId, pdfRemId, pageIndex, highlightRemId });
     try {
       await addPageToHistory(plugin, incrementalRemId, pdfRemId, pageIndex, undefined, highlightRemId);
       await setIncrementalReadingPosition(plugin, incrementalRemId, pdfRemId, pageIndex);

--- a/src/widgets/priority_editor.tsx
+++ b/src/widgets/priority_editor.tsx
@@ -24,6 +24,7 @@ import {
   safeRemTextToString,
   PageHistoryEntry,
 } from '../lib/pdfUtils';
+import { openRemInNewPane } from '../lib/remHelpers';
 
 // Move styles outside component to avoid recreation on every render
 const adjustButtonStyle: React.CSSProperties = {
@@ -613,14 +614,12 @@ export function PriorityEditor() {
                       if (!bookmarkRem) return;
 
                       // scrollToReaderHighlight is a no-op unless a PDF reader is
-                      // already mounted. Open the PDF rem first so the reader exists,
-                      // then scroll once it has had a moment to mount.
+                      // already mounted. Open the PDF rem in a NEW pane (to the
+                      // right) so the reader exists without closing the IncRem
+                      // view the user was looking at. Then scroll once mounted.
                       if (remData.pdfRemId) {
-                        const pdfRem = await plugin.rem.findOne(remData.pdfRemId);
-                        if (pdfRem) {
-                          await pdfRem.openRemAsPage();
-                          console.log('[PriorityEditor] Opened PDF rem as page:', remData.pdfRemId);
-                        }
+                        await openRemInNewPane(plugin, remData.pdfRemId);
+                        console.log('[PriorityEditor] Opened PDF rem in new pane:', remData.pdfRemId);
                       }
 
                       setTimeout(() => {

--- a/src/widgets/priority_editor.tsx
+++ b/src/widgets/priority_editor.tsx
@@ -97,6 +97,8 @@ export function PriorityEditor() {
         pdfRange = range;
         pdfHistory = history;
         pdfStats = stats;
+        console.log('[PriorityEditor] Fetched pdfHistory',
+          { incRemId: rem._id, pdfRemId: pdfRem._id, historyLength: history.length, lastEntry: history[history.length - 1] });
       }
 
       // Calculate relative priorities inline
@@ -591,6 +593,53 @@ export function PriorityEditor() {
                   )}
                 </div>
               )}
+
+              {/* Scroll to Bookmark — only when the LAST history entry carries a highlightId.
+                  A manual position recorded after a highlight bookmark would otherwise
+                  jump to a stale highlight, so we suppress the button in that case. */}
+              {(() => {
+                const history = remData.pdfHistory ?? [];
+                const lastEntry = history[history.length - 1];
+                const bookmarkHighlightId = lastEntry?.highlightId;
+                console.log('[PriorityEditor] pdfHistory check',
+                  { remId, pdfRemId: remData.pdfRemId, historyLength: history.length, lastEntry, bookmarkHighlightId });
+                if (!bookmarkHighlightId) return null;
+                return (
+                  <button
+                    onClick={async () => {
+                      const bookmarkRem = await plugin.rem.findOne(bookmarkHighlightId);
+                      console.log('[PriorityEditor] Scroll click → bookmarkRem:', bookmarkRem?._id,
+                        'has scrollToReaderHighlight:', typeof bookmarkRem?.scrollToReaderHighlight === 'function');
+                      if (!bookmarkRem) return;
+
+                      // scrollToReaderHighlight is a no-op unless a PDF reader is
+                      // already mounted. Open the PDF rem first so the reader exists,
+                      // then scroll once it has had a moment to mount.
+                      if (remData.pdfRemId) {
+                        const pdfRem = await plugin.rem.findOne(remData.pdfRemId);
+                        if (pdfRem) {
+                          await pdfRem.openRemAsPage();
+                          console.log('[PriorityEditor] Opened PDF rem as page:', remData.pdfRemId);
+                        }
+                      }
+
+                      setTimeout(() => {
+                        bookmarkRem.scrollToReaderHighlight();
+                        console.log('[PriorityEditor] scrollToReaderHighlight called for', bookmarkHighlightId);
+                      }, 400);
+                    }}
+                    className="w-full mt-2 py-1 rounded text-[11px] font-semibold transition-colors"
+                    style={{
+                      backgroundColor: 'var(--rn-clr-background-secondary)',
+                      color: 'var(--rn-clr-blue, #3b82f6)',
+                      border: '2px solid var(--rn-clr-blue, #3b82f6)',
+                    }}
+                    title="Scroll to Bookmark: Open the PDF and jump to your last saved reading position"
+                  >
+                    🔖 Scroll to Position
+                  </button>
+                );
+              })()}
 
               {/* Full panel link */}
               <button

--- a/src/widgets/priority_editor.tsx
+++ b/src/widgets/priority_editor.tsx
@@ -602,15 +602,11 @@ export function PriorityEditor() {
                 const history = remData.pdfHistory ?? [];
                 const lastEntry = history[history.length - 1];
                 const bookmarkHighlightId = lastEntry?.highlightId;
-                console.log('[PriorityEditor] pdfHistory check',
-                  { remId, pdfRemId: remData.pdfRemId, historyLength: history.length, lastEntry, bookmarkHighlightId });
                 if (!bookmarkHighlightId) return null;
                 return (
                   <button
                     onClick={async () => {
                       const bookmarkRem = await plugin.rem.findOne(bookmarkHighlightId);
-                      console.log('[PriorityEditor] Scroll click → bookmarkRem:', bookmarkRem?._id,
-                        'has scrollToReaderHighlight:', typeof bookmarkRem?.scrollToReaderHighlight === 'function');
                       if (!bookmarkRem) return;
 
                       // scrollToReaderHighlight is a no-op unless a PDF reader is
@@ -619,12 +615,10 @@ export function PriorityEditor() {
                       // view the user was looking at. Then scroll once mounted.
                       if (remData.pdfRemId) {
                         await openRemInNewPane(plugin, remData.pdfRemId);
-                        console.log('[PriorityEditor] Opened PDF rem in new pane:', remData.pdfRemId);
                       }
 
                       setTimeout(() => {
                         bookmarkRem.scrollToReaderHighlight();
-                        console.log('[PriorityEditor] scrollToReaderHighlight called for', bookmarkHighlightId);
                       }, 400);
                     }}
                     className="w-full mt-2 py-1 rounded text-[11px] font-semibold transition-colors"


### PR DESCRIPTION
## v0.2.188 - April 27th, 2026

### Summary: PDF split-pane scrolling in the Editor 📄

When reading a PDF incrementally in the **Editor** (not the queue), you can now jump straight to your last saved bookmark without losing your place:

- **Priority Editor** → click **🔖 Scroll to Position** — the PDF opens in a **new pane to the right** while your IncRem stays on the left
- **Editor Review popup** → click **⏱️ Start Timer** — same behavior: PDF splits to the right, timer starts
- **Review Timer bar** → a new **🔖 Scroll** button appears whenever your current IncRem has a saved bookmark highlight — one click to open the PDF and jump to it

Also: the **🔖 Bookmark popup** now correctly identifies your active IncRem when you're reviewing in the Editor (not just in the Queue), so "Update Current Reading" and the bookmarks history work in that context too.

### ✨ Scroll to Bookmark (in Editor): PDF Opens in a Split Pane

The **🔖 Scroll to Position** button in the **Priority Editor** sidebar and the **⏱️ Start Timer** button in the **Editor Review** popup now open the PDF in a **new pane to the right**, while the Incremental Rem you were reading stays visible on the left.

![Scroll to Position from Priority Editor — PDF opens in split pane](./assets/scroll-review-in-editor.gif)

* **New helper — `openRemInNewPane`** (`src/lib/remHelpers.ts`): Uses the SDK's window-tree API (`getCurrentWindowTree` → strip pane IDs → wrap as `{direction:'row', first: existing, second: newRemId}` → `setRemWindowTree`). A smart fast-path detects when the PDF is already open in some pane and calls `setFocusedPaneId` instead of splitting again — so repeated clicks don't stack duplicate panes.
* **Editor Review fix**: The `closePopup()` call was previously executed **before** the `openRemInNewPane` SDK call, which tore down the widget sandbox and caused all subsequent SDK operations to time out (`"operation has timed out"`). The popup is now closed **after** all SDK work completes.
* **🔖 Scroll button on the Editor Review Timer**: The timer toolbar now shows a **🔖 Scroll** button (next to the page controls) when the current IncRem has a saved bookmark highlight. Clicking it opens the PDF in a split pane and jumps to the bookmarked position — identical behavior to the Priority Editor's button.

![Scroll button on the Editor Review Timer toolbar](./assets/scroll-from-editor-toolbar.gif)

### ✨ Improved: PDF Bookmark Popup & Create IncRem Toolbar — Editor-Review-Timer Context

The **🔖 Bookmark Popup** and the **Create IncRem Toolbar** (funnel icon in the PDF highlight menu) now recognize the **Editor-Review Timer** as an active reading context, not just the queue.

* **Previously**, both widgets only checked `currentIncRemKey` / `incrementalQueueActiveKey` to detect the active IncRem. When reviewing in the editor (via the timer), the URL-change listener clears those keys, so the widgets fell through to the slow full-KB search path or failed to identify the active IncRem entirely.
* **Now**, when no queue context is found, both widgets check `editorReviewTimerRemIdKey` as a fallback. The timer's rem is validated by confirming it owns the current PDF (`findPDFinRem` with target doc ID match) before trusting it — the same safety pattern used by the queue path.
* **UI labels adapt**: The Bookmark Popup's action button shows "Update Current Editor Review Reading" (instead of "Update Current Queue Reading") and the history section header shows "Editor Review Bookmarks:" when the context came from the timer.

---

## v0.2.187 - April 26th, 2026

### 🐛 Bug Fix: UI lag and freezes when editing rems

Editing a single rem with a flashcard could cause RemNote to lock up for several seconds. The previous patch (`v0.2.186`) added a `lastUpdated > 0` clause to `autoAssignCardPriority`'s skip-write guards in an attempt to fix the **Card Priority widget not mounting** for newly cached cards. The clause was unnecessary — the widget already falls back to `getCardPriority()` for untagged rems via `lightCardInfo`, and the deferred batch pushes them into the cache by `remId` regardless of tag status. The real fix for the widget-mount issue was the separate `cardPriorityCacheRefreshKey` bump in `processDeferredCardPriorityCache`, which has been kept.

**The side effect:** the new clause forced `autoAssignCardPriority` to write a CardPriority powerup tag on every untagged rem with cards that fired `GlobalRemChanged`. Each write (`addPowerup` + 3 parallel `setPowerupProperty` calls) re-fired `GlobalRemChanged`, fanning out to ancestors and the cache rebuild. A single flashcard creation generated ~50 events across ~10 rems, blocking RemNote's main thread for seconds.

**The fix:** the `lastUpdated > 0` clauses in `autoAssignCardPriority` (`src/lib/card_priority/index.ts`) are reverted, restoring the original skip-on-match behavior. The `cardPriorityCacheRefreshKey` fix in `cache.ts` is preserved.

**Also in this release:** the cluster-card detection block in the `GlobalRemChanged` listener now short-circuits on `clusterVisibleCardId` first. When no cluster review is in progress (the common case), the listener skips both the `skip_mastery_drill` settings read and the `recentlyProcessedCards` bookkeeping — one fewer await per raw event.

---

## v0.2.186 - April 23rd, 2026

### 🐛 Bug Fix: Mastery Drill & Flashcard History — Card Cluster ratings not tracked

Cards belonging to a **Card Cluster** (a parent rem with the Cluster powerup, whose children are distinct flashcard rems) were never added to or removed from the Mastery Drill, and never appeared in the Flashcard History sidebar, regardless of how they were rated.

#### Why clusters are fundamentally different from normal cards

A Card Cluster is a **parent rem** tagged with the Cluster powerup. Each **child rem** under it is an independent flashcard with its own `remId` and `cardId`. This is different from a single rem that happens to have forward, backward, and cloze card types — those all share one `remId`.

When the queue displays a cluster, RemNote calls `QueueLoadCard` **once**, with the anchor child's `cardId` (this anchor being the first flashcard of the cluster). As the user navigates through subsequent siblings, `QueueLoadCard` does **not** re-fire — only the widget context changes inside the still-mounted queue view. When the user rates a sibling, two things break:

1. **`QueueCompleteCard` does not fire at all** for cluster card ratings. The scheduler updates the card's repetition history directly, but the event is suppressed.
2. **`data.cardId` in `QueueLoadCard` is the anchor's ID**, not the sibling currently on screen. Without additional signals, there is no way to know which sibling was just rated.

#### The role of `card_priority_display` (FlashcardUnder widget)

`card_priority_display.tsx` is a `FlashcardUnder` widget — it mounts inside the queue's card panel, re-rendering on each sibling transition via `getWidgetContext()`. It polls `getWidgetContext().cardId` every 500 ms and, when it detects a change, writes two keys to session storage:

- `clusterVisibleCardId` — the `cardId` of the sibling currently on screen
- `clusterVisibleCardLoadTime` — `Date.now()` at the moment of the write

This gives the event listeners in `events.ts` a reliable, up-to-date pointer to the actual sibling being shown, bridging the gap that `QueueLoadCard`/`QueueCompleteCard` cannot fill.

**Limitation:** `card_priority_display` is mounted inside the regular queue view. It is **not mounted** in the Mastery Drill popup — so `clusterVisibleCardId` is unavailable there.

#### Why `GlobalRemChanged` fires instead of `QueueCompleteCard`

When a cluster card is rated, the scheduler still modifies RemNote's internal data model. This triggers `GlobalRemChanged`, but with the **cluster parent rem's ID** — not any child rem's ID. The event fires 2–3 times per rating (for the parent and at least one other internal rem). This is the only event that signals a cluster card was rated.

#### The three-path fix

| Context | Card type | Mechanism |
|---|---|---|
| Regular queue | Non-cluster flashcard | `QueueCompleteCard` (existing) — `data.cardId` is reliable |
| Regular queue | Cluster sibling | `GlobalRemChanged` on the cluster parent rem → read `clusterVisibleCardId` from session storage (written by `card_priority_display`) → look up the sibling card's repetition history to confirm a fresh rating within the last 10 s |
| Mastery Drill | Any card (cluster or not) | `QueueLoadCard` / `QueueExit` → `processPreviousCard()` checks the **previous** card's repetition history; acts if the last entry is dated after that card's load time |

**Deduplication in the `GlobalRemChanged` path:** because the event fires multiple times per rating (multiple remIds), the listener claims the remId in `recentlyProcessedCards` synchronously before the first `await`, then releases it in a `finally` block once the async work completes (< 1 second). This prevents concurrent invocations from double-writing. For non-cluster cards, `QueueCompleteCard` fires first and adds the remId to the same set, so `GlobalRemChanged` silently skips — the two paths never collide.

**The drill path** (`registerDrillCardRatingListener`) is gated on `finalDrillActive` and does not interfere with the regular queue paths.

#### Flashcard History also fixed

`QueueCompleteCard` was the sole writer to `flashcardHistoryData` (the Flashcard History sidebar). Because it never fires for cluster cards or inside the drill popup, those ratings were silently absent from the history list. The `GlobalRemChanged` cluster path and `processPreviousCard()` now each write a history entry in the same format, closing both gaps.

---

## v0.2.185 - April 22nd, 2026

### ✨ New: SuperMemo-style Create Cloze Deletion (`Alt+Z`)

The **Create Cloze Deletion** command (`Alt+Z`) has been completely redesigned to follow the SuperMemo incremental reading workflow. Instead of marking the selected text as an inline cloze inside the original rem, it now creates a **standalone child rem** that functions as an independent flashcard.

**What happens when you press `Alt+Z`:**

1. A **child rem** is created containing the full text of the parent (front and back, if it is a flashcard). The card delimiter is replaced by a directional arrow (`⇒`, `⇐`, or `⇔`) derived from the rem's practice direction.
2. The **selected text** is marked as a cloze deletion in the child.
3. Any **existing cloze marks** in the parent text are stripped from the child copy and re-marked with yellow highlight + red font, so prior holes are visible without interfering with the new cloze.
4. If the parent is a **Concept** rem, the front portion of the child is rendered in bold; if a **Descriptor**, in italic — matching RemNote's native UI conventions.
5. A **back-reference pin** to the parent is appended at the end of the child's text.
6. The **selected text in the parent** is highlighted in yellow + red font to signal that this passage has been cloze-extracted.
7. The **parent rem** is tagged with `#remove-from-queue`.
8. The child receives a **`cloze-extract` tag**, which renders a small violet **↑** badge in the queue (hover for tooltip) so you can always identify cards created via this workflow.

**Compared to native RemNote clozes:** Native clozes have the advantage of offering **spoiler protection** (cards from the same rem are buried for ~1 hour). The new `Alt+Z` is recommended for when you want to create a **standalone rem** that can be incrementally simplified in wording over time — making each card more atomic and efficient for long-term retention; and when you want to attach different priorities for each cloze.

### 🐛 Bug Fix: Extract (`Alt+X`) — Blue highlight and pin misplaced when parent already had a prior extract

When triggering **Make Incremental with text selection** (`Alt+X`) on a rem that already contained a previous extract's reference pin, the blue highlight and pin were inserted up to 2 characters off from the correct position.

**Root cause:** RemNote's cursor position model counts `i:'q'` reference/pin nodes as **2 characters**, but the plugin's position traversal counted them as 1. Each pin preceding the selection shifted `r_start` by 1 in RemNote's model but only by 1 in our traversal — causing a cumulative offset.

**The fix:** Both `Alt+X` and `Alt+Z` now use **text-only string-matching** (`String.indexOf` on plain-text content) to locate the selection within its section, bypassing RemNote's cursor-width model for non-text nodes entirely. Reference and pin nodes are treated as zero-width in the traversal and pass through unchanged.


### 🐛 Bug Fix: Mastery Drill — Wrong Card Added/Removed Due to Stale Cluster Signal

Cards rated **Good** or **Easy** in the regular queue were incorrectly appearing in the Mastery Drill, and cards rated **Again** or **Hard** were sometimes not added.

**Root cause:** `QueueCompleteCard` used `clusterVisibleCardId` (a session-storage key written asynchronously by the Card Priority Display widget) to identify the specific cluster sibling being rated. When transitioning between cards quickly, `clusterVisibleCardId` could already reflect the *next* card that had just loaded — causing the wrong card to be added or removed from the drill.

**The fix (`src/register/events.ts`):** Before trusting `clusterVisibleCardId`, the listener now verifies that the referenced card belongs to the **same rem** as `data.cardId`. If it belongs to a different rem (i.e., it's stale from the next card), it is discarded and the event's own `data.cardId` is used instead. Legitimate cluster siblings — sharing the same rem — continue to work correctly.

**Cleanup utility:** A new command **"Mastery Drill: Remove cards whose last rating was Good or Easy"** (`cleanup_mastery_drill`) is available in the Command Palette. It audits the current knowledge base's drill queue and removes any entries where the card is missing, has no history, or whose last meaningful rating was not Again or Hard — cleaning up entries corrupted by this bug.



### 🐛 Bug Fix: PDF Database Only Registered First Source on Multi-PDF Rems

When triggering **Make Incremental (Alt+X)** on a rem that has **multiple PDF sources**, the synced `known_pdf_rems_` index (used by the Parent Selector widget to suggest parents for highlights) was only being populated for the **first** PDF source. Subsequent sources were silently skipped, so the Parent Selector would not surface this incremental rem when a highlight was created from those other PDFs.

* **The Issue:** `initIncrementalRem` called `findPDFinRem(rem)` without a target PDF ID, which — by design for backward compatibility — returns only the first PDF found. The result was passed to `registerRemsAsPdfKnown`, so only one entry was written to the index regardless of how many PDF sources the rem had.
* **The Fix:** The registration block now iterates all sources (and the rem itself), checks each one for the `UploadedFile` powerup and a `.pdf` URL, and calls `registerRemsAsPdfKnown` for every PDF found. Rems with multiple PDF sources are now correctly registered against all of them.
