### PR TITLE
Bookmark feature in the Text Reader mode (PDFs) and HTML Rem

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -7,7 +7,7 @@
   "version": {
     "major": 0,
     "minor": 2,
-    "patch": 188
+    "patch": 189
   },
   "unlisted": false,
   "theme": [],

--- a/src/components/Reader.tsx
+++ b/src/components/Reader.tsx
@@ -177,7 +177,9 @@ export function Reader(props: ReaderProps) {
         highlightExtract?.scrollToReaderHighlight();
         hasScrolled.current = true;
       }, 100);
-    } else if (actionType === 'pdf' && !hasScrolled.current && isReaderReady && criticalContext?.incrementalRemId) {
+    } else if ((actionType === 'pdf' || actionType === 'html') && !hasScrolled.current && isReaderReady && criticalContext?.incrementalRemId) {
+      // Auto-scroll to last saved bookmark for both PDF docs and HTML articles
+      // (Reader Mode). Highlight reps already auto-scroll above.
       const checkAndScrollBookmark = async () => {
         try {
           const history = await getPageHistory(plugin as ReactRNPlugin, criticalContext.incrementalRemId!, pdfRemId);

--- a/src/lib/consts.ts
+++ b/src/lib/consts.ts
@@ -131,6 +131,11 @@ export const pdfHighlightColorId = 'pdf-highlight-color'; // Incremental PDF hig
 export const currentDocumentIdKey = 'current-document-id';
 export const popupDocumentIdKey = 'popup-document-id';
 
+// Pending scroll-to-highlight request, picked up by the main-process listener
+// in callbacks.ts after a widget triggers `openRemInNewPane`. The widget's
+// iframe dies during the layout reorg, so the scroll must run in main-process.
+export const pendingScrollRequestKey = 'pending-scroll-request';
+
 // Priority Review Graph
 export const priorityGraphPowerupCode = 'priority_review_graph';
 export const GRAPH_DATA_KEY_PREFIX = 'priority_review_graph_data_';

--- a/src/lib/highlightActions.ts
+++ b/src/lib/highlightActions.ts
@@ -233,16 +233,20 @@ export const createRemUnderParent = async (
   console.log('[ParentSelector:HighlightActions] About to save last destination...');
   await saveLastSelectedDestination(plugin, pdfRemId, contextRemId, parentId);
 
-  // NEW: Save reading position/bookmark automatically for queue item 
+  // NEW: Save reading position/bookmark automatically for queue item.
+  // pageIndex is null for HTML / PDF Text Reader highlights — we still record
+  // the bookmark by highlight rem id so jumps work in those modes too.
   if (makeIncremental) {
     const { pdfRemId: actualPdf, pageIndex } = await getPdfInfoFromHighlight(plugin, highlightRem);
-    if (actualPdf && pageIndex !== null) {
+    if (actualPdf) {
         try {
             // Update progress for the currently reviewed Queue item (if active)
             const queueCtx = await plugin.storage.getSession<any>('pageRangeContext');
             if (queueCtx && queueCtx.pdfRemId === actualPdf && queueCtx.incrementalRemId) {
                 await addPageToHistory(plugin, queueCtx.incrementalRemId, actualPdf, pageIndex, undefined, highlightRem._id);
-                await setIncrementalReadingPosition(plugin, queueCtx.incrementalRemId, actualPdf, pageIndex);
+                if (pageIndex !== null) {
+                    await setIncrementalReadingPosition(plugin, queueCtx.incrementalRemId, actualPdf, pageIndex);
+                }
                 console.log('[ParentSelector:HighlightActions] Updated Queue item reading history from highlight capture');
             }
         } catch(e) {

--- a/src/lib/incremental_rem/index.ts
+++ b/src/lib/incremental_rem/index.ts
@@ -24,7 +24,7 @@ import { tryParseJson, getDailyDocReferenceForDate, sleep } from '../utils';
 import { getInitialPriority } from '../priority_inheritance';
 import { updateIncrementalRemCache } from './cache';
 import { mergeHistoryFromDismissed } from '../dismissed';
-import { registerRemsAsPdfKnown } from '../pdfUtils';
+import { registerRemsAsPdfKnown, registerRemsAsHtmlKnown, isHtmlSource } from '../pdfUtils';
 
 type ReviewOverrideOptions = {
   /**
@@ -349,10 +349,10 @@ export async function initIncrementalRem(plugin: ReactRNPlugin, rem: PluginRem, 
 
       await updateIncrementalRemCache(plugin, newIncRem);
 
-      // Register in the known_pdf_rems_ synced index so the parent selector
-      // can discover this IncRem instantly (PART 2 of performFullPDFSearch),
-      // even when the session cache (allIncrementalRemKey) is not yet loaded
-      // (e.g., WebBrowser / Light Mode).
+      // Register in the known_pdf_rems_ / known_html_rems_ synced indexes so
+      // the parent selector and bookmark popup can discover this IncRem
+      // instantly (PART 2 of findAllRemsFor*), even when the session cache
+      // (allIncrementalRemKey) is not yet loaded (e.g., WebBrowser / Light Mode).
       try {
         const sources = await rem.getSources();
         const allSources = [rem, ...sources];
@@ -367,10 +367,18 @@ export async function initIncrementalRem(plugin: ReactRNPlugin, rem: PluginRem, 
             } catch {
               // Skip candidates where URL can't be read
             }
+            continue;
+          }
+          if (await isHtmlSource(candidate)) {
+            try {
+              await registerRemsAsHtmlKnown(plugin as any, candidate._id, [rem._id]);
+            } catch {
+              // Skip candidates that fail registration
+            }
           }
         }
       } catch (e) {
-        console.error('[initIncrementalRem] Error registering in known_pdf_rems_:', e);
+        console.error('[initIncrementalRem] Error registering in known host indexes:', e);
       }
 
       // Bump the reload trigger so the tracker picks up the new IncRem.

--- a/src/lib/pdfUtils.ts
+++ b/src/lib/pdfUtils.ts
@@ -14,7 +14,8 @@ export interface PageRangeContext {
  * Enhanced structure for page history entries with duration tracking
  */
 export interface PageHistoryEntry {
-  page: number;
+  // Optional: HTML articles and PDF Text Reader highlights have no page number.
+  page?: number;
   timestamp: number;
   sessionDuration?: number;   // Duration in seconds for this reading session
   highlightId?: string;       // Rem ID of the specific highlight mapped to this bookmark
@@ -192,10 +193,11 @@ export const getPageHistory = async (
       if (typeof entry === 'number') {
         // Old format: just page number, no timestamp
         return { page: entry, timestamp: 0 };
-      } else if (entry && typeof entry.page === 'number') {
-        // New format with timestamp and possibly duration
+      } else if (entry && (typeof entry.page === 'number' || entry.highlightId)) {
+        // Accept entries with a real page number (PDF Reader) OR with a
+        // highlightId but no page (HTML / PDF Text Reader bookmarks).
         return {
-          page: entry.page,
+          page: typeof entry.page === 'number' ? entry.page : undefined,
           timestamp: entry.timestamp || 0,
           sessionDuration: entry.sessionDuration,
           highlightId: entry.highlightId
@@ -223,7 +225,9 @@ export const addPageToHistory = async (
   plugin: RNPlugin,
   incrementalRemId: string,
   pdfRemId: string,
-  pageToRecord?: number,
+  // Pass `null` for non-paginated sources (HTML / PDF Text Reader). Pass
+  // `undefined` to derive the page from the saved reading position.
+  pageToRecord?: number | null,
   sessionDurationOverride?: number,
   highlightId?: string
 ): Promise<void> => {
@@ -231,9 +235,11 @@ export const addPageToHistory = async (
 
   const historyKey = getPageHistoryKey(incrementalRemId, pdfRemId);
 
-  // Get the page to record - either provided or from current reading position
-  let page: number;
-  if (pageToRecord !== undefined) {
+  // Get the page to record. `null` = explicit "no page" (HTML/text reader).
+  let page: number | undefined;
+  if (pageToRecord === null) {
+    page = undefined;
+  } else if (pageToRecord !== undefined) {
     page = pageToRecord;
   } else {
     // Get the actual current reading position instead of defaulting to 1
@@ -366,7 +372,7 @@ export const getReadingStatistics = async (
     averageSessionSeconds: Math.round(averageSessionSeconds),
     lastSessionDate: lastEntry?.timestamp,
     lastSessionDuration: lastEntry?.sessionDuration,
-    pagesRead: new Set(history.map(e => e.page)),
+    pagesRead: new Set(history.map(e => e.page).filter((p): p is number => typeof p === 'number')),
     sessionsWithTime: sessionsWithDuration.length
   };
 };
@@ -1086,17 +1092,27 @@ export async function getRemCardContent(
 }
 
 /**
- * Extracts the associated PDF Document ID and native Page index from a PDF Highlight's Data slot.
+ * Extracts the host-document Rem ID and native Page index from a Reader highlight.
+ *
+ * Handles three highlight kinds with one signature:
+ *   - PDF Reader highlight  → host has UploadedFile powerup, page from Data slot
+ *   - PDF Text Reader highlight → host has UploadedFile powerup, no page
+ *   - HTML article highlight (Reader Mode) → host has Link powerup, no page
+ *
+ * The returned `pdfRemId` is the host doc rem id regardless of source type
+ * (name kept for backwards compatibility). `pageIndex` is null when the
+ * source is non-paginated.
  */
 export const getPdfInfoFromHighlight = async (
   plugin: RNPlugin,
   highlightRem: PluginRem
 ): Promise<{ pdfRemId: string | null; pageIndex: number | null }> => {
-  let pdfRemId: string | null = null;
+  let hostRemId: string | null = null;
   let pageIndex: number | null = null;
 
   try {
-    // 1. Resolve page index via Data slot JSON
+    // 1. Resolve page index via Data slot JSON. Only PDF Reader highlights
+    //    populate this slot — Text Reader and HTML highlights leave it undefined.
     const dataString = await highlightRem.getPowerupProperty(BuiltInPowerupCodes.PDFHighlight, 'Data');
     if (dataString) {
       const dataObj = JSON.parse(dataString);
@@ -1107,23 +1123,26 @@ export const getPdfInfoFromHighlight = async (
       }
     }
 
-    // 2. Resolve PDF Document ID by walking up to UploadedFile
-    let docRem: PluginRem | undefined = highlightRem;
-    while (docRem) {
-      const isPdf = await docRem.hasPowerup(BuiltInPowerupCodes.UploadedFile);
-      if (isPdf) {
-        pdfRemId = docRem._id;
+    // 2. Resolve host doc by walking up the parent chain. The host is whichever
+    //    ancestor first identifies as a Reader source: UploadedFile (PDFs) or
+    //    a non-YouTube Link (HTML articles).
+    let cursor: PluginRem | undefined = highlightRem;
+    while (cursor) {
+      if (await cursor.hasPowerup(BuiltInPowerupCodes.UploadedFile)) {
+        hostRemId = cursor._id;
         break;
       }
-      const parent = await docRem.getParentRem();
+      if (await isHtmlSource(cursor)) {
+        hostRemId = cursor._id;
+        break;
+      }
+      const parent: PluginRem | undefined = await cursor.getParentRem();
       if (!parent) break;
-      docRem = parent;
+      cursor = parent;
     }
-    
-    // (No further fallback — .document property does not exist on PluginRem)
   } catch (e) {
     console.error('[getPdfInfoFromHighlight] Error:', e);
   }
 
-  return { pdfRemId, pageIndex };
+  return { pdfRemId: hostRemId, pageIndex };
 };

--- a/src/lib/pdfUtils.ts
+++ b/src/lib/pdfUtils.ts
@@ -609,6 +609,32 @@ export const findPreferredPDFInRem = async (
 export const getKnownPdfRemsKey = (pdfRemId: string) => `known_pdf_rems_${pdfRemId}`;
 
 /**
+ * Register one or more rem IDs as known users of a specific HTML article.
+ * Mirror of registerRemsAsPdfKnown for HTML hosts. Idempotent.
+ * (The key generator getKnownHtmlRemsKey is defined further below alongside
+ * the other HTML-related helpers.)
+ */
+export const registerRemsAsHtmlKnown = async (
+  plugin: RNPlugin,
+  htmlRemId: string,
+  remIds: string[]
+): Promise<void> => {
+  const key = getKnownHtmlRemsKey(htmlRemId);
+  const existing = (await plugin.storage.getSynced<string[]>(key)) || [];
+  const existingSet = new Set(existing);
+  let changed = false;
+  for (const id of remIds) {
+    if (!existingSet.has(id)) {
+      existingSet.add(id);
+      changed = true;
+    }
+  }
+  if (changed) {
+    await plugin.storage.setSynced(key, Array.from(existingSet));
+  }
+};
+
+/**
  * Register one or more rem IDs as known users of a specific PDF in synced storage.
  * This is the index that getAllIncrementsForPDF and findAllRemsForPDF rely on to
  * discover rems that were not found via the local parent/sibling search.
@@ -957,6 +983,93 @@ export const findAllRemsForPDF = async (
     return result;
   } catch (error) {
     console.error('Error finding rems for PDF:', error);
+    return [];
+  }
+};
+
+/**
+ * Find all rems (incremental and non-incremental) that use a specific HTML
+ * article (Reader Mode source). Mirror of findAllRemsForPDF.
+ */
+export const findAllRemsForHTML = async (
+  plugin: RNPlugin,
+  htmlRemId: string
+): Promise<Array<{
+  remId: string;
+  name: string;
+  isIncremental: boolean;
+}>> => {
+  try {
+    const result: Array<{
+      remId: string;
+      name: string;
+      isIncremental: boolean;
+    }> = [];
+
+    const processedRemIds = new Set<string>();
+
+    // PART 1: Search all incremental rems from cache
+    const allIncrementalRems = await plugin.storage.getSession<IncrementalRem[]>(allIncrementalRemKey) || [];
+
+    for (const incRemInfo of allIncrementalRems) {
+      if (processedRemIds.has(incRemInfo.remId)) continue;
+
+      const rem = await plugin.rem.findOne(incRemInfo.remId);
+      if (!rem) continue;
+
+      // Skip highlight rems — we want host-doc-level IncRems only
+      const isPdfHighlight = await rem.hasPowerup(BuiltInPowerupCodes.PDFHighlight);
+      if (isPdfHighlight) continue;
+
+      const foundHtml = await findHTMLinRem(plugin, rem, htmlRemId);
+      if (foundHtml && foundHtml._id === htmlRemId) {
+        const remText = await safeRemTextToString(plugin, rem.text);
+        result.push({
+          remId: rem._id,
+          name: remText,
+          isIncremental: true
+        });
+        processedRemIds.add(rem._id);
+      }
+    }
+
+    // PART 2: Check known rems from storage (non-incremental + cache-cold cases)
+    const knownRemsKey = getKnownHtmlRemsKey(htmlRemId);
+    const knownRemIds = (await plugin.storage.getSynced<string[]>(knownRemsKey)) || [];
+
+    for (const remId of knownRemIds) {
+      if (processedRemIds.has(remId)) continue;
+
+      const rem = await plugin.rem.findOne(remId);
+      if (!rem) continue;
+
+      const isPdfHighlight = await rem.hasPowerup(BuiltInPowerupCodes.PDFHighlight);
+      if (isPdfHighlight) continue;
+
+      const isIncremental = await rem.hasPowerup(powerupCode);
+      const remText = await safeRemTextToString(plugin, rem.text);
+
+      const foundHtml = await findHTMLinRem(plugin, rem, htmlRemId);
+      if (foundHtml && foundHtml._id === htmlRemId) {
+        result.push({
+          remId: rem._id,
+          name: remText,
+          isIncremental
+        });
+        processedRemIds.add(rem._id);
+      }
+    }
+
+    result.sort((a, b) => {
+      if (a.isIncremental !== b.isIncremental) {
+        return a.isIncremental ? -1 : 1;
+      }
+      return a.name.localeCompare(b.name);
+    });
+
+    return result;
+  } catch (error) {
+    console.error('Error finding rems for HTML:', error);
     return [];
   }
 };

--- a/src/lib/remHelpers.ts
+++ b/src/lib/remHelpers.ts
@@ -1,5 +1,12 @@
 import { RNPlugin } from '@remnote/plugin-sdk';
 import type { PaneRemWindowTree, RemIdWindowTree } from '@remnote/plugin-sdk/dist/interfaces';
+import { pendingScrollRequestKey } from './consts';
+
+export interface PendingScrollRequest {
+  hostRemId: string;
+  highlightRemId: string;
+  requestedAt: number;
+}
 
 /**
  * Open a rem in a separate pane to the right of the current layout, or focus
@@ -54,6 +61,176 @@ export const openRemInNewPane = async (
     splitPercentage: 50,
   };
   await plugin.window.setRemWindowTree(newTree);
+};
+
+/**
+ * Polls until the given rem is open in some pane, or until `timeoutMs` elapses.
+ * Returns true when the pane appears, false on timeout.
+ *
+ * Intended to bridge the gap between `openRemInNewPane` resolving (the SDK
+ * has registered the new pane) and the native reader inside that pane being
+ * mounted enough to accept commands like `scrollToReaderHighlight`.
+ */
+export const waitForPaneOpen = async (
+  plugin: RNPlugin,
+  targetRemId: string,
+  timeoutMs: number = 5000,
+  intervalMs: number = 100
+): Promise<boolean> => {
+  const start = Date.now();
+  let polls = 0;
+  while (Date.now() - start < timeoutMs) {
+    polls++;
+    try {
+      const openRemIds = await plugin.window.getOpenPaneRemIds();
+      if (openRemIds.includes(targetRemId)) {
+        console.log(`[waitForPaneOpen] Pane appeared after ${Date.now() - start}ms (${polls} polls)`);
+        return true;
+      }
+    } catch (e) {
+      console.warn(`[waitForPaneOpen] poll #${polls} threw:`, e);
+    }
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+  console.warn(`[waitForPaneOpen] Timed out after ${timeoutMs}ms (${polls} polls) waiting for ${targetRemId}`);
+  return false;
+};
+
+/**
+ * Open a PDF/HTML host rem and reliably scroll to a saved highlight inside it,
+ * regardless of whether the doc is currently open (warm) or closed (cold).
+ *
+ * Cold-open path: PDF.js / the native reader has to mount and parse before
+ * `scrollToReaderHighlight` will do anything. We poll until the pane appears,
+ * then attempt the scroll twice — once after a grace period for the reader
+ * to boot, and a safety retry for slow large PDFs. Both attempts are
+ * idempotent (re-anchor at the same highlight).
+ */
+/**
+ * Trigger an open-and-scroll-to-highlight from a widget context. Writes a
+ * pending-scroll record to session storage, then opens the host pane. The
+ * actual polling and scrolling is handled by the main-process listener in
+ * `register/callbacks.ts`, because the widget's iframe is destroyed by the
+ * pane layout reorganization and any setTimeouts/awaits in it are killed.
+ */
+export const openAndScrollToHighlight = async (
+  plugin: RNPlugin,
+  hostRemId: string,
+  highlightRemId: string
+): Promise<void> => {
+  const tag = `[openAndScrollToHighlight ${highlightRemId.slice(0, 6)}]`;
+
+  // Warm vs. cold detection: if the host is already open in some pane,
+  // openRemInNewPane will only refocus (no layout reorg), so the widget
+  // iframe survives and we can scroll inline. If cold, the pane reorg
+  // will kill this iframe — stash the request and let the main-process
+  // listener finish the work.
+  let isWarmOpen = false;
+  try {
+    const openRemIds = await plugin.window.getOpenPaneRemIds();
+    isWarmOpen = openRemIds.includes(hostRemId);
+  } catch (e) {
+    console.warn(`${tag} could not query open panes, treating as cold:`, e);
+  }
+
+  if (isWarmOpen) {
+    console.log(`${tag} warm path — focusing existing pane and scrolling inline`);
+    const bookmarkRem = await plugin.rem.findOne(highlightRemId);
+    await openRemInNewPane(plugin, hostRemId); // just focuses the existing pane
+    setTimeout(() => {
+      console.log(`${tag} warm scroll firing`);
+      try {
+        bookmarkRem?.scrollToReaderHighlight();
+      } catch (e) {
+        console.error(`${tag} warm scroll threw:`, e);
+      }
+    }, 400);
+    return;
+  }
+
+  console.log(`${tag} cold path — stashing pending scroll, opening pane`);
+  const request: PendingScrollRequest = {
+    hostRemId,
+    highlightRemId,
+    requestedAt: Date.now(),
+  };
+  await plugin.storage.setSession(pendingScrollRequestKey, request);
+
+  await openRemInNewPane(plugin, hostRemId);
+  console.log(`${tag} openRemInNewPane resolved — main-process listener will finish the scroll`);
+};
+
+/**
+ * Drain a pending scroll request and execute the open+wait+scroll flow. Must
+ * be called from the main-process context (e.g. inside a registered event
+ * listener) so that the polling and setTimeouts survive the widget layout
+ * reorganization that triggered the request.
+ */
+export const consumePendingScrollRequest = async (
+  plugin: RNPlugin
+): Promise<boolean> => {
+  const request = await plugin.storage.getSession<PendingScrollRequest>(pendingScrollRequestKey);
+  if (!request) return false;
+
+  // Stale safety: ignore requests older than 30s (e.g. user closed the app).
+  if (Date.now() - request.requestedAt > 30_000) {
+    await plugin.storage.setSession(pendingScrollRequestKey, undefined);
+    return false;
+  }
+
+  // Clear immediately so concurrent listener firings don't double-process.
+  await plugin.storage.setSession(pendingScrollRequestKey, undefined);
+
+  const { hostRemId, highlightRemId } = request;
+  const tag = `[consumePendingScroll ${highlightRemId.slice(0, 6)}]`;
+  console.log(`${tag} processing — host=${hostRemId.slice(0, 6)}`);
+
+  const bookmarkRem = await plugin.rem.findOne(highlightRemId);
+  if (!bookmarkRem) {
+    console.warn(`${tag} highlight rem not found, aborting`);
+    return true;
+  }
+
+  // Wait for the SDK to surface the new pane, then give PDF.js / the native
+  // reader enough time to mount before issuing scroll commands.
+  const paneOpened = await waitForPaneOpen(plugin, hostRemId);
+  if (!paneOpened) {
+    console.warn(`${tag} pane never opened, best-effort scroll`);
+    try {
+      bookmarkRem.scrollToReaderHighlight();
+    } catch (e) {
+      console.error(`${tag} fallback scroll threw:`, e);
+    }
+    return true;
+  }
+
+  console.log(`${tag} pane open confirmed — scheduling scrolls at 1500ms, 3500ms, 6000ms`);
+  setTimeout(() => {
+    console.log(`${tag} scroll attempt #1 firing`);
+    try {
+      bookmarkRem.scrollToReaderHighlight();
+    } catch (e) {
+      console.error(`${tag} scroll #1 threw:`, e);
+    }
+  }, 1500);
+  setTimeout(() => {
+    console.log(`${tag} scroll attempt #2 firing`);
+    try {
+      bookmarkRem.scrollToReaderHighlight();
+    } catch (e) {
+      console.error(`${tag} scroll #2 threw:`, e);
+    }
+  }, 3500);
+  setTimeout(() => {
+    console.log(`${tag} scroll attempt #3 firing`);
+    try {
+      bookmarkRem.scrollToReaderHighlight();
+    } catch (e) {
+      console.error(`${tag} scroll #3 threw:`, e);
+    }
+  }, 6000);
+
+  return true;
 };
 
 /**

--- a/src/register/callbacks.ts
+++ b/src/register/callbacks.ts
@@ -1,4 +1,5 @@
 import {
+  AppEvents,
   QueueItemType,
   ReactRNPlugin,
   RemId,
@@ -20,6 +21,7 @@ import {
 } from '../lib/consts';
 import { getIncrementalRemFromRem, IncrementalRem } from '../lib/incremental_rem';
 import { getCardsPerRem, getSortingRandomness } from '../lib/sorting';
+import { consumePendingScrollRequest } from '../lib/remHelpers';
 
 
 // Registered once globally — safe because all selectors are highly specific to the
@@ -296,4 +298,23 @@ export function registerCallbacks(plugin: ReactRNPlugin) {
       }
     }
   );
+
+  // Pending-scroll listener. Runs in the main-process context, so the
+  // polling and setTimeouts inside `consumePendingScrollRequest` survive
+  // the widget iframe death caused by `setRemWindowTree` reorganizing the
+  // panes. Triggered widgets stash their request in session storage and
+  // call openRemInNewPane; this listener picks it up after the layout
+  // settles.
+  let scrollInflight = false;
+  plugin.event.addListener(AppEvents.CurrentWindowTreeChange, undefined, async () => {
+    if (scrollInflight) return;
+    scrollInflight = true;
+    try {
+      await consumePendingScrollRequest(plugin);
+    } catch (e) {
+      console.error('[pending-scroll listener] consume threw:', e);
+    } finally {
+      scrollInflight = false;
+    }
+  });
 }

--- a/src/widgets/answer_buttons.tsx
+++ b/src/widgets/answer_buttons.tsx
@@ -32,7 +32,7 @@ import { getIncrementalRemFromRem, handleNextRepetitionClick, handleNextRepetiti
 import { removeIncrementalRemCache } from '../lib/incremental_rem/cache';
 import { IncrementalRem } from '../lib/incremental_rem';
 import { percentileToHslColor, calculateRelativePercentile, calculateVolumeBasedPercentile, calculateWeightedShield, PERFORMANCE_MODE_LIGHT } from '../lib/utils';
-import { safeRemTextToString, findPDFinRem, addPageToHistory, getPageHistory, getCurrentPageKey, getDescendantsToDepth } from '../lib/pdfUtils';
+import { safeRemTextToString, findPDFinRem, findHTMLinRem, addPageToHistory, getPageHistory, getCurrentPageKey, getDescendantsToDepth } from '../lib/pdfUtils';
 import { QueueSessionCache, setCardPriority } from '../lib/card_priority';
 import { WeightedShieldTooltip } from '../components';
 import { shouldUseLightMode } from '../lib/mobileUtils';
@@ -201,16 +201,20 @@ export function AnswerButtons() {
     return url;
   }, [baseData?.rem?._id, remType]);
 
-  // Fetch the most recent PDF bookmark highlightId for this IncRem (only for pdf type)
+  // Fetch the most recent bookmark highlightId for this IncRem (pdf or html doc reps).
+  // Skipped for highlight reps — those auto-scroll to the highlight itself, no
+  // separate bookmark concept applies.
   const bookmarkHighlightId = useTrackerPlugin(async (rp) => {
     if (!baseData?.rem) return null;
     const type = await rp.storage.getSession<string | null>(currentIncrementalRemTypeKey);
-    if (type !== 'pdf') return null;
+    if (type !== 'pdf' && type !== 'html') return null;
 
-    const pdfRem = await findPDFinRem(rp, baseData.rem);
-    if (!pdfRem) return null;
+    const hostRem = type === 'pdf'
+      ? await findPDFinRem(rp, baseData.rem)
+      : await findHTMLinRem(rp, baseData.rem);
+    if (!hostRem) return null;
 
-    const history = await getPageHistory(rp, baseData.rem._id, pdfRem._id);
+    const history = await getPageHistory(rp, baseData.rem._id, hostRem._id);
     // Only use the highlight if the LAST entry carries a highlightId.
     // If a manual position was recorded after the highlight bookmark, the button
     // would scroll to a stale position, so we suppress it in that case.
@@ -541,7 +545,7 @@ export function AnswerButtons() {
                 border: '2px solid var(--rn-clr-blue, #3b82f6)',
                 fontWeight: 600,
               }}
-              title="Scroll to Bookmark: Jump to your last saved reading position in the PDF"
+              title="Scroll to Bookmark: Jump to your last saved reading position in the document"
             >
               <div style={buttonStyles.label}>🔖 Scroll</div>
               <div style={buttonStyles.sublabel}>to Bookmark</div>

--- a/src/widgets/create_inc_rem_toolbar.tsx
+++ b/src/widgets/create_inc_rem_toolbar.tsx
@@ -90,11 +90,15 @@ export function CreateIncRemToolbar() {
       showPriorityPopupIfNew: true,
     });
 
-    // 5. Save the bookmark position dynamically to the identified contextRem
-    if (contextRemId && docId && pageIndex !== null) {
+    // 5. Save the bookmark position dynamically to the identified contextRem.
+    //    pageIndex is null for HTML / PDF Text Reader highlights — we still
+    //    record the bookmark by highlight rem id so jumps work.
+    if (contextRemId && docId) {
       try {
         await addPageToHistory(plugin as any, contextRemId, docId, pageIndex, undefined, highlight._id);
-        await setIncrementalReadingPosition(plugin as any, contextRemId, docId, pageIndex);
+        if (pageIndex !== null) {
+          await setIncrementalReadingPosition(plugin as any, contextRemId, docId, pageIndex);
+        }
 
         // Optional: show a combined toast to indicate both tasks succeeded
         await plugin.app.toast('✅ Extract created & bookmark updated');

--- a/src/widgets/editor_review.tsx
+++ b/src/widgets/editor_review.tsx
@@ -13,10 +13,10 @@ import { powerupCode, prioritySlotCode, pageRangeWidgetId } from '../lib/consts'
 import { IncrementalRep } from '../lib/incremental_rem';
 import dayjs from 'dayjs';
 import { findClosestIncrementalAncestor } from '../lib/priority_inheritance';
-import { safeRemTextToString, findPDFinRem, getIncrementalReadingPosition, addPageToHistory, getPageHistory, getIncrementalPageRange, clearIncrementalPDFData, PageRangeContext } from '../lib/pdfUtils';
+import { safeRemTextToString, findPDFinRem, findHTMLinRem, getIncrementalReadingPosition, addPageToHistory, getPageHistory, getIncrementalPageRange, clearIncrementalPDFData, PageRangeContext } from '../lib/pdfUtils';
 import { addToIncrementalHistory } from '../lib/history_utils';
 import { determineIncRemType } from '../lib/incRemHelpers';
-import { openRemInNewPane } from '../lib/remHelpers';
+import { openRemInNewPane, openAndScrollToHighlight } from '../lib/remHelpers';
 import { PageControls } from '../components/reader/ui';
 import { usePdfPageControls } from '../components/reader/usePdfPageControls';
 
@@ -210,10 +210,13 @@ const EditorReviewInput: React.FC<{ plugin: RNPlugin; remId: string }> = ({ plug
 
     await plugin.app.toast(`⏱️ Timer started for: ${remName}`);
 
-    // Open the PDF (if any) and resume at the last bookmarked highlight.
-    // Mirrors the priority_editor Scroll-to-Position behavior: scrollToReaderHighlight
-    // is a no-op unless a PDF reader is mounted, so we explicitly open the PDF rem
-    // first. For non-PDF rems, fall back to the original opening logic.
+    // Open the host doc (PDF or HTML article) and resume at the last bookmarked
+    // highlight if any. openAndScrollToHighlight handles the warm/cold open
+    // distinction and survives the widget iframe death triggered by the layout
+    // reorganization (the polling/scroll work runs in the main process).
+    //
+    // For non-host rems (e.g. plain incremental rems), fall back to opening
+    // the rem directly so the user lands in something useful.
     //
     // IMPORTANT: closePopup() must come AFTER all SDK calls. Closing the popup
     // tears down the widget sandbox, so any plugin.* call after that will time out.
@@ -224,34 +227,25 @@ const EditorReviewInput: React.FC<{ plugin: RNPlugin; remId: string }> = ({ plug
         return;
       }
 
+      // Host resolution: PDF first, then HTML article (Reader Mode source).
       const pdfRem = await findPDFinRem(plugin, rem);
+      const hostRem = pdfRem ?? (await findHTMLinRem(plugin, rem));
       const incRemType = await determineIncRemType(plugin, rem);
 
-      if (pdfRem) {
-        // Mount the PDF reader in a NEW pane (right of the current layout) so
-        // the IncRem the user was viewing in the editor stays visible.
-        await openRemInNewPane(plugin, pdfRem._id);
+      if (hostRem) {
+        // Look for a saved bookmark to scroll to. If absent, just open the host.
+        const history = await getPageHistory(plugin, remId, hostRem._id);
+        const lastEntry = history[history.length - 1];
+        const bookmarkHighlightId = lastEntry?.highlightId;
+        if (bookmarkHighlightId) {
+          await openAndScrollToHighlight(plugin, hostRem._id, bookmarkHighlightId);
+        } else {
+          await openRemInNewPane(plugin, hostRem._id);
+        }
       } else if (incRemType === 'pdf-note') {
         await rem.openRemAsPage();
       } else {
         await plugin.window.openRem(rem);
-      }
-
-      if (pdfRem) {
-        const history = await getPageHistory(plugin, remId, pdfRem._id);
-        const lastEntry = history[history.length - 1];
-        const bookmarkHighlightId = lastEntry?.highlightId;
-        if (bookmarkHighlightId) {
-          const bookmarkRem = await plugin.rem.findOne(bookmarkHighlightId);
-          if (bookmarkRem && typeof bookmarkRem.scrollToReaderHighlight === 'function') {
-            // Delay so the reader has time to mount before we ask it to scroll.
-            setTimeout(() => {
-              bookmarkRem.scrollToReaderHighlight();
-            }, 400);
-          } else {
-
-          }
-        }
       }
     } catch (e) {
       console.error('[EditorReview.handleStartTimer] Failed to open & scroll', e);

--- a/src/widgets/editor_review_timer.tsx
+++ b/src/widgets/editor_review_timer.tsx
@@ -13,8 +13,8 @@ import { handleCardPriorityInheritance } from '../lib/card_priority/card_priorit
 import { addToIncrementalHistory } from '../lib/history_utils';
 import { IncrementalRep } from '../lib/incremental_rem';
 import { determineIncRemType } from '../lib/incRemHelpers';
-import { findPDFinRem, clearIncrementalPDFData, PageRangeContext, addPageToHistory, getPageHistory, safeRemTextToString } from '../lib/pdfUtils';
-import { openRemInNewPane } from '../lib/remHelpers';
+import { findPDFinRem, findHTMLinRem, clearIncrementalPDFData, PageRangeContext, addPageToHistory, getPageHistory, safeRemTextToString } from '../lib/pdfUtils';
+import { openAndScrollToHighlight } from '../lib/remHelpers';
 import { PageControls } from '../components/reader/ui';
 import { usePdfPageControls } from '../components/reader/usePdfPageControls';
 import dayjs from 'dayjs';
@@ -27,6 +27,12 @@ function EditorReviewTimer() {
   const [currentTime, setCurrentTime] = useState(Date.now());
   const [pdfRemId, setPdfRemId] = useState<string | null>(null);
   const [isPdfNote, setIsPdfNote] = useState(false);
+  // hostRemId is the host doc rem id when the IncRem reads from a PDF or HTML
+  // article. pdfRemId remains PDF-only (gates PageControls and page-keyed
+  // history saves). hostKind disambiguates the two for the bookmark Scroll
+  // button and addPageToHistory's page argument.
+  const [hostRemId, setHostRemId] = useState<string | null>(null);
+  const [hostKind, setHostKind] = useState<'pdf' | 'html' | null>(null);
   const [bookmarkHighlightId, setBookmarkHighlightId] = useState<string | null>(null);
 
   const timerData = useTrackerPlugin(
@@ -71,29 +77,48 @@ function EditorReviewTimer() {
 
   const pdfControls = usePdfPageControls(plugin, timerData?.remId, pdfRemId, 0);
 
-  // Load PDF info if the rem is a pdf or has a pdf source
+  // Load host (PDF or HTML article) info if the rem reads from one. PDFs
+  // additionally enable PageControls; HTML hosts only get the bookmark Scroll
+  // button.
   useEffect(() => {
     if (!timerData?.remId) return;
 
-    const loadPdfData = async () => {
+    const loadHostData = async () => {
       const rem = await plugin.rem.findOne(timerData.remId);
-      if (!rem) return;
+      if (!rem) {
+        setIsPdfNote(false);
+        setPdfRemId(null);
+        setHostRemId(null);
+        setHostKind(null);
+        setBookmarkHighlightId(null);
+        return;
+      }
 
       const pdfRem = await findPDFinRem(plugin, rem);
+      const htmlRem = pdfRem ? null : await findHTMLinRem(plugin, rem);
+      const host = pdfRem ?? htmlRem;
+
       if (pdfRem) {
         setIsPdfNote(true);
         setPdfRemId(pdfRem._id);
+      } else {
+        setIsPdfNote(false);
+        setPdfRemId(null);
+      }
 
-        // Check for a bookmark highlight in the last history entry
-        const history = await getPageHistory(plugin, timerData.remId, pdfRem._id);
+      if (host) {
+        setHostRemId(host._id);
+        setHostKind(pdfRem ? 'pdf' : 'html');
+        const history = await getPageHistory(plugin, timerData.remId, host._id);
         const lastEntry = history[history.length - 1];
         setBookmarkHighlightId(lastEntry?.highlightId ?? null);
       } else {
-        setIsPdfNote(false);
+        setHostRemId(null);
+        setHostKind(null);
         setBookmarkHighlightId(null);
       }
     };
-    loadPdfData();
+    loadHostData();
   }, [timerData?.remId, plugin]);
 
   const isPaused = !!(timerData?.pausedAt);
@@ -157,8 +182,11 @@ function EditorReviewTimer() {
       const reviewTimeSeconds = Math.round(elapsedMs / 1000);
 
       // Synchronize time spent reading directly to the PDF reading history tracker
-      if (isPdfNote && pdfRemId) {
-        await addPageToHistory(plugin, timerData.remId, pdfRemId, pdfControls.currentPage, reviewTimeSeconds);
+      // Record reading time against the host (PDF or HTML). Pages only apply
+      // to PDFs — pass null for HTML so the entry is page-less.
+      if (hostRemId) {
+        const pageArg = hostKind === 'pdf' ? pdfControls.currentPage : null;
+        await addPageToHistory(plugin, timerData.remId, hostRemId, pageArg, reviewTimeSeconds);
       }
 
       if (timerData.origin === 'queue') {
@@ -275,8 +303,11 @@ function EditorReviewTimer() {
 
       // Calculate review time and sync PDF page
       const reviewTimeSeconds = Math.round(elapsedMs / 1000);
-      if (isPdfNote && pdfRemId) {
-        await addPageToHistory(plugin, timerData.remId, pdfRemId, pdfControls.currentPage, reviewTimeSeconds);
+      // Record reading time against the host (PDF or HTML). Pages only apply
+      // to PDFs — pass null for HTML so the entry is page-less.
+      if (hostRemId) {
+        const pageArg = hostKind === 'pdf' ? pdfControls.currentPage : null;
+        await addPageToHistory(plugin, timerData.remId, hostRemId, pageArg, reviewTimeSeconds);
       }
 
       // Always create a new repetition, just like Mode 2
@@ -379,8 +410,11 @@ function EditorReviewTimer() {
       const reviewTimeSeconds = Math.round(elapsedMs / 1000);
 
       // Sync PDF page history if applicable
-      if (isPdfNote && pdfRemId) {
-        await addPageToHistory(plugin, timerData.remId, pdfRemId, pdfControls.currentPage, reviewTimeSeconds);
+      // Record reading time against the host (PDF or HTML). Pages only apply
+      // to PDFs — pass null for HTML so the entry is page-less.
+      if (hostRemId) {
+        const pageArg = hostKind === 'pdf' ? pdfControls.currentPage : null;
+        await addPageToHistory(plugin, timerData.remId, hostRemId, pageArg, reviewTimeSeconds);
       }
 
       const finalRep: IncrementalRep = {
@@ -524,24 +558,23 @@ function EditorReviewTimer() {
         </div>
       </div>
 
-      {isPdfNote && pdfRemId && (
+      {(isPdfNote || (hostRemId && bookmarkHighlightId)) && (
         <div style={{ display: 'flex', alignItems: 'center', gap: '8px', marginRight: '8px', paddingRight: '12px', borderRight: '1px solid #93c5fd' }}>
-          <PageControls
-            incrementalRemId={timerData.remId as any}
-            {...pdfControls}
-            totalPages={0}
-          />
-          {bookmarkHighlightId && (
+          {/* Page controls only apply to PDF hosts. */}
+          {isPdfNote && pdfRemId && (
+            <PageControls
+              incrementalRemId={timerData.remId as any}
+              {...pdfControls}
+              totalPages={0}
+            />
+          )}
+          {hostRemId && bookmarkHighlightId && (
             <button
               onClick={async () => {
-                // Open the PDF in a new pane (or focus existing) and scroll to bookmark
-                await openRemInNewPane(plugin, pdfRemId);
-                const bookmarkRem = await plugin.rem.findOne(bookmarkHighlightId);
-                if (bookmarkRem && typeof bookmarkRem.scrollToReaderHighlight === 'function') {
-                  setTimeout(() => {
-                    bookmarkRem.scrollToReaderHighlight();
-                  }, 400);
-                }
+                // openAndScrollToHighlight handles cold/warm open and survives
+                // the layout reorganization that destroys this widget's iframe
+                // on cold opens.
+                await openAndScrollToHighlight(plugin, hostRemId, bookmarkHighlightId);
               }}
               style={{
                 padding: '4px 10px',
@@ -562,7 +595,9 @@ function EditorReviewTimer() {
                 e.currentTarget.style.backgroundColor = 'transparent';
                 e.currentTarget.style.color = '#3b82f6';
               }}
-              title="Open PDF and scroll to your last bookmark position"
+              title={hostKind === 'html'
+                ? 'Open the article and scroll to your last bookmark position'
+                : 'Open PDF and scroll to your last bookmark position'}
             >
               🔖 Scroll
             </button>

--- a/src/widgets/page-range.tsx
+++ b/src/widgets/page-range.tsx
@@ -239,10 +239,16 @@ function PageRangeWidget() {
     if (currentPage && currentPage > 0) {
       page = currentPage;
     } else {
-      // Check if we have history for this rem
+      // Check if we have history for this rem (skip page-less HTML/text reader bookmarks)
       const history = remHistories[remId];
       if (history && history.length > 0) {
-        page = history[history.length - 1].page;
+        for (let i = history.length - 1; i >= 0; i--) {
+          const p = history[i].page;
+          if (typeof p === 'number') {
+            page = p;
+            break;
+          }
+        }
       }
     }
     setEditingState({ type: 'history', remId, page });
@@ -773,7 +779,7 @@ function PageRangeWidget() {
                   coverageInfo={item.childCoverage}
                   priorityInfo={remPriorities[item.remId]}
                   statistics={remStatistics[item.remId]}
-                  history={remHistories[item.remId]}
+                  history={remHistories[item.remId]?.filter((e): e is { page: number; timestamp: number; sessionDuration?: number; highlightId?: string } => typeof e.page === 'number')}
                   editingState={editingState}
                   onToggleExpanded={toggleExpanded}
                   onInitIncremental={handleInitIncrementalRem}

--- a/src/widgets/pdf_bookmark_popup.tsx
+++ b/src/widgets/pdf_bookmark_popup.tsx
@@ -1,6 +1,6 @@
 import { renderWidget, usePlugin, WidgetLocation, ReactRNPlugin } from '@remnote/plugin-sdk';
 import React, { useState, useEffect } from 'react';
-import { getPdfInfoFromHighlight, findAllRemsForPDF, findPDFinRem, addPageToHistory, getPageHistory, PageHistoryEntry, PageRangeContext, setIncrementalReadingPosition, getIncrementalPageRange, safeRemTextToString } from '../lib/pdfUtils';
+import { getPdfInfoFromHighlight, findAllRemsForPDF, findAllRemsForHTML, findPDFinRem, findHTMLinRem, isHtmlSource, addPageToHistory, getPageHistory, PageHistoryEntry, PageRangeContext, setIncrementalReadingPosition, getIncrementalPageRange, safeRemTextToString } from '../lib/pdfUtils';
 import { incrementalQueueActiveKey, currentIncRemKey, editorReviewTimerRemIdKey } from '../lib/consts';
 
 export function PdfBookmarkPopup() {
@@ -60,6 +60,12 @@ export function PdfBookmarkPopup() {
         setPageIndex(pIndex);
 
         if (docId) {
+          // Host kind: PDF (UploadedFile) or HTML (Link, non-YouTube). Used to
+          // dispatch between findPDFinRem / findHTMLinRem and findAllRemsForPDF
+          // / findAllRemsForHTML so that HTML IncRems are discoverable too.
+          const hostRem = await plugin.rem.findOne(docId);
+          const isHtmlHost = hostRem ? await isHtmlSource(hostRem) : false;
+
           // Queue detection: read current-inc-rem directly as the primary signal.
           // incrementalQueueActiveKey can get stuck false due to useEffect lifecycle
           // timing, but current-inc-rem is reliably set by setCurrentIncrementalRem
@@ -77,8 +83,12 @@ export function PdfBookmarkPopup() {
             const editorTimerRemId = await plugin.storage.getSession<string>(editorReviewTimerRemIdKey);
             if (editorTimerRemId) {
               const editorTimerRem = await plugin.rem.findOne(editorTimerRemId);
-              const foundPdf = editorTimerRem ? await findPDFinRem(plugin, editorTimerRem, docId) : null;
-              if (foundPdf && foundPdf._id === docId) {
+              const foundHost = editorTimerRem
+                ? (isHtmlHost
+                    ? await findHTMLinRem(plugin, editorTimerRem, docId)
+                    : await findPDFinRem(plugin, editorTimerRem, docId))
+                : null;
+              if (foundHost && foundHost._id === docId) {
                 activeRemId = editorTimerRemId;
                 activeSource = 'editor-timer';
               }
@@ -117,8 +127,12 @@ export function PdfBookmarkPopup() {
             // associatedRems stays [] — not rendered in fast-path mode anyway
 
           } else {
-            // 🐌 FULL PATH (non-queue): find all IncRems that read this PDF
-            const associated = (await findAllRemsForPDF(plugin, docId)).filter(a => a.isIncremental);
+            // 🐌 FULL PATH (non-queue): find all IncRems that read this host doc.
+            // For PDFs we get page-range hierarchy; for HTML the range concept
+            // doesn't apply and the list ends up flat (range stays null).
+            const associated = (await (isHtmlHost
+              ? findAllRemsForHTML(plugin, docId)
+              : findAllRemsForPDF(plugin, docId))).filter(a => a.isIncremental);
 
             // Fetch their page ranges to build hierarchy
             const associatedWithRanges = await Promise.all(

--- a/src/widgets/pdf_bookmark_popup.tsx
+++ b/src/widgets/pdf_bookmark_popup.tsx
@@ -193,10 +193,14 @@ export function PdfBookmarkPopup() {
   }, [plugin]);
 
   const saveBookmark = async (incrementalRemId: string) => {
-    if (!pdfRemId || pageIndex === null || !highlightRemId) return;
+    // Host doc and highlight are required; page is optional (null for HTML/Text Reader).
+    if (!pdfRemId || !highlightRemId) return;
     try {
       await addPageToHistory(plugin, incrementalRemId, pdfRemId, pageIndex, undefined, highlightRemId);
-      await setIncrementalReadingPosition(plugin, incrementalRemId, pdfRemId, pageIndex);
+      // Reading-position pointer only makes sense for paginated sources.
+      if (pageIndex !== null) {
+        await setIncrementalReadingPosition(plugin, incrementalRemId, pdfRemId, pageIndex);
+      }
       await plugin.app.toast('✅ Bookmark saved successfully');
     } catch (e) {
       await plugin.app.toast('❌ Failed to save bookmark');
@@ -216,8 +220,8 @@ export function PdfBookmarkPopup() {
     return <div style={{ padding: '8px', fontSize: '13px' }}>Loading...</div>;
   }
 
-  if (!pdfRemId || pageIndex === null) {
-    return <div style={{ padding: '8px', fontSize: '13px', color: 'var(--rn-clr-content-secondary)' }}>No page context found.</div>;
+  if (!pdfRemId) {
+    return <div style={{ padding: '8px', fontSize: '13px', color: 'var(--rn-clr-content-secondary)' }}>No reader context found.</div>;
   }
 
   return (
@@ -230,7 +234,9 @@ export function PdfBookmarkPopup() {
     }}>
       <div style={{ marginBottom: '12px', paddingBottom: '8px', borderBottom: '1px solid var(--rn-clr-border-primary)', fontWeight: 600, display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
         <span>🔖 Bookmark Position</span>
-        <span style={{ fontSize: '12px', color: 'var(--rn-clr-content-secondary)' }}>Page {pageIndex}</span>
+        {pageIndex !== null && (
+          <span style={{ fontSize: '12px', color: 'var(--rn-clr-content-secondary)' }}>Page {pageIndex}</span>
+        )}
       </div>
 
       {activeQueueContext && (
@@ -344,7 +350,7 @@ export function PdfBookmarkPopup() {
                               onMouseOut={(e) => e.currentTarget.style.backgroundColor = 'var(--rn-clr-background-secondary)'}
                             >
                               <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-                                <span>📄 Page {entry.page}</span>
+                                <span>{typeof entry.page === 'number' ? `📄 Page ${entry.page}` : '🔖 Bookmark'}</span>
                                 <span style={{ color: 'var(--rn-clr-content-tertiary)', fontSize: '10px', fontWeight: 400 }}>{new Date(entry.timestamp).toLocaleDateString()}</span>
                               </div>
                               {entry.highlightId && highlightTexts[entry.highlightId] && (
@@ -389,7 +395,7 @@ export function PdfBookmarkPopup() {
                               onMouseOver={(e) => e.currentTarget.style.backgroundColor = 'var(--rn-clr-background-modifier-hover)'}
                               onMouseOut={(e) => e.currentTarget.style.backgroundColor = 'transparent'}
                             >
-                              <span>Page {entry.page}</span>
+                              <span>{typeof entry.page === 'number' ? `Page ${entry.page}` : 'Bookmark'}</span>
                               <span style={{ fontSize: '9px', color: 'var(--rn-clr-content-tertiary)' }}>{new Date(entry.timestamp).toLocaleDateString()}</span>
                             </button>
                           ))}

--- a/src/widgets/priority_editor.tsx
+++ b/src/widgets/priority_editor.tsx
@@ -15,6 +15,7 @@ import { updateCardPriorityCache } from '../lib/card_priority/cache';
 import { PriorityBadge } from '../components';
 import {
   findPreferredPDFInRem,
+  findHTMLinRem,
   getIncrementalPageRange,
   getPageHistory,
   getReadingStatistics,
@@ -81,25 +82,40 @@ export function PriorityEditor() {
         findPreferredPDFInRem(plugin as any, rem, false),
       ]);
 
-      // Fetch PDF range / history / stats if a PDF source was found
+      // Fetch host (PDF or HTML) range / history / stats. PDFs get a page-range
+      // panel; HTML hosts only get a bookmark/history panel since pages don't
+      // apply. The state name `pdfRemId` is kept for backwards compat — it now
+      // stores either a PDF or an HTML host id.
       let pdfRemId: string | null = null;
       let pdfRemName: string | null = null;
       let pdfRange: { start: number; end: number | null } | null = null;
       let pdfHistory: PageHistoryEntry[] = [];
       let pdfStats: any = null;
-      if (pdfRem) {
-        pdfRemId = pdfRem._id;
-        pdfRemName = pdfRem.text ? await safeRemTextToString(plugin as any, pdfRem.text) : null;
+      let hostKind: 'pdf' | 'html' | null = null;
+
+      let hostRem: typeof pdfRem = pdfRem;
+      if (!hostRem) {
+        // Fall back to HTML host (Reader Mode source) for non-PDF IncRems.
+        hostRem = await findHTMLinRem(plugin as any, rem);
+      }
+
+      if (hostRem) {
+        hostKind = pdfRem ? 'pdf' : 'html';
+        pdfRemId = hostRem._id;
+        pdfRemName = hostRem.text ? await safeRemTextToString(plugin as any, hostRem.text) : null;
         const [range, history, stats] = await Promise.all([
-          getIncrementalPageRange(plugin as any, rem._id, pdfRem._id),
-          getPageHistory(plugin as any, rem._id, pdfRem._id),
-          getReadingStatistics(plugin as any, rem._id, pdfRem._id),
+          // Range only applies to PDFs.
+          hostKind === 'pdf'
+            ? getIncrementalPageRange(plugin as any, rem._id, hostRem._id)
+            : Promise.resolve(null),
+          getPageHistory(plugin as any, rem._id, hostRem._id),
+          getReadingStatistics(plugin as any, rem._id, hostRem._id),
         ]);
         pdfRange = range;
         pdfHistory = history;
         pdfStats = stats;
-        console.log('[PriorityEditor] Fetched pdfHistory',
-          { incRemId: rem._id, pdfRemId: pdfRem._id, historyLength: history.length, lastEntry: history[history.length - 1] });
+        console.log('[PriorityEditor] Fetched host history',
+          { incRemId: rem._id, hostRemId: hostRem._id, hostKind, historyLength: history.length, lastEntry: history[history.length - 1] });
       }
 
       // Calculate relative priorities inline
@@ -126,6 +142,7 @@ export function PriorityEditor() {
         pdfRange,
         pdfHistory,
         pdfStats,
+        hostKind,
       };
     },
     [remId, refreshSignal]
@@ -274,7 +291,7 @@ export function PriorityEditor() {
           {showCardEditor && (
             <PriorityBadge priority={cardInfo?.priority ?? 50} percentile={cardRelativePriority ?? undefined} compact source={cardInfo?.source} isCardPriority={true} />
           )}
-          {remData?.pdfRemId && (
+          {remData?.hostKind === 'pdf' && remData?.pdfRemId && (
             <span
               title={remData.pdfRange ? `PDF: p.${remData.pdfRange.start}–${remData.pdfRange.end || '∞'}` : 'PDF source — no range set'}
               style={{
@@ -307,6 +324,25 @@ export function PriorityEditor() {
               ) : ' —'}
             </span>
           )}
+          {remData?.hostKind === 'html' && remData?.pdfRemId && (() => {
+            const last = remData.pdfHistory?.[remData.pdfHistory.length - 1];
+            const hasBookmark = !!last?.highlightId;
+            return (
+              <span
+                title={hasBookmark ? 'Web source — saved bookmark' : 'Web source'}
+                style={{
+                  fontSize: '10px',
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  gap: 2,
+                  color: 'var(--rn-clr-content-secondary)',
+                  whiteSpace: 'nowrap',
+                }}
+              >
+                🌐{hasBookmark && <span style={{ color: '#10b981', marginLeft: '2px' }}>🔖</span>}
+              </span>
+            );
+          })()}
         </div>
       ) : (
         <div className="flex flex-col gap-3">
@@ -454,7 +490,7 @@ export function PriorityEditor() {
           )}
 
           {/* PDF Range Section */}
-          {remData?.pdfRemId && (
+          {remData?.hostKind === 'pdf' && remData?.pdfRemId && (
             <div
               className="p-3 rounded-lg"
               style={{
@@ -664,6 +700,80 @@ export function PriorityEditor() {
               >
                 PDF Control Panel ↗
               </button>
+            </div>
+          )}
+
+          {/* Web Source Section (HTML hosts) — minimal panel: name + bookmark
+              info + Scroll to Position. No range / page editing because HTML
+              articles aren't paginated. */}
+          {remData?.hostKind === 'html' && remData?.pdfRemId && (
+            <div
+              className="p-3 rounded-lg"
+              style={{
+                backgroundColor: 'var(--rn-clr-background-secondary)',
+                border: '1px solid var(--rn-clr-border-primary)',
+              }}
+            >
+              <div className="flex items-center justify-between mb-2">
+                <div className="flex items-center gap-1.5">
+                  <span className="text-xs">🌐</span>
+                  <span className="text-xs font-semibold" style={{ color: 'var(--rn-clr-content-primary)' }}>Web Source</span>
+                  {remData.pdfRemName && (
+                    <span className="text-[10px] truncate max-w-[140px]" style={{ color: 'var(--rn-clr-content-tertiary)' }}
+                      title={remData.pdfRemName}>{remData.pdfRemName}</span>
+                  )}
+                </div>
+              </div>
+
+              {/* Stats + last bookmark */}
+              {(remData.pdfStats?.totalTimeSeconds > 0 || remData.pdfHistory?.length > 0) && (
+                <div className="mt-1 flex items-center gap-3 flex-wrap">
+                  {remData.pdfStats?.totalTimeSeconds > 0 && (
+                    <span className="text-[10px]" style={{ color: '#10b981' }}
+                      title="Total reading time">⏱️{formatDuration(remData.pdfStats.totalTimeSeconds)}</span>
+                  )}
+                  {remData.pdfHistory?.length > 0 && (() => {
+                    const last = remData.pdfHistory[remData.pdfHistory.length - 1];
+                    if (!last.highlightId) return null;
+                    return (
+                      <span className="text-[10px]" style={{ color: 'var(--rn-clr-content-tertiary)' }}
+                        title="Last: bookmark with no page info">
+                        Last 🔖
+                      </span>
+                    );
+                  })()}
+                </div>
+              )}
+
+              {/* Scroll to Bookmark — same logic as the PDF panel: only when the
+                  LAST history entry carries a highlightId. */}
+              {(() => {
+                const history = remData.pdfHistory ?? [];
+                const lastEntry = history[history.length - 1];
+                const bookmarkHighlightId = lastEntry?.highlightId;
+                if (!bookmarkHighlightId) return null;
+                return (
+                  <button
+                    onClick={async () => {
+                      if (remData.pdfRemId) {
+                        await openAndScrollToHighlight(plugin, remData.pdfRemId, bookmarkHighlightId);
+                      } else {
+                        const bookmarkRem = await plugin.rem.findOne(bookmarkHighlightId);
+                        bookmarkRem?.scrollToReaderHighlight();
+                      }
+                    }}
+                    className="w-full mt-2 py-1 rounded text-[11px] font-semibold transition-colors"
+                    style={{
+                      backgroundColor: 'var(--rn-clr-background-secondary)',
+                      color: 'var(--rn-clr-blue, #3b82f6)',
+                      border: '2px solid var(--rn-clr-blue, #3b82f6)',
+                    }}
+                    title="Scroll to Bookmark: Open the article and jump to your last saved reading position"
+                  >
+                    🔖 Scroll to Position
+                  </button>
+                );
+              })()}
             </div>
           )}
 

--- a/src/widgets/priority_editor.tsx
+++ b/src/widgets/priority_editor.tsx
@@ -290,11 +290,19 @@ export function PriorityEditor() {
               📄{remData.pdfRange ? (
                 <>
                   {` p.${remData.pdfRange.start}–${remData.pdfRange.end || '∞'}`}
-                  {remData.pdfHistory && remData.pdfHistory.length > 0 && (
-                    <span style={{ color: '#10b981', marginLeft: '2px' }}>
-                      ({remData.pdfHistory[remData.pdfHistory.length - 1].page})
-                    </span>
-                  )}
+                  {(() => {
+                    const last = remData.pdfHistory?.[remData.pdfHistory.length - 1];
+                    if (!last) return null;
+                    const hasPage = typeof last.page === 'number';
+                    if (!hasPage && !last.highlightId) return null;
+                    return (
+                      <span style={{ color: '#10b981', marginLeft: '2px' }}>
+                        {hasPage && `(${last.page})`}
+                        {hasPage && last.highlightId && ' '}
+                        {last.highlightId && '🔖'}
+                      </span>
+                    );
+                  })()}
                 </>
               ) : ' —'}
             </span>
@@ -468,11 +476,19 @@ export function PriorityEditor() {
                   <span className="text-[10px] px-1.5 py-0.5 rounded font-medium"
                     style={{ backgroundColor: 'var(--rn-clr-background-primary)', color: 'var(--rn-clr-content-secondary)', whiteSpace: 'nowrap' }}>
                     p.{remData.pdfRange.start}–{remData.pdfRange.end || '∞'}
-                    {remData.pdfHistory && remData.pdfHistory.length > 0 && (
-                      <span style={{ color: '#10b981', marginLeft: '2px' }}>
-                        ({remData.pdfHistory[remData.pdfHistory.length - 1].page})
-                      </span>
-                    )}
+                    {(() => {
+                      const last = remData.pdfHistory?.[remData.pdfHistory.length - 1];
+                      if (!last) return null;
+                      const hasPage = typeof last.page === 'number';
+                      if (!hasPage && !last.highlightId) return null;
+                      return (
+                        <span style={{ color: '#10b981', marginLeft: '2px' }}>
+                          {hasPage && `(${last.page})`}
+                          {hasPage && last.highlightId && ' '}
+                          {last.highlightId && '🔖'}
+                        </span>
+                      );
+                    })()}
                   </span>
                 ) : (
                   <span className="text-[10px]" style={{ color: 'var(--rn-clr-content-tertiary)', opacity: 0.6 }}>No range</span>
@@ -586,12 +602,20 @@ export function PriorityEditor() {
                     <span className="text-[10px]" style={{ color: '#10b981' }}
                       title="Total reading time">⏱️{formatDuration(remData.pdfStats.totalTimeSeconds)}</span>
                   )}
-                  {remData.pdfHistory?.length > 0 && (
-                    <span className="text-[10px]" style={{ color: 'var(--rn-clr-content-tertiary)' }}
-                      title={`Last: page ${remData.pdfHistory[remData.pdfHistory.length - 1].page}`}>
-                      Last p.{remData.pdfHistory[remData.pdfHistory.length - 1].page}
-                    </span>
-                  )}
+                  {remData.pdfHistory?.length > 0 && (() => {
+                    const last = remData.pdfHistory[remData.pdfHistory.length - 1];
+                    const hasPage = typeof last.page === 'number';
+                    if (!hasPage && !last.highlightId) return null;
+                    const tooltip = hasPage
+                      ? `Last: page ${last.page}${last.highlightId ? ' (auto-scrollable bookmark)' : ''}`
+                      : 'Last: bookmark with no page info';
+                    return (
+                      <span className="text-[10px]" style={{ color: 'var(--rn-clr-content-tertiary)' }}
+                        title={tooltip}>
+                        Last {hasPage ? `p.${last.page}` : ''}{hasPage && last.highlightId ? ' ' : ''}{last.highlightId ? '🔖' : ''}
+                      </span>
+                    );
+                  })()}
                 </div>
               )}
 

--- a/src/widgets/priority_editor.tsx
+++ b/src/widgets/priority_editor.tsx
@@ -24,7 +24,7 @@ import {
   safeRemTextToString,
   PageHistoryEntry,
 } from '../lib/pdfUtils';
-import { openRemInNewPane } from '../lib/remHelpers';
+import { openAndScrollToHighlight } from '../lib/remHelpers';
 
 // Move styles outside component to avoid recreation on every render
 const adjustButtonStyle: React.CSSProperties = {
@@ -630,20 +630,16 @@ export function PriorityEditor() {
                 return (
                   <button
                     onClick={async () => {
-                      const bookmarkRem = await plugin.rem.findOne(bookmarkHighlightId);
-                      if (!bookmarkRem) return;
-
-                      // scrollToReaderHighlight is a no-op unless a PDF reader is
-                      // already mounted. Open the PDF rem in a NEW pane (to the
-                      // right) so the reader exists without closing the IncRem
-                      // view the user was looking at. Then scroll once mounted.
+                      // openAndScrollToHighlight handles cold-open vs warm-open:
+                      // polls for the pane to mount, then retries the scroll
+                      // through PDF.js's boot window so a single click works
+                      // even when the PDF was previously closed.
                       if (remData.pdfRemId) {
-                        await openRemInNewPane(plugin, remData.pdfRemId);
+                        await openAndScrollToHighlight(plugin, remData.pdfRemId, bookmarkHighlightId);
+                      } else {
+                        const bookmarkRem = await plugin.rem.findOne(bookmarkHighlightId);
+                        bookmarkRem?.scrollToReaderHighlight();
                       }
-
-                      setTimeout(() => {
-                        bookmarkRem.scrollToReaderHighlight();
-                      }, 400);
                     }}
                     className="w-full mt-2 py-1 rounded text-[11px] font-semibold transition-colors"
                     style={{

--- a/src/widgets/priority_editor.tsx
+++ b/src/widgets/priority_editor.tsx
@@ -291,39 +291,45 @@ export function PriorityEditor() {
           {showCardEditor && (
             <PriorityBadge priority={cardInfo?.priority ?? 50} percentile={cardRelativePriority ?? undefined} compact source={cardInfo?.source} isCardPriority={true} />
           )}
-          {remData?.hostKind === 'pdf' && remData?.pdfRemId && (
-            <span
-              title={remData.pdfRange ? `PDF: p.${remData.pdfRange.start}–${remData.pdfRange.end || '∞'}` : 'PDF source — no range set'}
-              style={{
-                fontSize: '10px',
-                display: 'inline-flex',
-                alignItems: 'center',
-                gap: 2,
-                color: remData.pdfRange ? 'var(--rn-clr-content-secondary)' : 'var(--rn-clr-content-tertiary)',
-                opacity: remData.pdfRange ? 1 : 0.55,
-                whiteSpace: 'nowrap',
-              }}
-            >
-              📄{remData.pdfRange ? (
-                <>
-                  {` p.${remData.pdfRange.start}–${remData.pdfRange.end || '∞'}`}
-                  {(() => {
-                    const last = remData.pdfHistory?.[remData.pdfHistory.length - 1];
-                    if (!last) return null;
-                    const hasPage = typeof last.page === 'number';
-                    if (!hasPage && !last.highlightId) return null;
-                    return (
-                      <span style={{ color: '#10b981', marginLeft: '2px' }}>
-                        {hasPage && `(${last.page})`}
-                        {hasPage && last.highlightId && ' '}
-                        {last.highlightId && '🔖'}
-                      </span>
-                    );
-                  })()}
-                </>
-              ) : ' —'}
-            </span>
-          )}
+          {remData?.hostKind === 'pdf' && remData?.pdfRemId && (() => {
+            const last = remData.pdfHistory?.[remData.pdfHistory.length - 1];
+            const hasPage = typeof last?.page === 'number';
+            const hasBookmark = !!last?.highlightId;
+            const hasRange = !!remData.pdfRange;
+            const hasAnyState = hasRange || hasPage || hasBookmark;
+            const titleParts = [
+              hasRange ? `p.${remData.pdfRange!.start}–${remData.pdfRange!.end || '∞'}` : null,
+              hasBookmark ? 'saved bookmark' : null,
+            ].filter(Boolean);
+            const title = titleParts.length > 0
+              ? `PDF: ${titleParts.join(' · ')}`
+              : 'PDF source — no range set';
+            return (
+              <span
+                title={title}
+                style={{
+                  fontSize: '10px',
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  gap: 2,
+                  color: hasAnyState ? 'var(--rn-clr-content-secondary)' : 'var(--rn-clr-content-tertiary)',
+                  opacity: hasAnyState ? 1 : 0.55,
+                  whiteSpace: 'nowrap',
+                }}
+              >
+                📄
+                {hasRange && ` p.${remData.pdfRange!.start}–${remData.pdfRange!.end || '∞'}`}
+                {(hasPage || hasBookmark) && (
+                  <span style={{ color: '#10b981', marginLeft: '2px' }}>
+                    {hasPage && `(${last!.page})`}
+                    {hasPage && hasBookmark && ' '}
+                    {hasBookmark && '🔖'}
+                  </span>
+                )}
+                {!hasAnyState && ' —'}
+              </span>
+            );
+          })()}
           {remData?.hostKind === 'html' && remData?.pdfRemId && (() => {
             const last = remData.pdfHistory?.[remData.pdfHistory.length - 1];
             const hasBookmark = !!last?.highlightId;

--- a/src/widgets/toggle_incremental_toolbar.tsx
+++ b/src/widgets/toggle_incremental_toolbar.tsx
@@ -88,11 +88,15 @@ export function ToggleIncrementalToolbar() {
         }
       }
 
-      // 4. Save bookmark position safely to identified context
-      if (contextRemId && docId && pageIndex !== null) {
+      // 4. Save bookmark position safely to identified context.
+      //    pageIndex is null for HTML / PDF Text Reader highlights — we still
+      //    want to record the bookmark by highlight rem id so jumps work.
+      if (contextRemId && docId) {
         try {
           await addPageToHistory(plugin as any, contextRemId, docId, pageIndex, undefined, rem._id);
-          await setIncrementalReadingPosition(plugin as any, contextRemId, docId, pageIndex);
+          if (pageIndex !== null) {
+            await setIncrementalReadingPosition(plugin as any, contextRemId, docId, pageIndex);
+          }
           await plugin.app.toast('✅ Tagged & bookmark updated');
         } catch (e) {
           console.error('Error creating bookmark for toggle_incremental_toolbar', e);


### PR DESCRIPTION
## v0.2.189 - April 28th, 2026

- The **Bookmark** feature can now save and retrieve bookmarks in the **Text Reader** mode (PDFs) and **HTML Rem** as well.
- Enhanced the **Editor Toolbar** integration with the bookmark and page controls.
- When Reviewing in Editor using the Ctrl+Shift+J command, the IncRem PDF or HTML source is now opened in a new pane to the right, and scrolls to the last bookmarked highlight; a "Scroll" button is also available.
