### PR TITLE
Sorting Criteria is now Knowledge-Base Dependent, Practiced Queues Incremental Rem Tracking improvement

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -7,7 +7,7 @@
   "version": {
     "major": 0,
     "minor": 2,
-    "patch": 193
+    "patch": 194
   },
   "unlisted": false,
   "theme": [],

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -7,7 +7,7 @@
   "version": {
     "major": 0,
     "minor": 2,
-    "patch": 192
+    "patch": 193
   },
   "unlisted": false,
   "theme": [],

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -7,7 +7,7 @@
   "version": {
     "major": 0,
     "minor": 2,
-    "patch": 190
+    "patch": 191
   },
   "unlisted": false,
   "theme": [],

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -7,7 +7,7 @@
   "version": {
     "major": 0,
     "minor": 2,
-    "patch": 189
+    "patch": 190
   },
   "unlisted": false,
   "theme": [],

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -7,7 +7,7 @@
   "version": {
     "major": 0,
     "minor": 2,
-    "patch": 191
+    "patch": 192
   },
   "unlisted": false,
   "theme": [],

--- a/src/lib/card_priority/cache.ts
+++ b/src/lib/card_priority/cache.ts
@@ -1,7 +1,7 @@
 import { RNPlugin, RemId } from '@remnote/plugin-sdk';
 import { allCardPriorityInfoKey, cardPriorityCacheRefreshKey } from '../consts';
 import { CardPriorityInfo, PrioritySource } from './types';
-import { getCardPriority, autoAssignCardPriority } from './index';
+import { getCardPriority, calculateNewPriority, setCardPriority } from './index';
 import * as _ from 'remeda';
 
 let cacheUpdateTimer: ReturnType<typeof setTimeout> | null = null;
@@ -395,7 +395,8 @@ async function processDeferredCardPriorityCache(plugin: RNPlugin, untaggedRemIds
               return;
             }
 
-            await autoAssignCardPriority(plugin, rem);
+            const calculated = await calculateNewPriority(plugin, rem);
+            await setCardPriority(plugin, rem, calculated.priority, calculated.source);
 
             const cardInfo = await getCardPriority(plugin, rem);
             if (cardInfo) {

--- a/src/lib/consts.ts
+++ b/src/lib/consts.ts
@@ -68,6 +68,7 @@ export const seenRemInSessionKey = 'seen-rem-in-session-key';
 export const seenCardInSessionKey = 'seen-card-in-session-key';
 export const displayPriorityShieldId = 'display-priority-shield';
 export const displayQueueToolbarPriorityId = 'display-queue-toolbar-priority';
+export const autoFocusQueueDashboardId = 'auto-focus-queue-dashboard';
 export const priorityShieldHistoryKey = 'priority-shield-history-key';
 export const priorityShieldHistoryMenuItemId = 'priority-shield-history-menu-item-id';
 export const documentPriorityShieldHistoryKey = 'document-priority-shield-history-key';

--- a/src/lib/queue_session.ts
+++ b/src/lib/queue_session.ts
@@ -1,10 +1,11 @@
 import {
   AppEvents,
   QueueInteractionScore,
-  QueueItemType,
   ReactRNPlugin,
+  RNPlugin,
 } from '@remnote/plugin-sdk';
 import { safeRemTextToString } from './pdfUtils';
+import { autoFocusQueueDashboardId } from './consts';
 import type { PracticedQueueSession } from '../widgets/practiced_queues';
 
 const PRACTICED_QUEUES_HISTORY_KEY = 'practicedQueuesHistory';
@@ -12,21 +13,211 @@ const ACTIVE_SESSION_KEY = 'activeQueueSession';
 const FLASHCARD_RESPONSE_TIME_LIMIT_SETTING = 'flashcard_response_time_limit';
 const DEFAULT_RESPONSE_TIME_LIMIT_SEC = 180;
 
+// Editor-only IncRem sessions auto-close after this much idle time so a row
+// is recorded for the burst of activity. Cleared/rescheduled on every
+// engagement and rep tick. See startIncRemEngagement / recordIncRemRep.
+const EDITOR_SESSION_IDLE_MS = 60 * 60 * 1000;
+const EDITOR_REVIEW_SCOPE = 'Editor Review';
+
 let currentSession: PracticedQueueSession | null = null;
 const cardStartTimes = new Map<string, number>();
-let currentIncRemStart: number | null = null;
 
-async function syncLiveSession(plugin: ReactRNPlugin) {
+// Open IncRem engagement timer. Replaces the old currentIncRemStart variable
+// and is now driven by explicit start/end calls from the IncRem rendering
+// surfaces (queue widget, editor timer) rather than inferred from QueueLoadCard.
+let incRemEngagementStart: number | null = null;
+let incRemEngagementRemId: string | null = null;
+
+// Set by markIncRemTransition() right before a queue→editor handoff. Tells the
+// next startIncRemEngagement(remId) to skip the count++ so a single IncRem
+// reviewed across queue + editor counts as one rep with combined time.
+let incRemTransitionFlag: string | null = null;
+
+let editorIncRemIdleTimer: ReturnType<typeof setTimeout> | null = null;
+
+async function syncLiveSession(plugin: RNPlugin) {
   await plugin.storage.setSession(ACTIVE_SESSION_KEY, currentSession);
 }
 
-export async function saveCurrentSession(plugin: ReactRNPlugin, _reason: string) {
+function clearEditorIdleSave() {
+  if (editorIncRemIdleTimer) {
+    clearTimeout(editorIncRemIdleTimer);
+    editorIncRemIdleTimer = null;
+  }
+}
+
+function scheduleEditorIdleSave(plugin: RNPlugin) {
+  if (!currentSession || currentSession.scopeName !== EDITOR_REVIEW_SCOPE) return;
+  clearEditorIdleSave();
+  editorIncRemIdleTimer = setTimeout(() => {
+    if (currentSession?.scopeName === EDITOR_REVIEW_SCOPE) {
+      saveCurrentSession(plugin, 'Editor Review Idle Timeout').catch((err) =>
+        console.error('Failed to auto-save editor IncRem session:', err)
+      );
+    }
+  }, EDITOR_SESSION_IDLE_MS);
+}
+
+async function ensureSessionForIncRem(plugin: RNPlugin) {
+  if (currentSession) return;
+  try {
+    const kbData = await plugin.kb.getCurrentKnowledgeBaseData();
+    currentSession = {
+      id: Math.random().toString(36).substring(7),
+      startTime: Date.now(),
+      kbId: kbData._id,
+      scopeName: EDITOR_REVIEW_SCOPE,
+      totalTime: 0,
+      flashcardsCount: 0,
+      flashcardsTime: 0,
+      incRemsCount: 0,
+      incRemsTime: 0,
+      againCount: 0,
+      currentCardFirstRep: undefined,
+    };
+    await syncLiveSession(plugin);
+  } catch (err) {
+    console.error('Failed to lazily create Editor Review session:', err);
+  }
+}
+
+async function maybeAdoptScopeFromRem(plugin: RNPlugin, remId: string) {
+  if (!currentSession) return;
+  const generic =
+    !currentSession.scopeName ||
+    currentSession.scopeName === 'Untitled' ||
+    currentSession.scopeName === 'Ad-hoc Queue' ||
+    currentSession.scopeName === 'Ad-hoc Session' ||
+    currentSession.scopeName === EDITOR_REVIEW_SCOPE;
+  if (!generic) return;
+  const rem = await plugin.rem.findOne(remId);
+  if (rem?.text) {
+    const text = await safeRemTextToString(plugin, rem.text);
+    if (text && text !== 'Untitled') currentSession.scopeName = text;
+  }
+}
+
+// ─── Widget→main IncRem signaling ──────────────────────────────────────────────
+// Widgets run in sandboxed iframes, so they cannot mutate this module's
+// `currentSession` directly — their import of this file gets a separate
+// in-iframe copy. To bridge that, the public helpers (start/end engagement,
+// record rep, mark transition) push events to a session-storage log, and
+// registerQueueSessionTracking (which runs in the main process) polls and
+// drains that log into the real `currentSession`.
+//
+// Pattern mirrors the existing card_priority_display → cluster-sibling poll.
+
+const INC_REM_EVENT_LOG_KEY = 'ieIncRemEventLog';
+
+type IncRemEvent =
+  | { type: 'start'; remId: string; ts: number }
+  | { type: 'end'; ts: number }
+  | { type: 'rep'; remId: string; durationMs: number; ts: number }
+  | { type: 'transition'; remId: string; ts: number };
+
+async function pushIncRemEvent(plugin: RNPlugin, event: IncRemEvent) {
+  const log = ((await plugin.storage.getSession<IncRemEvent[]>(INC_REM_EVENT_LOG_KEY)) || []).slice();
+  log.push(event);
+  await plugin.storage.setSession(INC_REM_EVENT_LOG_KEY, log);
+}
+
+export function markIncRemTransition(plugin: RNPlugin, remId: string) {
+  // Fire-and-forget: handleReviewInEditorRem callers don't await this
+  // historically, and the next polled drain will pick it up anyway.
+  pushIncRemEvent(plugin, { type: 'transition', remId, ts: Date.now() }).catch((err) =>
+    console.error('Failed to push IncRem transition event:', err)
+  );
+}
+
+export async function startIncRemEngagement(plugin: RNPlugin, remId: string) {
+  await pushIncRemEvent(plugin, { type: 'start', remId, ts: Date.now() });
+}
+
+export async function endIncRemEngagement(plugin: RNPlugin) {
+  await pushIncRemEvent(plugin, { type: 'end', ts: Date.now() });
+}
+
+export async function recordIncRemRep(plugin: RNPlugin, remId: string, durationMs: number) {
+  await pushIncRemEvent(plugin, { type: 'rep', remId, durationMs, ts: Date.now() });
+}
+
+// ─── Main-process apply functions (only called by the poll) ────────────────────
+
+async function applyIncRemEngagementStart(
+  plugin: RNPlugin,
+  remId: string,
+  startTs: number
+) {
+  await ensureSessionForIncRem(plugin);
+  if (!currentSession) return;
+
+  // Already engaged with this rem (e.g., widget re-render): keep timer.
+  if (incRemEngagementRemId === remId && incRemEngagementStart !== null) {
+    return;
+  }
+
+  // Engaged with a different rem: close that engagement first (time only).
+  if (incRemEngagementStart !== null) {
+    const duration = Math.max(0, startTs - incRemEngagementStart);
+    currentSession.incRemsTime += duration;
+    currentSession.totalTime += duration;
+    incRemEngagementStart = null;
+    incRemEngagementRemId = null;
+  }
+
+  const isTransition = incRemTransitionFlag === remId;
+  incRemTransitionFlag = null;
+
+  if (!isTransition) {
+    currentSession.incRemsCount++;
+    await maybeAdoptScopeFromRem(plugin, remId);
+  }
+
+  incRemEngagementStart = startTs;
+  incRemEngagementRemId = remId;
+
+  scheduleEditorIdleSave(plugin);
+  await syncLiveSession(plugin);
+}
+
+async function applyIncRemEngagementEnd(plugin: RNPlugin, endTs: number) {
+  if (!currentSession || incRemEngagementStart === null) return;
+  const duration = Math.max(0, endTs - incRemEngagementStart);
+  currentSession.incRemsTime += duration;
+  currentSession.totalTime += duration;
+  incRemEngagementStart = null;
+  incRemEngagementRemId = null;
+
+  scheduleEditorIdleSave(plugin);
+  await syncLiveSession(plugin);
+}
+
+async function applyIncRemRep(
+  plugin: RNPlugin,
+  remId: string,
+  durationMs: number
+) {
+  await ensureSessionForIncRem(plugin);
+  if (!currentSession) return;
+
+  currentSession.incRemsCount++;
+  if (durationMs > 0) {
+    currentSession.incRemsTime += durationMs;
+    currentSession.totalTime += durationMs;
+  }
+  await maybeAdoptScopeFromRem(plugin, remId);
+
+  scheduleEditorIdleSave(plugin);
+  await syncLiveSession(plugin);
+}
+
+export async function saveCurrentSession(plugin: RNPlugin, _reason: string) {
   if (!currentSession) return;
 
   currentSession.endTime = Date.now();
 
-  if (currentIncRemStart) {
-    currentSession.incRemsTime += Date.now() - currentIncRemStart;
+  if (incRemEngagementStart !== null) {
+    currentSession.incRemsTime += Date.now() - incRemEngagementStart;
   }
   currentSession.totalTime = currentSession.flashcardsTime + currentSession.incRemsTime;
 
@@ -38,7 +229,10 @@ export async function saveCurrentSession(plugin: ReactRNPlugin, _reason: string)
 
   currentSession = null;
   cardStartTimes.clear();
-  currentIncRemStart = null;
+  incRemEngagementStart = null;
+  incRemEngagementRemId = null;
+  incRemTransitionFlag = null;
+  clearEditorIdleSave();
   await plugin.storage.setSession(ACTIVE_SESSION_KEY, null);
   await plugin.storage.setSession('finalDrillHeartbeat', 0);
 }
@@ -52,7 +246,7 @@ export function hasActiveSession(): boolean {
  * repetitionHistory. Used by both QueueLoadCard and the cluster-sibling poll.
  */
 async function loadCardStats(
-  plugin: ReactRNPlugin,
+  plugin: RNPlugin,
   session: PracticedQueueSession,
   cardId: string
 ) {
@@ -124,6 +318,31 @@ export function registerQueueSessionTracking(plugin: ReactRNPlugin) {
     }
   }, 500);
 
+  // IncRem event-log drain: widgets push start/end/rep/transition events to
+  // session storage (see pushIncRemEvent above). Poll, drain, apply in order.
+  // Read-clear-process: a widget appending between read and write loses that
+  // event, but the race window is sub-millisecond — acceptable.
+  setInterval(async () => {
+    try {
+      const log = await plugin.storage.getSession<IncRemEvent[]>(INC_REM_EVENT_LOG_KEY);
+      if (!log || log.length === 0) return;
+      await plugin.storage.setSession(INC_REM_EVENT_LOG_KEY, []);
+      for (const event of log) {
+        if (event.type === 'start') {
+          await applyIncRemEngagementStart(plugin, event.remId, event.ts);
+        } else if (event.type === 'end') {
+          await applyIncRemEngagementEnd(plugin, event.ts);
+        } else if (event.type === 'rep') {
+          await applyIncRemRep(plugin, event.remId, event.durationMs);
+        } else if (event.type === 'transition') {
+          incRemTransitionFlag = event.remId;
+        }
+      }
+    } catch (error) {
+      console.error('ERROR in IncRem event-log drain poll:', error);
+    }
+  }, 250);
+
   plugin.event.addListener(AppEvents.QueueEnter, undefined, async (data: any) => {
     try {
       if (currentSession) {
@@ -167,7 +386,21 @@ export function registerQueueSessionTracking(plugin: ReactRNPlugin) {
 
       await syncLiveSession(plugin);
       cardStartTimes.clear();
-      currentIncRemStart = null;
+      incRemEngagementStart = null;
+      incRemEngagementRemId = null;
+      incRemTransitionFlag = null;
+      clearEditorIdleSave();
+
+      // Auto-focus the Practiced Queues dashboard in the right sidebar so the
+      // user always has a live session view while reviewing. Opt-in via setting.
+      const autoFocus = await plugin.settings.getSetting<boolean>(autoFocusQueueDashboardId);
+      if (autoFocus) {
+        try {
+          await plugin.window.openWidgetInRightSidebar('practiced_queues');
+        } catch (err) {
+          console.error('Failed to auto-focus Practiced Queues dashboard:', err);
+        }
+      }
     } catch (error) {
       console.error('ERROR in QueueSession QueueEnter listener:', error);
     }
@@ -188,7 +421,6 @@ export function registerQueueSessionTracking(plugin: ReactRNPlugin) {
   plugin.event.addListener(AppEvents.QueueLoadCard, undefined, async (data: any) => {
     try {
       const now = Date.now();
-      const type = await plugin.queue.getCurrentQueueScreenType();
 
       // Staleness defense: clear cluster signals at the start of each new card load so a
       // value left over from the previous card can't leak in if the widget fails to mount.
@@ -217,56 +449,19 @@ export function registerQueueSessionTracking(plugin: ReactRNPlugin) {
           };
           await syncLiveSession(plugin);
           cardStartTimes.clear();
-          currentIncRemStart = null;
+          incRemEngagementStart = null;
+          incRemEngagementRemId = null;
+          incRemTransitionFlag = null;
         } catch (err) {
           console.error('ERROR: Failed to lazily initialize practice session', err);
         }
       }
 
-      const isLikelyIncRem =
-        type === QueueItemType.Plugin || ((type === undefined || type === null) && !data?.cardId);
-
-      if (isLikelyIncRem) {
-        if (currentIncRemStart && currentSession) {
-          const duration = now - currentIncRemStart;
-          currentSession.incRemsTime += duration;
-          currentSession.totalTime += duration;
-        }
-
-        if (currentSession) {
-          currentSession.incRemsCount++;
-        }
-
-        currentIncRemStart = now;
-
-        if (currentSession) {
-          await syncLiveSession(plugin);
-        }
-
-        // Capture scope from first IncRem text if scope is generic
-        if (
-          currentSession &&
-          (currentSession.scopeName === 'Untitled' ||
-            currentSession.scopeName === 'Ad-hoc Queue' ||
-            currentSession.scopeName === 'Ad-hoc Session' ||
-            !currentSession.scopeName) &&
-          data?.remId
-        ) {
-          const rem = await plugin.rem.findOne(data.remId);
-          if (rem?.text) {
-            const text = await safeRemTextToString(plugin, rem.text);
-            if (text && text !== 'Untitled') currentSession.scopeName = text;
-          }
-        }
-      } else {
-        // Switched to a flashcard — close any open IncRem timing
-        if (currentIncRemStart && currentSession) {
-          const duration = now - currentIncRemStart;
-          currentSession.incRemsTime += duration;
-          currentSession.totalTime += duration;
-        }
-        currentIncRemStart = null;
-      }
+      // IncRem engagement (count + time) is now tracked explicitly by the
+      // IncRem rendering surfaces (queue.tsx and editor_review_timer.tsx) via
+      // startIncRemEngagement / endIncRemEngagement, plus by editor_review.tsx's
+      // manual-minutes confirm via recordIncRemRep. This event no longer
+      // infers IncRem activity from QueueItemType.Plugin.
 
       if (data?.cardId) {
         // Track current and previous card for Mastery Drill edit features
@@ -363,12 +558,11 @@ export function registerQueueSessionTracking(plugin: ReactRNPlugin) {
 
           cardStartTimes.delete(effectiveCardId);
         }
-      } else if (currentIncRemStart && currentSession) {
-        // No cardId means IncRem completion (or generic) — close timing
-        const duration = Date.now() - currentIncRemStart;
-        currentSession.incRemsTime += duration;
-        currentSession.totalTime += duration;
-        currentIncRemStart = null;
+      } else if (incRemEngagementStart !== null && currentSession) {
+        // No cardId — IncRem rep completion. Close any open engagement so
+        // its accumulated time is captured even if the widget cleanup hasn't
+        // fired yet (the rendering surfaces also call endIncRemEngagement).
+        await endIncRemEngagement(plugin);
       }
 
       // Update prev-card interval/coverage now that scheduler has updated

--- a/src/lib/review_actions.ts
+++ b/src/lib/review_actions.ts
@@ -3,6 +3,7 @@ import { findPDFinRem, getCurrentPageKey, addPageToHistory, safeRemTextToString 
 import { getIncrementalRemFromRem, updateReviewRemData } from './incremental_rem';
 import { incremReviewStartTimeKey } from './consts';
 import { determineIncRemType } from './incRemHelpers';
+import { markIncRemTransition } from './queue_session';
 
 export const handleReviewInEditorRem = async (
     plugin: RNPlugin,
@@ -25,6 +26,10 @@ export const handleReviewInEditorRem = async (
 
     const incRemInfo = await getIncrementalRemFromRem(plugin, rem);
     await updateReviewRemData(plugin, incRemInfo ?? undefined);
+
+    // Tell PracticedQueues this is a queue→editor handoff for the same rem,
+    // so the editor timer's startIncRemEngagement doesn't double-count it.
+    markIncRemTransition(plugin, rem._id);
 
     // Start the timer
     const remName = await safeRemTextToString(plugin, rem.text);

--- a/src/lib/sorting.ts
+++ b/src/lib/sorting.ts
@@ -6,18 +6,27 @@ export const DEFAULT_CARDS_PER_REM = 6;
 
 export const setSortingRandomness = async (plugin: RNPlugin, randomness: number) => {
   randomness = Math.min(1, Math.max(0, randomness));
-  await plugin.storage.setSynced('randomness', randomness);
+  const kbId = (await plugin.kb.getCurrentKnowledgeBaseData())._id;
+  await plugin.storage.setSynced(`randomness_${kbId}`, randomness);
 };
 
 export const getSortingRandomness = async (plugin: RNPlugin) => {
-  const val = (await plugin.storage.getSynced('randomness')) as number;
+  const kbId = (await plugin.kb.getCurrentKnowledgeBaseData())._id;
+  let val = (await plugin.storage.getSynced(`randomness_${kbId}`)) as number;
+  if (val == null) {
+    val = (await plugin.storage.getSynced('randomness')) as number;
+  }
   return val == null ? DEFAULT_RANDOMNESS : val;
 };
 
 export type CardsPerRem = 'no-rem' | 'no-cards' | number;
 
 export const getCardsPerRem = async (plugin: RNPlugin): Promise<CardsPerRem> => {
-	const val = await plugin.storage.getSynced('cardsPerRem');
+	const kbId = (await plugin.kb.getCurrentKnowledgeBaseData())._id;
+	let val = await plugin.storage.getSynced(`cardsPerRem_${kbId}`);
+	if (val == null) {
+		val = await plugin.storage.getSynced('cardsPerRem');
+	}
 	if (val === 'no-rem' || val === 'no-cards' || typeof val === 'number') {
 		return val;
 	}
@@ -25,20 +34,25 @@ export const getCardsPerRem = async (plugin: RNPlugin): Promise<CardsPerRem> => 
 }
 
 export const setCardsPerRem = async (plugin: RNPlugin, value: CardsPerRem) => {
-	await plugin.storage.setSynced('cardsPerRem', value);
+	const kbId = (await plugin.kb.getCurrentKnowledgeBaseData())._id;
+	await plugin.storage.setSynced(`cardsPerRem_${kbId}`, value);
 }
-
 
 // Add new functions for flashcard randomness
 export const DEFAULT_CARD_RANDOMNESS = 0.1;
 
 export const setCardRandomness = async (plugin: RNPlugin, randomness: number) => {
   randomness = Math.min(1, Math.max(0, randomness));
-  await plugin.storage.setSynced('cardRandomness', randomness);
+  const kbId = (await plugin.kb.getCurrentKnowledgeBaseData())._id;
+  await plugin.storage.setSynced(`cardRandomness_${kbId}`, randomness);
 };
 
 export const getCardRandomness = async (plugin: RNPlugin) => {
-  const val = (await plugin.storage.getSynced('cardRandomness')) as number;
+  const kbId = (await plugin.kb.getCurrentKnowledgeBaseData())._id;
+  let val = (await plugin.storage.getSynced(`cardRandomness_${kbId}`)) as number;
+  if (val == null) {
+    val = (await plugin.storage.getSynced('cardRandomness')) as number;
+  }
   return val == null ? DEFAULT_CARD_RANDOMNESS : val;
 };
 

--- a/src/register/menus.ts
+++ b/src/register/menus.ts
@@ -81,6 +81,25 @@ export async function registerMenus(plugin: ReactRNPlugin) {
   });
 
   plugin.app.registerMenuItem({
+    id: 'set_priority_document_menuitem',
+    location: PluginCommandMenuLocation.DocumentMenu,
+    name: 'Set Priority',
+    action: async (args: { remId: string }) => {
+      const rem = await plugin.rem.findOne(args.remId);
+      if (!rem) {
+        await plugin.app.toast('Could not find a Rem to set priority for.');
+        return;
+      }
+
+      await plugin.storage.setSession('priorityPopupTargetRemId', undefined);
+
+      await plugin.widget.openPopup('priority', {
+        remId: rem._id,
+      });
+    },
+  });
+
+  plugin.app.registerMenuItem({
     id: 'batch_priority_menuitem',
     location: PluginCommandMenuLocation.DocumentMenu,
     name: 'Batch Priority Change',

--- a/src/register/settings.ts
+++ b/src/register/settings.ts
@@ -18,6 +18,7 @@ import {
   fsrsWeightsId,
   displayQueueToolbarPriorityId,
   displayWeightedShieldId,
+  autoFocusQueueDashboardId,
 } from '../lib/consts';
 
 const hideCardPriorityTagId = 'hide-card-priority-tag';
@@ -248,6 +249,14 @@ export async function registerPluginSettings(plugin: ReactRNPlugin) {
     title: 'Show regular Rems in isolated view (Queue)',
     description:
       'When enabled, incremental Rems that are plain Rems will use the isolated card view in the queue instead of the full document context. Switch back to context with the button in the queue.',
+    defaultValue: false,
+  });
+
+  plugin.settings.registerBooleanSetting({
+    id: autoFocusQueueDashboardId,
+    title: 'Auto focus Queue Dashboard',
+    description:
+      'When enabled, opens the Practiced Queues dashboard in the Right Sidebar automatically on Queue Enter so you always have a live view of the current session. Note: PDF IncRems may temporarily steal focus to PDF-related tabs; the dashboard tab stays available for re-selection.',
     defaultValue: false,
   });
 

--- a/src/widgets/editor_review.tsx
+++ b/src/widgets/editor_review.tsx
@@ -19,6 +19,7 @@ import { determineIncRemType } from '../lib/incRemHelpers';
 import { openRemInNewPane, openAndScrollToHighlight } from '../lib/remHelpers';
 import { PageControls } from '../components/reader/ui';
 import { usePdfPageControls } from '../components/reader/usePdfPageControls';
+import { recordIncRemRep } from '../lib/queue_session';
 
 async function handleEditorReview(
   plugin: RNPlugin,
@@ -193,6 +194,7 @@ const EditorReviewInput: React.FC<{ plugin: RNPlugin; remId: string }> = ({ plug
     if (!isNaN(numDays)) {
       const result = await handleEditorReview(plugin, remId, numDays, priority, numMinutes);
       if (result) {
+        await recordIncRemRep(plugin, remId, Math.round(numMinutes * 60 * 1000));
         const dateStr = dayjs(result.newNextRepDate).format('MMMM D, YYYY');
         await plugin.app.toast(`✓ ${remName}: Repetition stored, next review: ${dateStr}`);
         await plugin.widget.closePopup();

--- a/src/widgets/editor_review_timer.tsx
+++ b/src/widgets/editor_review_timer.tsx
@@ -17,6 +17,7 @@ import { findPDFinRem, findHTMLinRem, clearIncrementalPDFData, PageRangeContext,
 import { openAndScrollToHighlight } from '../lib/remHelpers';
 import { PageControls } from '../components/reader/ui';
 import { usePdfPageControls } from '../components/reader/usePdfPageControls';
+import { startIncRemEngagement, endIncRemEngagement } from '../lib/queue_session';
 import dayjs from 'dayjs';
 import duration from 'dayjs/plugin/duration';
 
@@ -74,6 +75,20 @@ function EditorReviewTimer() {
 
     return () => clearInterval(intervalId);
   }, []);
+
+  // Track IncRem engagement for PracticedQueues (count + time). When the
+  // timer is started for a rem, engagement starts; when remId changes (Next)
+  // or clears (End Review / Cancel), engagement ends and accumulated time is
+  // added. For queue→editor handoffs, markIncRemTransition() in
+  // handleReviewInEditorRem suppresses the count++ here so the IncRem is
+  // counted only once across the combined queue + editor time.
+  useEffect(() => {
+    if (!timerData?.remId) return;
+    startIncRemEngagement(plugin, timerData.remId);
+    return () => {
+      endIncRemEngagement(plugin);
+    };
+  }, [timerData?.remId, plugin]);
 
   const pdfControls = usePdfPageControls(plugin, timerData?.remId, pdfRemId, 0);
 

--- a/src/widgets/priority_editor.tsx
+++ b/src/widgets/priority_editor.tsx
@@ -61,7 +61,32 @@ export function PriorityEditor() {
     []
   );
 
-  // SUPER OPTIMIZED: Combine ALL data fetching into a single hook
+  // Host (PDF or HTML) resolution. Keyed on `remId` only so it does NOT refetch
+  // when the card priority cache flushes — host structure doesn't change with
+  // priority. The state name `pdfRemId` is kept for backwards compat — it now
+  // stores either a PDF or an HTML host id.
+  const hostInfo = useRunAsync(async () => {
+    if (!remId) return null;
+    const rem = await plugin.rem.findOne(remId);
+    if (!rem) return null;
+    const pdfRem = await findPreferredPDFInRem(plugin as any, rem, false);
+    const hostRem = pdfRem ?? await findHTMLinRem(plugin as any, rem);
+    if (!hostRem) {
+      return { pdfRemId: null, pdfRemName: null, hostKind: null as 'pdf' | 'html' | null };
+    }
+    const pdfRemName = hostRem.text ? await safeRemTextToString(plugin as any, hostRem.text) : null;
+    return {
+      pdfRemId: hostRem._id,
+      pdfRemName,
+      hostKind: (pdfRem ? 'pdf' : 'html') as 'pdf' | 'html',
+    };
+  }, [remId]);
+
+  const hostPdfRemId = hostInfo?.pdfRemId ?? null;
+  const hostPdfRemName = hostInfo?.pdfRemName ?? null;
+  const hostKind = hostInfo?.hostKind ?? null;
+
+  // SUPER OPTIMIZED: Combine ALL priority/range/history fetching into a single hook
   // This reduces the render cascade from ~9 renders to ~3 renders
   const remData = useTrackerPlugin(
     async (plugin) => {
@@ -70,8 +95,9 @@ export function PriorityEditor() {
       const rem = await plugin.rem.findOne(remId);
       if (!rem) return null;
 
-      // Execute ALL queries in parallel for maximum performance
-      const [incRemInfo, cardInfo, cards, hasPowerup, allIncRems, allPrioritizedCardInfo, displayMode, pdfRem] = await Promise.all([
+      // Execute priority queries in parallel for maximum performance.
+      // Host resolution is handled separately via `hostInfo` (useRunAsync).
+      const [incRemInfo, cardInfo, cards, hasPowerup, allIncRems, allPrioritizedCardInfo, displayMode] = await Promise.all([
         getIncrementalRemFromRem(plugin, rem),
         getCardPriority(plugin, rem),
         rem.getCards(),
@@ -79,43 +105,27 @@ export function PriorityEditor() {
         plugin.storage.getSession<IncrementalRem[]>(allIncrementalRemKey),
         plugin.storage.getSession<CardPriorityInfo[]>(allCardPriorityInfoKey),
         plugin.settings.getSetting<string>('priorityEditorDisplayMode'),
-        findPreferredPDFInRem(plugin as any, rem, false),
       ]);
 
-      // Fetch host (PDF or HTML) range / history / stats. PDFs get a page-range
-      // panel; HTML hosts only get a bookmark/history panel since pages don't
-      // apply. The state name `pdfRemId` is kept for backwards compat — it now
-      // stores either a PDF or an HTML host id.
-      let pdfRemId: string | null = null;
-      let pdfRemName: string | null = null;
+      // Range / history / stats depend on the host (resolved by useRunAsync above).
+      // PDFs get a page-range panel; HTML hosts only get bookmark/history.
       let pdfRange: { start: number; end: number | null } | null = null;
       let pdfHistory: PageHistoryEntry[] = [];
       let pdfStats: any = null;
-      let hostKind: 'pdf' | 'html' | null = null;
 
-      let hostRem: typeof pdfRem = pdfRem;
-      if (!hostRem) {
-        // Fall back to HTML host (Reader Mode source) for non-PDF IncRems.
-        hostRem = await findHTMLinRem(plugin as any, rem);
-      }
-
-      if (hostRem) {
-        hostKind = pdfRem ? 'pdf' : 'html';
-        pdfRemId = hostRem._id;
-        pdfRemName = hostRem.text ? await safeRemTextToString(plugin as any, hostRem.text) : null;
+      if (hostPdfRemId) {
         const [range, history, stats] = await Promise.all([
-          // Range only applies to PDFs.
           hostKind === 'pdf'
-            ? getIncrementalPageRange(plugin as any, rem._id, hostRem._id)
+            ? getIncrementalPageRange(plugin as any, rem._id, hostPdfRemId)
             : Promise.resolve(null),
-          getPageHistory(plugin as any, rem._id, hostRem._id),
-          getReadingStatistics(plugin as any, rem._id, hostRem._id),
+          getPageHistory(plugin as any, rem._id, hostPdfRemId),
+          getReadingStatistics(plugin as any, rem._id, hostPdfRemId),
         ]);
         pdfRange = range;
         pdfHistory = history;
         pdfStats = stats;
         console.log('[PriorityEditor] Fetched host history',
-          { incRemId: rem._id, hostRemId: hostRem._id, hostKind, historyLength: history.length, lastEntry: history[history.length - 1] });
+          { incRemId: rem._id, hostRemId: hostPdfRemId, hostKind, historyLength: history.length, lastEntry: history[history.length - 1] });
       }
 
       // Calculate relative priorities inline
@@ -137,15 +147,12 @@ export function PriorityEditor() {
         cardRelativePriority,
         allPrioritizedCardInfo: allPrioritizedCardInfo || [],
         displayMode: displayMode || 'all',
-        pdfRemId,
-        pdfRemName,
         pdfRange,
         pdfHistory,
         pdfStats,
-        hostKind,
       };
     },
-    [remId, refreshSignal]
+    [remId, refreshSignal, hostPdfRemId, hostKind]
   );
 
   const rem = remData?.rem ?? null;
@@ -199,9 +206,9 @@ export function PriorityEditor() {
 
   // PDF callbacks
   const pdfSaveRange = useCallback(async () => {
-    if (pdfEdit.mode !== 'range' || !remId || !remData?.pdfRemId) return;
+    if (pdfEdit.mode !== 'range' || !remId || !hostPdfRemId) return;
     const { start, end } = pdfEdit;
-    const rangeKey = getPageRangeKey(remId, remData.pdfRemId);
+    const rangeKey = getPageRangeKey(remId, hostPdfRemId);
     if (start > 1 || end > 0) {
       await plugin.storage.setSynced(rangeKey, { start, end });
       await plugin.app.toast(`Saved page range: ${start}–${end || '∞'}`);
@@ -210,28 +217,28 @@ export function PriorityEditor() {
       await plugin.app.toast('Cleared page range');
     }
     setPdfEdit({ mode: 'none' });
-  }, [pdfEdit, remId, remData?.pdfRemId, plugin]);
+  }, [pdfEdit, remId, hostPdfRemId, plugin]);
 
   const pdfSaveHistory = useCallback(async () => {
-    if (pdfEdit.mode !== 'history' || !remId || !remData?.pdfRemId) return;
+    if (pdfEdit.mode !== 'history' || !remId || !hostPdfRemId) return;
     const { page } = pdfEdit;
     if (page <= 0) { await plugin.app.toast('Enter a valid page number.'); return; }
-    await setIncrementalReadingPosition(plugin as any, remId, remData.pdfRemId, page);
-    await addPageToHistory(plugin as any, remId, remData.pdfRemId, page, undefined);
+    await setIncrementalReadingPosition(plugin as any, remId, hostPdfRemId, page);
+    await addPageToHistory(plugin as any, remId, hostPdfRemId, page, undefined);
     await plugin.app.toast(`Reading position set to page ${page}`);
     setPdfEdit({ mode: 'none' });
-  }, [pdfEdit, remId, remData?.pdfRemId, plugin]);
+  }, [pdfEdit, remId, hostPdfRemId, plugin]);
 
   const openPdfPanel = useCallback(async () => {
-    if (!remId || !remData?.pdfRemId) return;
+    if (!remId || !hostPdfRemId) return;
     await plugin.storage.setSession('pageRangeContext', {
       incrementalRemId: remId,
-      pdfRemId: remData.pdfRemId,
+      pdfRemId: hostPdfRemId,
       totalPages: undefined,
       currentPage: undefined,
     });
     await plugin.widget.openPopup(pageRangeWidgetId, { remId });
-  }, [remId, remData?.pdfRemId, plugin]);
+  }, [remId, hostPdfRemId, plugin]);
 
   // Memoize computed values
   const showCardEditor = useMemo(
@@ -291,14 +298,14 @@ export function PriorityEditor() {
           {showCardEditor && (
             <PriorityBadge priority={cardInfo?.priority ?? 50} percentile={cardRelativePriority ?? undefined} compact source={cardInfo?.source} isCardPriority={true} />
           )}
-          {remData?.hostKind === 'pdf' && remData?.pdfRemId && (() => {
-            const last = remData.pdfHistory?.[remData.pdfHistory.length - 1];
+          {hostKind === 'pdf' && hostPdfRemId && (() => {
+            const last = remData?.pdfHistory?.[remData.pdfHistory.length - 1];
             const hasPage = typeof last?.page === 'number';
             const hasBookmark = !!last?.highlightId;
-            const hasRange = !!remData.pdfRange;
+            const hasRange = !!remData?.pdfRange;
             const hasAnyState = hasRange || hasPage || hasBookmark;
             const titleParts = [
-              hasRange ? `p.${remData.pdfRange!.start}–${remData.pdfRange!.end || '∞'}` : null,
+              hasRange ? `p.${remData!.pdfRange!.start}–${remData!.pdfRange!.end || '∞'}` : null,
               hasBookmark ? 'saved bookmark' : null,
             ].filter(Boolean);
             const title = titleParts.length > 0
@@ -318,7 +325,7 @@ export function PriorityEditor() {
                 }}
               >
                 📄
-                {hasRange && ` p.${remData.pdfRange!.start}–${remData.pdfRange!.end || '∞'}`}
+                {hasRange && ` p.${remData!.pdfRange!.start}–${remData!.pdfRange!.end || '∞'}`}
                 {(hasPage || hasBookmark) && (
                   <span style={{ color: '#10b981', marginLeft: '2px' }}>
                     {hasPage && `(${last!.page})`}
@@ -330,8 +337,8 @@ export function PriorityEditor() {
               </span>
             );
           })()}
-          {remData?.hostKind === 'html' && remData?.pdfRemId && (() => {
-            const last = remData.pdfHistory?.[remData.pdfHistory.length - 1];
+          {hostKind === 'html' && hostPdfRemId && (() => {
+            const last = remData?.pdfHistory?.[remData.pdfHistory.length - 1];
             const hasBookmark = !!last?.highlightId;
             return (
               <span
@@ -496,7 +503,7 @@ export function PriorityEditor() {
           )}
 
           {/* PDF Range Section */}
-          {remData?.hostKind === 'pdf' && remData?.pdfRemId && (
+          {hostKind === 'pdf' && hostPdfRemId && remData && (
             <div
               className="p-3 rounded-lg"
               style={{
@@ -509,9 +516,9 @@ export function PriorityEditor() {
                 <div className="flex items-center gap-1.5">
                   <span className="text-xs">📄</span>
                   <span className="text-xs font-semibold" style={{ color: 'var(--rn-clr-content-primary)' }}>PDF Range</span>
-                  {remData.pdfRemName && (
+                  {hostPdfRemName && (
                     <span className="text-[10px] truncate max-w-[100px]" style={{ color: 'var(--rn-clr-content-tertiary)' }}
-                      title={remData.pdfRemName}>{remData.pdfRemName}</span>
+                      title={hostPdfRemName}>{hostPdfRemName}</span>
                   )}
                 </div>
                 {remData.pdfRange ? (
@@ -676,8 +683,8 @@ export function PriorityEditor() {
                       // polls for the pane to mount, then retries the scroll
                       // through PDF.js's boot window so a single click works
                       // even when the PDF was previously closed.
-                      if (remData.pdfRemId) {
-                        await openAndScrollToHighlight(plugin, remData.pdfRemId, bookmarkHighlightId);
+                      if (hostPdfRemId) {
+                        await openAndScrollToHighlight(plugin, hostPdfRemId, bookmarkHighlightId);
                       } else {
                         const bookmarkRem = await plugin.rem.findOne(bookmarkHighlightId);
                         bookmarkRem?.scrollToReaderHighlight();
@@ -712,7 +719,7 @@ export function PriorityEditor() {
           {/* Web Source Section (HTML hosts) — minimal panel: name + bookmark
               info + Scroll to Position. No range / page editing because HTML
               articles aren't paginated. */}
-          {remData?.hostKind === 'html' && remData?.pdfRemId && (
+          {hostKind === 'html' && hostPdfRemId && remData && (
             <div
               className="p-3 rounded-lg"
               style={{
@@ -724,9 +731,9 @@ export function PriorityEditor() {
                 <div className="flex items-center gap-1.5">
                   <span className="text-xs">🌐</span>
                   <span className="text-xs font-semibold" style={{ color: 'var(--rn-clr-content-primary)' }}>Web Source</span>
-                  {remData.pdfRemName && (
+                  {hostPdfRemName && (
                     <span className="text-[10px] truncate max-w-[140px]" style={{ color: 'var(--rn-clr-content-tertiary)' }}
-                      title={remData.pdfRemName}>{remData.pdfRemName}</span>
+                      title={hostPdfRemName}>{hostPdfRemName}</span>
                   )}
                 </div>
               </div>
@@ -761,8 +768,8 @@ export function PriorityEditor() {
                 return (
                   <button
                     onClick={async () => {
-                      if (remData.pdfRemId) {
-                        await openAndScrollToHighlight(plugin, remData.pdfRemId, bookmarkHighlightId);
+                      if (hostPdfRemId) {
+                        await openAndScrollToHighlight(plugin, hostPdfRemId, bookmarkHighlightId);
                       } else {
                         const bookmarkRem = await plugin.rem.findOne(bookmarkHighlightId);
                         bookmarkRem?.scrollToReaderHighlight();

--- a/src/widgets/priority_editor.tsx
+++ b/src/widgets/priority_editor.tsx
@@ -86,8 +86,10 @@ export function PriorityEditor() {
   const hostPdfRemName = hostInfo?.pdfRemName ?? null;
   const hostKind = hostInfo?.hostKind ?? null;
 
-  // SUPER OPTIMIZED: Combine ALL priority/range/history fetching into a single hook
-  // This reduces the render cascade from ~9 renders to ~3 renders
+  // SUPER OPTIMIZED: Combine priority queries into a single hook.
+  // Host range/history/stats are fetched in a separate tracker below so that
+  // priority cache flushes (during inheritance cascades) don't trigger refetches
+  // of unrelated host data.
   const remData = useTrackerPlugin(
     async (plugin) => {
       if (!remId) return null;
@@ -96,7 +98,6 @@ export function PriorityEditor() {
       if (!rem) return null;
 
       // Execute priority queries in parallel for maximum performance.
-      // Host resolution is handled separately via `hostInfo` (useRunAsync).
       const [incRemInfo, cardInfo, cards, hasPowerup, allIncRems, allPrioritizedCardInfo, displayMode] = await Promise.all([
         getIncrementalRemFromRem(plugin, rem),
         getCardPriority(plugin, rem),
@@ -106,27 +107,6 @@ export function PriorityEditor() {
         plugin.storage.getSession<CardPriorityInfo[]>(allCardPriorityInfoKey),
         plugin.settings.getSetting<string>('priorityEditorDisplayMode'),
       ]);
-
-      // Range / history / stats depend on the host (resolved by useRunAsync above).
-      // PDFs get a page-range panel; HTML hosts only get bookmark/history.
-      let pdfRange: { start: number; end: number | null } | null = null;
-      let pdfHistory: PageHistoryEntry[] = [];
-      let pdfStats: any = null;
-
-      if (hostPdfRemId) {
-        const [range, history, stats] = await Promise.all([
-          hostKind === 'pdf'
-            ? getIncrementalPageRange(plugin as any, rem._id, hostPdfRemId)
-            : Promise.resolve(null),
-          getPageHistory(plugin as any, rem._id, hostPdfRemId),
-          getReadingStatistics(plugin as any, rem._id, hostPdfRemId),
-        ]);
-        pdfRange = range;
-        pdfHistory = history;
-        pdfStats = stats;
-        console.log('[PriorityEditor] Fetched host history',
-          { incRemId: rem._id, hostRemId: hostPdfRemId, hostKind, historyLength: history.length, lastEntry: history[history.length - 1] });
-      }
 
       // Calculate relative priorities inline
       const incRemRelativePriority = (incRemInfo && allIncRems && allIncRems.length > 0)
@@ -147,13 +127,35 @@ export function PriorityEditor() {
         cardRelativePriority,
         allPrioritizedCardInfo: allPrioritizedCardInfo || [],
         displayMode: displayMode || 'all',
-        pdfRange,
-        pdfHistory,
-        pdfStats,
       };
     },
-    [remId, refreshSignal, hostPdfRemId, hostKind]
+    [remId, refreshSignal]
   );
+
+  // Host data (range / history / stats). Reads only from the synced storage
+  // keys for this incRem+host pair, so it does NOT subscribe to priority
+  // caches and won't refetch during inheritance cascades. Re-runs only when
+  // the user actually changes range/history (or when remId/host change).
+  const hostData = useTrackerPlugin(
+    async (plugin) => {
+      if (!remId || !hostPdfRemId) return null;
+      const [range, history, stats] = await Promise.all([
+        hostKind === 'pdf'
+          ? getIncrementalPageRange(plugin as any, remId, hostPdfRemId)
+          : Promise.resolve(null),
+        getPageHistory(plugin as any, remId, hostPdfRemId),
+        getReadingStatistics(plugin as any, remId, hostPdfRemId),
+      ]);
+      console.log('[PriorityEditor] Fetched host history',
+        { incRemId: remId, hostRemId: hostPdfRemId, hostKind, historyLength: history.length, lastEntry: history[history.length - 1] });
+      return { pdfRange: range, pdfHistory: history, pdfStats: stats as any };
+    },
+    [remId, hostPdfRemId, hostKind]
+  );
+
+  const pdfRange = hostData?.pdfRange ?? null;
+  const pdfHistory = hostData?.pdfHistory ?? [];
+  const pdfStats: any = hostData?.pdfStats ?? null;
 
   const rem = remData?.rem ?? null;
   const incRemInfo = remData?.incRemInfo ?? null;
@@ -299,13 +301,13 @@ export function PriorityEditor() {
             <PriorityBadge priority={cardInfo?.priority ?? 50} percentile={cardRelativePriority ?? undefined} compact source={cardInfo?.source} isCardPriority={true} />
           )}
           {hostKind === 'pdf' && hostPdfRemId && (() => {
-            const last = remData?.pdfHistory?.[remData.pdfHistory.length - 1];
+            const last = pdfHistory?.[pdfHistory.length - 1];
             const hasPage = typeof last?.page === 'number';
             const hasBookmark = !!last?.highlightId;
-            const hasRange = !!remData?.pdfRange;
+            const hasRange = !!pdfRange;
             const hasAnyState = hasRange || hasPage || hasBookmark;
             const titleParts = [
-              hasRange ? `p.${remData!.pdfRange!.start}–${remData!.pdfRange!.end || '∞'}` : null,
+              hasRange ? `p.${pdfRange!.start}–${pdfRange!.end || '∞'}` : null,
               hasBookmark ? 'saved bookmark' : null,
             ].filter(Boolean);
             const title = titleParts.length > 0
@@ -325,7 +327,7 @@ export function PriorityEditor() {
                 }}
               >
                 📄
-                {hasRange && ` p.${remData!.pdfRange!.start}–${remData!.pdfRange!.end || '∞'}`}
+                {hasRange && ` p.${pdfRange!.start}–${pdfRange!.end || '∞'}`}
                 {(hasPage || hasBookmark) && (
                   <span style={{ color: '#10b981', marginLeft: '2px' }}>
                     {hasPage && `(${last!.page})`}
@@ -338,7 +340,7 @@ export function PriorityEditor() {
             );
           })()}
           {hostKind === 'html' && hostPdfRemId && (() => {
-            const last = remData?.pdfHistory?.[remData.pdfHistory.length - 1];
+            const last = pdfHistory?.[pdfHistory.length - 1];
             const hasBookmark = !!last?.highlightId;
             return (
               <span
@@ -503,7 +505,7 @@ export function PriorityEditor() {
           )}
 
           {/* PDF Range Section */}
-          {hostKind === 'pdf' && hostPdfRemId && remData && (
+          {hostKind === 'pdf' && hostPdfRemId && (
             <div
               className="p-3 rounded-lg"
               style={{
@@ -521,12 +523,12 @@ export function PriorityEditor() {
                       title={hostPdfRemName}>{hostPdfRemName}</span>
                   )}
                 </div>
-                {remData.pdfRange ? (
+                {pdfRange ? (
                   <span className="text-[10px] px-1.5 py-0.5 rounded font-medium"
                     style={{ backgroundColor: 'var(--rn-clr-background-primary)', color: 'var(--rn-clr-content-secondary)', whiteSpace: 'nowrap' }}>
-                    p.{remData.pdfRange.start}–{remData.pdfRange.end || '∞'}
+                    p.{pdfRange.start}–{pdfRange.end || '∞'}
                     {(() => {
-                      const last = remData.pdfHistory?.[remData.pdfHistory.length - 1];
+                      const last = pdfHistory?.[pdfHistory.length - 1];
                       if (!last) return null;
                       const hasPage = typeof last.page === 'number';
                       if (!hasPage && !last.highlightId) return null;
@@ -580,8 +582,8 @@ export function PriorityEditor() {
                 </div>
               )}
               {pdfEdit.mode === 'history' && (() => {
-                const rangeStart = remData.pdfRange?.start ?? 1;
-                const rangeEnd = remData.pdfRange?.end ?? null;
+                const rangeStart = pdfRange?.start ?? 1;
+                const rangeEnd = pdfRange?.end ?? null;
                 const outOfRange = pdfEdit.page < rangeStart || (rangeEnd !== null && pdfEdit.page > rangeEnd);
                 return (
                   <div
@@ -623,7 +625,7 @@ export function PriorityEditor() {
               {pdfEdit.mode === 'none' && (
                 <div className="flex gap-1 flex-wrap">
                   <button
-                    onClick={() => setPdfEdit({ mode: 'range', start: remData.pdfRange?.start || 1, end: remData.pdfRange?.end || 0 })}
+                    onClick={() => setPdfEdit({ mode: 'range', start: pdfRange?.start || 1, end: pdfRange?.end || 0 })}
                     className="px-2 py-1 text-[11px] rounded transition-colors"
                     style={{ backgroundColor: 'var(--rn-clr-background-tertiary)', color: '#3b82f6' }}
                     onMouseEnter={(e) => { e.currentTarget.style.backgroundColor = '#3b82f6'; e.currentTarget.style.color = 'white'; }}
@@ -631,8 +633,8 @@ export function PriorityEditor() {
                   >📄 Range</button>
                   <button
                     onClick={() => {
-                      const lastPage = remData.pdfHistory?.slice(-1)[0]?.page
-                        ?? remData.pdfRange?.start
+                      const lastPage = pdfHistory?.slice(-1)[0]?.page
+                        ?? pdfRange?.start
                         ?? 1;
                       setPdfEdit({ mode: 'history', page: lastPage });
                     }}
@@ -645,14 +647,14 @@ export function PriorityEditor() {
               )}
 
               {/* Stats + last session */}
-              {(remData.pdfStats?.totalTimeSeconds > 0 || remData.pdfHistory?.length > 0) && (
+              {(pdfStats?.totalTimeSeconds > 0 || pdfHistory?.length > 0) && (
                 <div className="mt-2 flex items-center gap-3 flex-wrap">
-                  {remData.pdfStats?.totalTimeSeconds > 0 && (
+                  {pdfStats?.totalTimeSeconds > 0 && (
                     <span className="text-[10px]" style={{ color: '#10b981' }}
-                      title="Total reading time">⏱️{formatDuration(remData.pdfStats.totalTimeSeconds)}</span>
+                      title="Total reading time">⏱️{formatDuration(pdfStats.totalTimeSeconds)}</span>
                   )}
-                  {remData.pdfHistory?.length > 0 && (() => {
-                    const last = remData.pdfHistory[remData.pdfHistory.length - 1];
+                  {pdfHistory?.length > 0 && (() => {
+                    const last = pdfHistory[pdfHistory.length - 1];
                     const hasPage = typeof last.page === 'number';
                     if (!hasPage && !last.highlightId) return null;
                     const tooltip = hasPage
@@ -672,7 +674,7 @@ export function PriorityEditor() {
                   A manual position recorded after a highlight bookmark would otherwise
                   jump to a stale highlight, so we suppress the button in that case. */}
               {(() => {
-                const history = remData.pdfHistory ?? [];
+                const history = pdfHistory ?? [];
                 const lastEntry = history[history.length - 1];
                 const bookmarkHighlightId = lastEntry?.highlightId;
                 if (!bookmarkHighlightId) return null;
@@ -719,7 +721,7 @@ export function PriorityEditor() {
           {/* Web Source Section (HTML hosts) — minimal panel: name + bookmark
               info + Scroll to Position. No range / page editing because HTML
               articles aren't paginated. */}
-          {hostKind === 'html' && hostPdfRemId && remData && (
+          {hostKind === 'html' && hostPdfRemId && (
             <div
               className="p-3 rounded-lg"
               style={{
@@ -739,14 +741,14 @@ export function PriorityEditor() {
               </div>
 
               {/* Stats + last bookmark */}
-              {(remData.pdfStats?.totalTimeSeconds > 0 || remData.pdfHistory?.length > 0) && (
+              {(pdfStats?.totalTimeSeconds > 0 || pdfHistory?.length > 0) && (
                 <div className="mt-1 flex items-center gap-3 flex-wrap">
-                  {remData.pdfStats?.totalTimeSeconds > 0 && (
+                  {pdfStats?.totalTimeSeconds > 0 && (
                     <span className="text-[10px]" style={{ color: '#10b981' }}
-                      title="Total reading time">⏱️{formatDuration(remData.pdfStats.totalTimeSeconds)}</span>
+                      title="Total reading time">⏱️{formatDuration(pdfStats.totalTimeSeconds)}</span>
                   )}
-                  {remData.pdfHistory?.length > 0 && (() => {
-                    const last = remData.pdfHistory[remData.pdfHistory.length - 1];
+                  {pdfHistory?.length > 0 && (() => {
+                    const last = pdfHistory[pdfHistory.length - 1];
                     if (!last.highlightId) return null;
                     return (
                       <span className="text-[10px]" style={{ color: 'var(--rn-clr-content-tertiary)' }}
@@ -761,7 +763,7 @@ export function PriorityEditor() {
               {/* Scroll to Bookmark — same logic as the PDF panel: only when the
                   LAST history entry carries a highlightId. */}
               {(() => {
-                const history = remData.pdfHistory ?? [];
+                const history = pdfHistory ?? [];
                 const lastEntry = history[history.length - 1];
                 const bookmarkHighlightId = lastEntry?.highlightId;
                 if (!bookmarkHighlightId) return null;

--- a/src/widgets/queue.tsx
+++ b/src/widgets/queue.tsx
@@ -23,6 +23,7 @@ import {
 } from '../lib/consts';
 import { setCurrentIncrementalRem } from '../lib/incremental_rem';
 import { safeRemTextToString } from '../lib/pdfUtils';
+import { startIncRemEngagement, endIncRemEngagement } from '../lib/queue_session';
 
 console.log('QUEUE.TSX FILE LOADED');
 
@@ -93,6 +94,18 @@ export function QueueComponent() {
       plugin.storage.setSession(incrementalQueueActiveKey, false);
     };
   }, [plugin]);
+
+  // Drive PracticedQueues IncRem count + time from explicit mount/unmount of
+  // this widget rather than the QueueLoadCard heuristic. Mount = engagement
+  // starts (count++ unless this is a queue→editor handoff). Unmount or remId
+  // change = engagement ends (accumulated time is added to the session).
+  useEffect(() => {
+    if (!ctx?.remId) return;
+    startIncRemEngagement(plugin, ctx.remId);
+    return () => {
+      endIncRemEngagement(plugin);
+    };
+  }, [ctx?.remId, plugin]);
 
   useEffect(() => {
     // The true identity of the incremental item in the queue is ALWAYS ctx.remId.

--- a/src/widgets/sorting_criteria.tsx
+++ b/src/widgets/sorting_criteria.tsx
@@ -75,6 +75,11 @@ export function SortingCriteria() {
     []
   );
 
+  const currentKbName = useTrackerPlugin(
+    async (rp) => (await rp.kb.getCurrentKnowledgeBaseData())?.name,
+    []
+  );
+
   const [sliderValue, setSliderValue] = useState<number | undefined>(undefined);
 
   const [currentTime, setCurrentTime] = useState(Date.now());
@@ -155,6 +160,11 @@ export function SortingCriteria() {
       )}
 
       <div className="text-2xl font-bold">Sorting Criteria</div>
+      {currentKbName && (
+        <div className="rn-clr-content-secondary text-sm italic mt-[-8px]">
+          Knowledge Base: {currentKbName}
+        </div>
+      )}
 
       {/* Randomness slider is unchanged */}
       <div className="flex flex-col gap-2 ">


### PR DESCRIPTION
## v0.2.194 - May 1st, 2026

### ✨ Improvement: Sorting Criteria is now Knowledge-Base Dependent

The **Sorting Criteria** widget settings (Flashcard Ratio, Incremental Rem Randomness, and Flashcard Randomness) are now scoped to your current Knowledge Base.
- If you use multiple Knowledge Bases, you can now have completely different sorting parameters for each one.
- The active Knowledge Base name is now clearly displayed at the top of the Sorting Criteria popup so you always know which settings you are editing.
- Your previous global settings have been preserved and act as a seamless fallback if you haven't set KB-specific criteria yet.

---

## v0.2.193 - May 1st, 2026

### ✨ Incremental Rem Tracking — All Review Surfaces

IncRem time in the **Practiced Queues** dashboard is now tracked reliably from every place you can review an IncRem, not just the in-queue widget.

**What changed:**

- **All three review surfaces are now instrumented:** the in-queue `QueueComponent`, the **Editor Review Timer** (`⏱️ Start Timer`), and the **Editor Review popup** (manual-minutes confirm) all emit typed tracking signals via a session-storage event log. The main plugin process drains this log at 250 ms intervals and applies the events — the same cross-iframe messaging pattern used for card cluster tracking.
- **Removed the `QueueItemType.Plugin` heuristic.** The old code inferred that the current queue item was an IncRem by checking `QueueItemType.Plugin`. This was fragile and would silently miss editor-side reviews. It has been replaced by explicit signals from the review components.
- **Editor-only sessions.** If you review an IncRem directly from the editor (not from a queue), the plugin now opens a dedicated **"Editor Review"** session. That session auto-saves and closes after **60 minutes of inactivity**, keeping your history clean without any manual step.
- **Queue → editor deduplication.** When you click *Review in Editor* from the queue, the time is counted once — it carries over into the same session rather than starting a separate engagement. The queue and editor timer together record a single continuous block.
- **New setting — Auto focus Queue Dashboard** (default `false`): when enabled, the Practiced Queues dashboard opens automatically in the Right Sidebar every time you enter a queue. See [Plugin Settings Reference](Plugin-Settings-Reference#queue-display) for details.

## v0.2.192 - May 1st, 2026

### 🐛 Fix: Deferred card-priority tagging at startup now actually persists tags

On every startup, the cache loader's deferred phase reported successfully processing untagged cards (e.g. "Processed 29 cards in 0s"), but the next session would re-discover the **same** untagged cards and run the deferred phase again. The `Update all inherited Card Priorities` (UCP) command, by contrast, tagged them correctly.

The deferred path was delegating to `autoAssignCardPriority()`, which is intentionally loop-safe in the `GlobalRemChanged` listener: it skips writes when the rem's computed priority already matches its inherited/default value. Since `getCardPriority()` resolves inheritance on-the-fly even for untagged rems, that guard always fired in the deferred context — and the powerup tag was never actually written. The in-memory cache entry made it look like work had happened, but the persistent state was unchanged.

The fix mirrors the UCP pattern: the deferred process now computes via `calculateNewPriority()` (no writes) and unconditionally calls `setCardPriority()` for each untagged rem, bypassing the listener-safe guard. The pre-existing `plugin_operation_active` session flag continues to suppress `GlobalRemChanged` during the batch, so no write storm.

## v0.2.191 - April 29th, 2026

### 🐛 Perf Fix: Priority Editor no longer refetches host data during inheritance cascades

When changing the priority of an ancestor with many descendants, the Background inheritance cascade repeatedly flushed the card priority cache — triggering unnecessary refetches of PDF/HTML host data (source lookup, page range, history, stats) in every open Priority Editor widget.

The fix splits data fetching into three independent hooks:
- **Host identity** (`useRunAsync` on `remId`) — resolves the PDF/HTML source once; never reruns on priority changes.
- **Range / history / stats** (separate `useTrackerPlugin` on `remId + hostId`) — subscribes only to its own synced storage keys; reruns when the user saves a range or bookmark, not during cascades.
- **Priority data** (existing tracker) — reacts to cache flushes as before, but no longer drags along host lookups.

## v0.2.190 - April 29th, 2026

- For setting priorities to **Canvases** and PDFs, now there is a Document Menu Item to **Set Priority**.
