### PR TITLE
Multi-PDF Support; Priority Distribution Graphs — Stacked Due / Processed Bars

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,12 +98,13 @@ The plugin now features **Automatic Light Mode**.
 ### Incremental Reading
 
 - You can tag PDFs, websites and highlights with the `Incremental` tag to do classic SuperMemo-style incremental reading.
-- It will work if you tag the PDF or website itself, a Rem with a single PDF or website as a source, or a Rem with multiple sources where exactly one PDF has the `#preferthispdf` tag.
+- It works whether you tag the PDF/website itself, a Rem with a single source, or a Rem with **multiple PDF sources** — the plugin lets you switch between them on the fly and pin one as the *active* PDF for that Inc Rem.
 - The plugin will render the PDF or website reader view inside the queue.
 - If you want to turn a highlight into an incremental Rem, click on the highlight and click the puzzle piece icon.
 - 📄 **PDFs & Web**
   - **Visual Status**: Highlights turn **Green** when toggled as Incremental, and **Blue** when extracted.
   - **PDF Control Panel**: Manage chapters, set page ranges, and view reading history for long documents.
+  - **Multi-PDF Switcher** *(new)*: When an Inc Rem has multiple PDF sources, a dropdown appears in the Reader (next to the 📝 Document Notes icon), in the Editor Review Timer, in the Execute Repetition popup, in the PDF Control Panel, and in the Editor Toolbar — letting you switch the PDF in view and pin a chosen one as active for that Inc Rem. Resolution order is **explicit pin → `#preferthispdf` → first PDF**, applied uniformly across every surface.
   - **Position Tracking**: The plugin automatically saves your last read page when using the PDF Chapter workflow or creating extracts.
   - **Create Incremental Rem**: Select text in a PDF -> Highlight it -> Click the Funnel Icon -> **"Create Incremental Rem"**. This extracts the text to a new Rem under a parent of your choice (using the smart parent selector).
 

--- a/README_ES.md
+++ b/README_ES.md
@@ -84,11 +84,14 @@ El complemento ahora cuenta con **Modo Ligero Automático**.
 ### Lectura Incremental
 
 - Puedes etiquetar PDFs, sitios web y resaltados con la etiqueta `Incremental` para hacer lectura incremental clásica estilo SuperMemo.
-- Funcionará si etiquetas el PDF o sitio web en sí, o un Rem con un solo PDF o sitio web como fuente.
+- Funciona si etiquetas el PDF/sitio en sí, un Rem con una única fuente, o un Rem con **múltiples PDFs como fuente** — el complemento te permite alternar entre ellos al vuelo y fijar uno como el PDF *activo* para ese Inc Rem.
 - El complemento renderizará la vista de lectura del PDF o sitio web dentro de la cola.
 - Si quieres convertir un resaltado en un Rem incremental, haz clic en el resaltado y haz clic en el icono de la pieza de rompecabezas.
 - ** 📄 PDFs y Web**
   - **Estado Visual**: Los resaltados se vuelven **Verdes** cuando se activan como Incrementales, y **Azules** cuando se extraen.
+  - **Panel de Control de PDF**: Gestiona capítulos, define rangos de páginas y consulta el historial de lectura para documentos largos.
+  - **Selector multi-PDF** *(nuevo)*: Cuando un Inc Rem tiene múltiples PDFs como fuente, aparece un desplegable en el Reader (junto al ícono 📝 de Notas del Documento), en el Cronómetro de Revisión del Editor, en el popup de Ejecutar Repetición, en el Panel de Control de PDF y en el Priority Editor — permitiéndote cambiar el PDF que se muestra y fijar uno como activo para ese Inc Rem. El orden de resolución es **fijación explícita → `#preferthispdf` → primer PDF**, aplicado de forma uniforme en todas las superficies.
+  - **Seguimiento de Posición**: El complemento guarda automáticamente tu última página leída al usar el flujo de Capítulos de PDF o al crear extractos.
   - **Crear Rem Incremental**: Selecciona texto en un PDF -> Resáltalo -> Haz clic en el Icono de Rompecabezas -> **"Create Incremental Rem"**. Esto extrae el texto a un nuevo Rem bajo un padre de tu elección (usando el selector inteligente de padres).
 ![Resaltar](https://raw.githubusercontent.com/bjsi/incremental-everything/main/img/highlight.gif)
 

--- a/README_PT-BR.md
+++ b/README_PT-BR.md
@@ -84,11 +84,14 @@ O plugin agora possui **Modo Leve Automático**.
 ### Leitura Incremental
 
 - Você pode marcar PDFs, sites e destaques com a etiqueta `Incremental` para fazer leitura incremental clássica estilo SuperMemo.
-- Funcionará se você marcar o PDF ou site em si, ou um Rem com um único PDF ou site como fonte.
+- Funciona se você marcar o PDF/site em si, um Rem com uma única fonte, ou um Rem com **múltiplos PDFs como fonte** — o plugin permite alternar entre eles e fixar um como o PDF *ativo* para aquele Inc Rem.
 - O plugin renderizará a visualização de leitura do PDF ou site dentro da fila.
 - Se você quiser transformar um destaque em um Rem incremental, clique no destaque e clique no ícone da peça de quebra-cabeça.
 - ** 📄 PDFs e Web**
   - **Estado Visual**: Os destaques ficam **Verdes** quando alternados como Incrementais e **Azuis** quando extraídos.
+  - **Painel de Controle de PDF**: Gerencie capítulos, defina intervalos de páginas e veja o histórico de leitura para documentos longos.
+  - **Seletor multi-PDF** *(novo)*: Quando um Inc Rem tem múltiplos PDFs como fonte, um dropdown aparece no Reader (ao lado do ícone 📝 de Notas do Documento), no Cronômetro de Revisão no Editor, no popup de Executar Repetição, no Painel de Controle de PDF e no Priority Editor — permitindo alternar o PDF em exibição e fixar um como ativo para aquele Inc Rem. A ordem de resolução é **fixação explícita → `#preferthispdf` → primeiro PDF**, aplicada uniformemente em todas as superfícies.
+  - **Rastreamento de Posição**: O plugin salva automaticamente sua última página lida ao usar o fluxo de Capítulos de PDF ou ao criar extrações.
   - **Criar Rem Incremental**: Selecione o texto em um PDF -> Destaque-o -> Clique no ícone de quebra-cabeça -> **"Create Incremental Rem"**. Isso extrai o texto para um novo Rem sob um pai de sua escolha (usando o seletor inteligente de pais).
 ![Destacar](https://raw.githubusercontent.com/bjsi/incremental-everything/main/img/highlight.gif)
 

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -7,7 +7,7 @@
   "version": {
     "major": 0,
     "minor": 2,
-    "patch": 224
+    "patch": 226
   },
   "unlisted": false,
   "theme": [],

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -7,7 +7,7 @@
   "version": {
     "major": 0,
     "minor": 2,
-    "patch": 226
+    "patch": 227
   },
   "unlisted": false,
   "theme": [],

--- a/src/components/Reader.tsx
+++ b/src/components/Reader.tsx
@@ -3,7 +3,7 @@ import { usePlugin, RemId, ReactRNPlugin } from '@remnote/plugin-sdk';
 import React, { useMemo } from 'react';
 import { activeHighlightIdKey, pageRangeWidgetId, incremNotesSidebarWidgetId } from '../lib/consts';
 import { HTMLActionItem, HTMLHighlightActionItem, PDFActionItem, PDFHighlightActionItem, RemActionItem } from '../lib/incremental_rem';
-import { getIncrementalReadingPosition, getIncrementalPageRange, clearIncrementalPDFData, PageRangeContext, getPageHistory } from '../lib/pdfUtils';
+import { getIncrementalReadingPosition, getIncrementalPageRange, clearIncrementalPDFData, PageRangeContext, getPageHistory, getAllPDFsInRem, setActivePdfForIncRem, safeRemTextToString } from '../lib/pdfUtils';
 import { Breadcrumb, BreadcrumbItem } from './Breadcrumb';
 import { useCriticalContext, useMetadataStats } from './reader/hooks';
 import { MemoizedPdfReader, PageControls, StatsGroup } from './reader/ui';
@@ -35,6 +35,10 @@ export function Reader(props: ReaderProps) {
   const [canRenderPdf, setCanRenderPdf] = React.useState(
     !(isIOS && (actionType === 'pdf' || actionType === 'pdf-highlight'))
   );
+  // PDFs available on the IncRem (>1 enables the switcher next to the 📝
+  // notes button). Only meaningful for actionType === 'pdf'; highlights are
+  // tied to a specific PDF and switching would invalidate the queue card.
+  const [pdfOptions, setPdfOptions] = React.useState<Array<{ remId: string; name: string; isPreferred: boolean }>>([]);
 
   // useState (Deferred States)
   const criticalContext = useCriticalContext(plugin as ReactRNPlugin, pdfRemId, pdfParentId, actionType, highlightExtractId || undefined, props.queueIncRemId);
@@ -224,6 +228,47 @@ export function Reader(props: ReaderProps) {
     hasScrolled.current = false;
   }, [pdfRemId]);
 
+  // Load PDF selector options when the IncRem is known. Keyed on IncRem id
+  // (not pdfRemId) so switching between this IncRem's PDFs doesn't re-fetch
+  // the list — the option set is the same.
+  const incRemIdForOptions = criticalContext?.incrementalRemId ?? null;
+  React.useEffect(() => {
+    if (!incRemIdForOptions || actionType !== 'pdf') {
+      setPdfOptions([]);
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      try {
+        const incRem = await plugin.rem.findOne(incRemIdForOptions);
+        if (!incRem || cancelled) return;
+        const pdfs = await getAllPDFsInRem(plugin as ReactRNPlugin, incRem);
+        if (cancelled) return;
+        const options = await Promise.all(
+          pdfs.map(async (p) => ({
+            remId: p.rem._id,
+            name: await safeRemTextToString(plugin as ReactRNPlugin, p.rem.text),
+            isPreferred: p.isPreferred,
+          }))
+        );
+        if (!cancelled) setPdfOptions(options);
+      } catch (e) {
+        console.error('[Reader] Failed to load PDF options:', e);
+        if (!cancelled) setPdfOptions([]);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [incRemIdForOptions, actionType, plugin]);
+
+  // Switch the active PDF for the IncRem. Writes the pin to synced storage,
+  // which fires queue.tsx's `remToActionItemType` tracker (it reads the pin
+  // key); the queue then hands Reader a new actionItem with the new PDF,
+  // and React reconciliation re-renders everything against the new pdfRemId.
+  const handlePdfSwitch = React.useCallback(async (newPdfId: string) => {
+    if (!incRemIdForOptions || newPdfId === pdfRemId) return;
+    await setActivePdfForIncRem(plugin as ReactRNPlugin, incRemIdForOptions, newPdfId);
+  }, [plugin, incRemIdForOptions, pdfRemId]);
+
   // --- 5. RENDER START ---
 
   // Use state variables for rendering
@@ -279,6 +324,30 @@ export function Reader(props: ReaderProps) {
           >
             📝
           </button>
+        )}
+        {actionType === 'pdf' && pdfOptions.length > 1 && (
+          <select
+            value={pdfRemId}
+            onChange={(e) => handlePdfSwitch(e.target.value)}
+            title="Switch active PDF for this IncRem"
+            style={{
+              flexShrink: 0,
+              fontSize: '11px',
+              padding: '2px 6px',
+              borderRadius: '4px',
+              border: '1px solid var(--rn-clr-border-primary)',
+              backgroundColor: 'var(--rn-clr-background-primary)',
+              color: 'var(--rn-clr-content-primary)',
+              maxWidth: '220px',
+              cursor: 'pointer',
+            }}
+          >
+            {pdfOptions.map((opt) => (
+              <option key={opt.remId} value={opt.remId}>
+                📄 {opt.name}{opt.isPreferred ? ' ★' : ''}
+              </option>
+            ))}
+          </select>
         )}
         <div style={{ flex: 1, minWidth: 0 }}>
           <Breadcrumb

--- a/src/lib/incremental_rem/action_items.ts
+++ b/src/lib/incremental_rem/action_items.ts
@@ -5,7 +5,7 @@ import {
   RichTextElementRemInterface,
 } from '@remnote/plugin-sdk';
 import { RemAndType } from './types';
-import { safeRemTextToString, getActivePdfKey } from '../pdfUtils';
+import { safeRemTextToString, getActivePdfForIncRem } from '../pdfUtils';
 import {
   videoExtractPowerupCode,
   videoExtractUrlSlotCode,
@@ -125,17 +125,18 @@ export const remToActionItemType = async (
     if (sources.length === 1) {
       selectedSource = sources[0];
     } else if (sources.length > 1) {
-      // An explicit per-IncRem PDF pin trumps the #preferthispdf tag scan.
-      // (No pin → existing tag-based behavior is preserved verbatim.)
-      const pinnedPdfId = await plugin.storage.getSynced<string>(getActivePdfKey(rem._id));
-      if (pinnedPdfId) {
-        const pinned = sources.find((s) => s._id === pinnedPdfId);
-        if (pinned) {
-          selectedSource = pinned;
-        }
-      }
-
-      if (!selectedSource) {
+      // Multi-source resolution for PDFs: pin → #preferthispdf → first PDF.
+      // Whenever the IncRem has any PDF source we open it in the Reader
+      // (the Reader's PDF switcher lets the user pick a different one).
+      // The legacy ExtractViewer fallback is reserved for the
+      // #extractviewer-tagged case handled at the top of this function.
+      const resolvedPdf = await getActivePdfForIncRem(plugin, rem);
+      if (resolvedPdf) {
+        selectedSource = resolvedPdf;
+      } else {
+        // No PDFs on this rem — fall back to the legacy #preferthispdf scan,
+        // which can also disambiguate among non-PDF sources (HTML, video, etc.)
+        // when the user has explicitly tagged one.
         const preferredSources: PluginRem[] = [];
         for (const source of sources) {
           try {
@@ -157,7 +158,7 @@ export const remToActionItemType = async (
         if (preferredSources.length === 1) {
           selectedSource = preferredSources[0];
         } else if (preferredSources.length > 1) {
-          await plugin.app.toast('Multiple PDFs have the #preferthispdf tag. Opening in standard Rem view instead of Reader.');
+          await plugin.app.toast('Multiple sources have the #preferthispdf tag. Opening in standard Rem view.');
         }
       }
     }

--- a/src/lib/incremental_rem/action_items.ts
+++ b/src/lib/incremental_rem/action_items.ts
@@ -5,7 +5,7 @@ import {
   RichTextElementRemInterface,
 } from '@remnote/plugin-sdk';
 import { RemAndType } from './types';
-import { safeRemTextToString } from '../pdfUtils';
+import { safeRemTextToString, getActivePdfKey } from '../pdfUtils';
 import {
   videoExtractPowerupCode,
   videoExtractUrlSlotCode,
@@ -125,28 +125,40 @@ export const remToActionItemType = async (
     if (sources.length === 1) {
       selectedSource = sources[0];
     } else if (sources.length > 1) {
-      const preferredSources: PluginRem[] = [];
-      for (const source of sources) {
-        try {
-          const tags = await source.getTagRems();
-          for (const tagRem of tags) {
-            if (!tagRem.text) continue;
-            const tagText = await safeRemTextToString(plugin, tagRem.text);
-            const tagLower = tagText.toLowerCase().replace(/\s+/g, '');
-            if (tagLower === 'preferthispdf') {
-              preferredSources.push(source);
-              break;
-            }
-          }
-        } catch (e) {
-          // Ignore errors reading tags
+      // An explicit per-IncRem PDF pin trumps the #preferthispdf tag scan.
+      // (No pin → existing tag-based behavior is preserved verbatim.)
+      const pinnedPdfId = await plugin.storage.getSynced<string>(getActivePdfKey(rem._id));
+      if (pinnedPdfId) {
+        const pinned = sources.find((s) => s._id === pinnedPdfId);
+        if (pinned) {
+          selectedSource = pinned;
         }
       }
 
-      if (preferredSources.length === 1) {
-        selectedSource = preferredSources[0];
-      } else if (preferredSources.length > 1) {
-        await plugin.app.toast('Multiple PDFs have the #preferthispdf tag. Opening in standard Rem view instead of Reader.');
+      if (!selectedSource) {
+        const preferredSources: PluginRem[] = [];
+        for (const source of sources) {
+          try {
+            const tags = await source.getTagRems();
+            for (const tagRem of tags) {
+              if (!tagRem.text) continue;
+              const tagText = await safeRemTextToString(plugin, tagRem.text);
+              const tagLower = tagText.toLowerCase().replace(/\s+/g, '');
+              if (tagLower === 'preferthispdf') {
+                preferredSources.push(source);
+                break;
+              }
+            }
+          } catch (e) {
+            // Ignore errors reading tags
+          }
+        }
+
+        if (preferredSources.length === 1) {
+          selectedSource = preferredSources[0];
+        } else if (preferredSources.length > 1) {
+          await plugin.app.toast('Multiple PDFs have the #preferthispdf tag. Opening in standard Rem view instead of Reader.');
+        }
       }
     }
 

--- a/src/lib/pdfUtils.ts
+++ b/src/lib/pdfUtils.ts
@@ -8,6 +8,13 @@ export interface PageRangeContext {
   pdfRemId: RemId;
   totalPages: number;
   currentPage: number;
+  /**
+   * All PDF rem IDs available for the IncRem, when known at popup-open time.
+   * Used by the panel's PDF selector for instant render. Undefined when the
+   * popup enters from a path that hasn't resolved the IncRem yet (the widget
+   * computes the list itself once the IncRem is resolved).
+   */
+  allPdfRemIds?: RemId[];
 }
 
 /**

--- a/src/lib/pdfUtils.ts
+++ b/src/lib/pdfUtils.ts
@@ -569,6 +569,121 @@ export const findPDFinRem = async (
 };
 
 /**
+ * Enumerate every PDF source attached to a rem, flagging which carry the
+ * `#preferthispdf` tag. The rem itself is included if it is an uploaded PDF.
+ *
+ * This is the building block for `findPreferredPDFInRem` (legacy strict
+ * resolver) and `getActivePdfForIncRem` (active-PDF-aware resolver).
+ */
+export const getAllPDFsInRem = async (
+  plugin: RNPlugin,
+  rem: PluginRem
+): Promise<Array<{ rem: PluginRem; isPreferred: boolean }>> => {
+  const isUploadedPdf = async (r: PluginRem): Promise<boolean> => {
+    if (!(await r.hasPowerup(BuiltInPowerupCodes.UploadedFile))) return false;
+    try {
+      const url = await r.getPowerupProperty(BuiltInPowerupCodes.UploadedFile, 'URL');
+      return typeof url === 'string' && url.toLowerCase().endsWith('.pdf');
+    } catch {
+      return false;
+    }
+  };
+
+  const hasPreferTag = async (r: PluginRem): Promise<boolean> => {
+    try {
+      const tags = await r.getTagRems();
+      for (const tagRem of tags) {
+        if (!tagRem.text) continue;
+        const tagText = (await safeRemTextToString(plugin, tagRem.text))
+          .toLowerCase()
+          .replace(/\s+/g, '');
+        if (tagText === 'preferthispdf') return true;
+      }
+    } catch {
+      // Ignore tag-read errors for individual PDFs
+    }
+    return false;
+  };
+
+  const result: Array<{ rem: PluginRem; isPreferred: boolean }> = [];
+
+  if (await isUploadedPdf(rem)) {
+    result.push({ rem, isPreferred: await hasPreferTag(rem) });
+  }
+
+  const sources = await rem.getSources();
+  for (const source of sources) {
+    if (await isUploadedPdf(source)) {
+      result.push({ rem: source, isPreferred: await hasPreferTag(source) });
+    }
+  }
+
+  return result;
+};
+
+/**
+ * Storage key for the user's explicitly chosen "active PDF" on an IncRem.
+ * Lets the user pin a non-preferred PDF as the focus of their work without
+ * editing tags.
+ */
+export const getActivePdfKey = (incRemId: string) => `active_pdf_for_${incRemId}`;
+
+/**
+ * Pin a PDF as the active one for an IncRem. Pass `null` to clear the pin.
+ */
+export const setActivePdfForIncRem = async (
+  plugin: RNPlugin,
+  incRemId: string,
+  pdfRemId: string | null
+): Promise<void> => {
+  await plugin.storage.setSynced(getActivePdfKey(incRemId), pdfRemId);
+};
+
+/**
+ * Resolve the PDF the user is currently focused on for an IncRem.
+ *
+ * Resolution order:
+ *   1. Explicit active PDF (`active_pdf_for_${remId}`) if still a source —
+ *      stale stored IDs are auto-cleared.
+ *   2. PDF tagged `#preferthispdf`. With multiple such PDFs:
+ *        - strict mode → null (caller communicates the conflict).
+ *        - default mode → first preferred PDF (graceful fallback).
+ *   3. First PDF source found.
+ *
+ * Returns null only if the rem has no PDFs, or if strict mode hit a
+ * multi-preferred conflict.
+ */
+export const getActivePdfForIncRem = async (
+  plugin: RNPlugin,
+  rem: PluginRem,
+  opts: { strict?: boolean } = {}
+): Promise<PluginRem | null> => {
+  const allPdfs = await getAllPDFsInRem(plugin, rem);
+  if (allPdfs.length === 0) return null;
+  if (allPdfs.length === 1) return allPdfs[0].rem;
+
+  // 1. Explicit active PDF
+  const activeId = await plugin.storage.getSynced<string>(getActivePdfKey(rem._id));
+  if (activeId) {
+    const match = allPdfs.find(p => p.rem._id === activeId);
+    if (match) return match.rem;
+    // Stored PDF is no longer a source — clear the stale pin.
+    await plugin.storage.setSynced(getActivePdfKey(rem._id), null);
+  }
+
+  // 2. Preferred PDF (#preferthispdf)
+  const preferred = allPdfs.filter(p => p.isPreferred);
+  if (preferred.length === 1) return preferred[0].rem;
+  if (preferred.length > 1) {
+    if (opts.strict) return null;
+    return preferred[0].rem;
+  }
+
+  // 3. First PDF source
+  return allPdfs[0].rem;
+};
+
+/**
  * Finds the best PDF for a given rem, respecting the `#preferthispdf` tag.
  *
  * Resolution order:
@@ -579,8 +694,9 @@ export const findPDFinRem = async (
  *     (caller should fall back to the standard ExtractViewer path).
  *  5. If no source has the tag → return the first PDF found (legacy behaviour).
  *
- * This mirrors the logic in `action_items.ts` but is exposed here so any
- * command or widget can call it without duplicating the tag-check loop.
+ * Strict resolver — does NOT consult the per-IncRem "active PDF" pin. Prefer
+ * `getActivePdfForIncRem` for new code; this remains for call sites that
+ * specifically want the multi-preferred conflict toast (e.g. legacy paths).
  */
 export const findPreferredPDFInRem = async (
   plugin: RNPlugin,
@@ -588,55 +704,12 @@ export const findPreferredPDFInRem = async (
   /** If true, show a toast when multiple #preferthispdf tags are found */
   showWarningToast: boolean = true
 ): Promise<PluginRem | null> => {
-  // Collect all PDF sources on this rem
-  const allPdfs: PluginRem[] = [];
-
-  // Rem itself may be a PDF
-  const isUploadedPdf = async (r: PluginRem) => {
-    if (!(await r.hasPowerup(BuiltInPowerupCodes.UploadedFile))) return false;
-    try {
-      const url = await r.getPowerupProperty(BuiltInPowerupCodes.UploadedFile, 'URL');
-      return typeof url === 'string' && url.toLowerCase().endsWith('.pdf');
-    } catch {
-      return false;
-    }
-  };
-
-  if (await isUploadedPdf(rem)) {
-    allPdfs.push(rem);
-  }
-
-  const sources = await rem.getSources();
-  for (const source of sources) {
-    if (await isUploadedPdf(source)) {
-      allPdfs.push(source);
-    }
-  }
-
+  const allPdfs = await getAllPDFsInRem(plugin, rem);
   if (allPdfs.length === 0) return null;
-  if (allPdfs.length === 1) return allPdfs[0];
+  if (allPdfs.length === 1) return allPdfs[0].rem;
 
-  // Multiple PDFs — look for #preferthispdf tag
-  const preferred: PluginRem[] = [];
-  for (const pdf of allPdfs) {
-    try {
-      const tags = await pdf.getTagRems();
-      for (const tagRem of tags) {
-        if (!tagRem.text) continue;
-        const tagText = (await safeRemTextToString(plugin, tagRem.text))
-          .toLowerCase()
-          .replace(/\s+/g, '');
-        if (tagText === 'preferthispdf') {
-          preferred.push(pdf);
-          break;
-        }
-      }
-    } catch {
-      // Ignore tag-read errors for individual PDFs
-    }
-  }
-
-  if (preferred.length === 1) return preferred[0];
+  const preferred = allPdfs.filter(p => p.isPreferred);
+  if (preferred.length === 1) return preferred[0].rem;
 
   if (preferred.length > 1 && showWarningToast) {
     await plugin.app.toast(
@@ -646,7 +719,7 @@ export const findPreferredPDFInRem = async (
   }
 
   // No tag found — fall back to first PDF (legacy behaviour)
-  return allPdfs[0];
+  return allPdfs[0].rem;
 };
 
 /**

--- a/src/lib/priority_graph_data.ts
+++ b/src/lib/priority_graph_data.ts
@@ -11,8 +11,14 @@ import { buildDocumentScope } from './scope_helpers';
 
 export interface GraphDataPoint {
     range: string;
-    incRem: number;
-    card: number;
+    /** IncRems with nextRepDate <= now */
+    incRemDue: number;
+    /** IncRems scheduled forward (already processed for now) */
+    incRemNotDue: number;
+    /** Rems with cards where dueCards > 0 */
+    cardDue: number;
+    /** Rems with cards where dueCards === 0 (all cards scheduled forward) */
+    cardNotDue: number;
 }
 
 export interface PriorityGraphData {
@@ -27,8 +33,10 @@ export interface PriorityGraphData {
 function createBins(): GraphDataPoint[] {
     return Array(20).fill(0).map((_, i) => ({
         range: `${i * 5}-${(i + 1) * 5}`,
-        incRem: 0,
-        card: 0,
+        incRemDue: 0,
+        incRemNotDue: 0,
+        cardDue: 0,
+        cardNotDue: 0,
     }));
 }
 
@@ -58,17 +66,21 @@ export function computePriorityGraphData(
 
     const binsAbsolute = createBins();
     const binsKbRelative = createBins();
+    const now = Date.now();
 
     // Fill bins from document-scoped IncRems
     for (const item of docIncRems) {
+        const isDue = item.nextRepDate <= now;
         const pAbs = Math.max(0, Math.min(100, item.priority));
         const absIndex = Math.min(Math.floor(pAbs / 5), 19);
-        binsAbsolute[absIndex].incRem++;
+        if (isDue) binsAbsolute[absIndex].incRemDue++;
+        else binsAbsolute[absIndex].incRemNotDue++;
 
         // KB-wide percentile for this item
         const pKb = Math.max(0, Math.min(100, kbIncRemPercentiles[item.remId] ?? 100));
         const kbIndex = Math.min(Math.floor(pKb / 5), 19);
-        binsKbRelative[kbIndex].incRem++;
+        if (isDue) binsKbRelative[kbIndex].incRemDue++;
+        else binsKbRelative[kbIndex].incRemNotDue++;
     }
 
     // Fill bins from document-scoped Cards
@@ -76,13 +88,16 @@ export function computePriorityGraphData(
     // only for child inheritance but have no actual cards themselves.
     for (const item of docCardInfos) {
         if (item.cardCount !== undefined && item.cardCount <= 0) continue;
+        const isDue = (item.dueCards ?? 0) > 0;
         const pAbs = Math.max(0, Math.min(100, item.priority));
         const absIndex = Math.min(Math.floor(pAbs / 5), 19);
-        binsAbsolute[absIndex].card++;
+        if (isDue) binsAbsolute[absIndex].cardDue++;
+        else binsAbsolute[absIndex].cardNotDue++;
 
         const pKb = Math.max(0, Math.min(100, kbCardPercentiles[item.remId] ?? 100));
         const kbIndex = Math.min(Math.floor(pKb / 5), 19);
-        binsKbRelative[kbIndex].card++;
+        if (isDue) binsKbRelative[kbIndex].cardDue++;
+        else binsKbRelative[kbIndex].cardNotDue++;
     }
 
     return {

--- a/src/lib/review_actions.ts
+++ b/src/lib/review_actions.ts
@@ -1,5 +1,5 @@
 import { RNPlugin, PluginRem } from '@remnote/plugin-sdk';
-import { findPDFinRem, getCurrentPageKey, addPageToHistory, safeRemTextToString } from './pdfUtils';
+import { getActivePdfForIncRem, getCurrentPageKey, addPageToHistory, safeRemTextToString } from './pdfUtils';
 import { getIncrementalRemFromRem, updateReviewRemData } from './incremental_rem';
 import { incremReviewStartTimeKey } from './consts';
 import { determineIncRemType } from './incRemHelpers';
@@ -13,7 +13,7 @@ export const handleReviewInEditorRem = async (
     if (!rem) return;
 
     if (remType === 'pdf') {
-        const pdfRem = await findPDFinRem(plugin, rem);
+        const pdfRem = await getActivePdfForIncRem(plugin, rem);
         if (pdfRem) {
             const pageKey = getCurrentPageKey(rem._id, pdfRem._id);
             const currentPage = await plugin.storage.getSynced<number>(pageKey);

--- a/src/register/commands.ts
+++ b/src/register/commands.ts
@@ -1093,11 +1093,15 @@ export async function registerCommands(plugin: ReactRNPlugin) {
 
       // 4. Prepare the context for the popup widget, similar to how the Reader does it.
       //    This context tells the popup which incremental Rem and which PDF to work with.
+      //    We also include the full list of PDFs on this IncRem so the panel can
+      //    render its PDF selector immediately (no re-derivation flash).
+      const allPdfs = await getAllPDFsInRem(plugin, rem);
       const context = {
         incrementalRemId: rem._id,
         pdfRemId: pdfRem._id,
         totalPages: undefined, // Not available in the editor context
         currentPage: undefined, // Not available in the editor context
+        allPdfRemIds: allPdfs.map((p) => p.rem._id),
       };
 
       // 5. Store the context in session storage so the popup can access it.

--- a/src/register/commands.ts
+++ b/src/register/commands.ts
@@ -27,7 +27,7 @@ import { initIncrementalRem } from './powerups';
 import { getIncrementalRemFromRem, handleNextRepetitionClick, getCurrentIncrementalRem } from '../lib/incremental_rem';
 import { removeIncrementalRemCache } from '../lib/incremental_rem/cache';
 import { IncrementalRep } from '../lib/incremental_rem/types';
-import { findPDFinRem, safeRemTextToString, getCurrentPageKey, addPageToHistory, registerRemsAsPdfKnown, findPreferredPDFInRem, getDescendantsToDepth, getRemCardContent } from '../lib/pdfUtils';
+import { safeRemTextToString, getCurrentPageKey, addPageToHistory, registerRemsAsPdfKnown, getActivePdfForIncRem, getAllPDFsInRem, getDescendantsToDepth, getRemCardContent } from '../lib/pdfUtils';
 import { transferToDismissed } from '../lib/dismissed';
 import { handleCardPriorityInheritance } from '../lib/card_priority/card_priority_inheritance';
 import { CARD_PRIORITY_CODE } from '../lib/card_priority/types';
@@ -1067,16 +1067,21 @@ export async function registerCommands(plugin: ReactRNPlugin) {
         return;
       }
 
-      // 1. Find the associated PDF Rem, honouring #preferthispdf when multiple sources exist
-      const pdfRem = await findPreferredPDFInRem(plugin, rem);
+      // 1. Resolve the active PDF for this rem.
+      //    Strict mode surfaces the multi-#preferthispdf conflict so the user
+      //    is alerted; an explicit active-PDF pin (when present) bypasses the
+      //    conflict by definition.
+      const pdfRem = await getActivePdfForIncRem(plugin, rem, { strict: true });
 
-      // 2. If no PDF is found (or multiple #preferthispdf tags conflict), inform the user and stop.
+      // 2. If nothing resolved, distinguish "no PDFs at all" from "ambiguous preference".
       if (!pdfRem) {
-        // findPreferredPDFInRem already showed a toast for the multi-tag conflict case;
-        // only show the generic message when truly no PDF was found.
-        const hasSomePdf = await findPDFinRem(plugin, rem);
-        if (!hasSomePdf) {
+        const pdfs = await getAllPDFsInRem(plugin, rem);
+        if (pdfs.length === 0) {
           await plugin.app.toast('No PDF found in the focused Rem or its sources.');
+        } else {
+          await plugin.app.toast(
+            'Multiple PDFs have the #preferthispdf tag — cannot determine which to open. Add the tag to exactly one PDF source.'
+          );
         }
         return;
       }
@@ -1848,7 +1853,7 @@ export async function registerCommands(plugin: ReactRNPlugin) {
       // Handle PDF page history (same as handleNextClick in answer_buttons.tsx)
       const remType = await plugin.storage.getSession<string | null>(currentIncrementalRemTypeKey);
       if (remType === 'pdf') {
-        const pdfRem = await findPDFinRem(plugin, rem);
+        const pdfRem = await getActivePdfForIncRem(plugin, rem);
         if (pdfRem) {
           const pageKey = getCurrentPageKey(rem._id, pdfRem._id);
           const currentPage = await plugin.storage.getSynced<number>(pageKey);

--- a/src/register/menus.ts
+++ b/src/register/menus.ts
@@ -12,7 +12,7 @@ import {
   pageRangeWidgetId,
   incRemDisabledDeviceKey,
 } from '../lib/consts';
-import { safeRemTextToString, findPDFinRem, findIncrementalRemForPDF, getPdfInfoFromHighlight, addPageToHistory, setIncrementalReadingPosition } from '../lib/pdfUtils';
+import { safeRemTextToString, getActivePdfForIncRem, findIncrementalRemForPDF, getPdfInfoFromHighlight, addPageToHistory, setIncrementalReadingPosition } from '../lib/pdfUtils';
 import { initIncrementalRem } from './powerups';
 import { createRemFromHighlight } from '../lib/highlightActions';
 
@@ -217,7 +217,7 @@ export async function registerMenus(plugin: ReactRNPlugin) {
       const rem = await plugin.rem.findOne(args.remId);
       if (!rem) return;
 
-      const pdfRem = await findPDFinRem(plugin, rem);
+      const pdfRem = await getActivePdfForIncRem(plugin, rem);
       if (!pdfRem) {
         await plugin.app.toast('No PDF found in this rem or its sources');
         return;

--- a/src/register/menus.ts
+++ b/src/register/menus.ts
@@ -12,7 +12,7 @@ import {
   pageRangeWidgetId,
   incRemDisabledDeviceKey,
 } from '../lib/consts';
-import { safeRemTextToString, getActivePdfForIncRem, findIncrementalRemForPDF, getPdfInfoFromHighlight, addPageToHistory, setIncrementalReadingPosition } from '../lib/pdfUtils';
+import { safeRemTextToString, getActivePdfForIncRem, getAllPDFsInRem, findIncrementalRemForPDF, getPdfInfoFromHighlight, addPageToHistory, setIncrementalReadingPosition } from '../lib/pdfUtils';
 import { initIncrementalRem } from './powerups';
 import { createRemFromHighlight } from '../lib/highlightActions';
 
@@ -223,14 +223,30 @@ export async function registerMenus(plugin: ReactRNPlugin) {
         return;
       }
 
-      // Open the popup immediately with a partial context (no incrementalRemId yet).
-      // The widget will resolve incrementalRemId itself using a fast cache-first path.
-      console.log('[PDF Control Panel] Opening popup immediately with pdfRemId:', pdfRem._id);
+      // If the menu was triggered from an IncRem document (rather than from
+      // the PDF document itself), pass the IncRem id directly. Without this,
+      // the widget falls back to findIncrementalRemForPDFFast, which walks
+      // the known-rems index and returns the *first* match — silently
+      // landing on the wrong IncRem when many share the same PDF (e.g. a
+      // book's chapters all sourcing the same textbook PDF). Pre-populating
+      // allPdfRemIds lets the PDF selector render immediately too.
+      const isIncRem = await rem.hasPowerup(powerupCode);
+      const incrementalRemId = isIncRem ? rem._id : null;
+      const allPdfRemIds = isIncRem
+        ? (await getAllPDFsInRem(plugin, rem)).map((p) => p.rem._id)
+        : undefined;
+
+      console.log('[PDF Control Panel] Opening popup with', {
+        pdfRemId: pdfRem._id,
+        incrementalRemId,
+        allPdfCount: allPdfRemIds?.length ?? 'unknown',
+      });
       await plugin.storage.setSession('pageRangeContext', {
         pdfRemId: pdfRem._id,
-        incrementalRemId: null,   // widget will fill this in
+        incrementalRemId,   // null only when triggered from a non-IncRem doc
         totalPages: 0,
         currentPage: 1,
+        allPdfRemIds,
       });
       await plugin.storage.setSession('pageRangePopupOpen', true);
       await plugin.widget.openPopup(pageRangeWidgetId);

--- a/src/widgets/answer_buttons.tsx
+++ b/src/widgets/answer_buttons.tsx
@@ -32,7 +32,7 @@ import { getIncrementalRemFromRem, handleNextRepetitionClick, handleNextRepetiti
 import { removeIncrementalRemCache } from '../lib/incremental_rem/cache';
 import { IncrementalRem } from '../lib/incremental_rem';
 import { percentileToHslColor, calculateRelativePercentile, calculateVolumeBasedPercentile, calculateWeightedShield, PERFORMANCE_MODE_LIGHT } from '../lib/utils';
-import { safeRemTextToString, findPDFinRem, findHTMLinRem, addPageToHistory, getPageHistory, getCurrentPageKey, getDescendantsToDepth } from '../lib/pdfUtils';
+import { safeRemTextToString, getActivePdfForIncRem, findHTMLinRem, addPageToHistory, getPageHistory, getCurrentPageKey, getDescendantsToDepth } from '../lib/pdfUtils';
 import { QueueSessionCache, setCardPriority } from '../lib/card_priority';
 import { WeightedShieldTooltip } from '../components';
 import { shouldUseLightMode } from '../lib/mobileUtils';
@@ -210,7 +210,7 @@ export function AnswerButtons() {
     if (type !== 'pdf' && type !== 'html') return null;
 
     const hostRem = type === 'pdf'
-      ? await findPDFinRem(rp, baseData.rem)
+      ? await getActivePdfForIncRem(rp, baseData.rem)
       : await findHTMLinRem(rp, baseData.rem);
     if (!hostRem) return null;
 
@@ -296,7 +296,7 @@ export function AnswerButtons() {
 
   const handleNextClick = async () => {
     if (remType === 'pdf') {
-      const pdfRem = await findPDFinRem(plugin, rem);
+      const pdfRem = await getActivePdfForIncRem(plugin, rem);
       if (pdfRem) {
         const pageKey = getCurrentPageKey(rem._id, pdfRem._id);
         const currentPage = await plugin.storage.getSynced<number>(pageKey);

--- a/src/widgets/editor_review.tsx
+++ b/src/widgets/editor_review.tsx
@@ -13,7 +13,7 @@ import { powerupCode, prioritySlotCode, pageRangeWidgetId } from '../lib/consts'
 import { IncrementalRep } from '../lib/incremental_rem';
 import dayjs from 'dayjs';
 import { findClosestIncrementalAncestor } from '../lib/priority_inheritance';
-import { safeRemTextToString, getActivePdfForIncRem, findHTMLinRem, getIncrementalReadingPosition, addPageToHistory, getPageHistory, getIncrementalPageRange, clearIncrementalPDFData, PageRangeContext } from '../lib/pdfUtils';
+import { safeRemTextToString, getActivePdfForIncRem, setActivePdfForIncRem, getAllPDFsInRem, findHTMLinRem, getIncrementalReadingPosition, addPageToHistory, getPageHistory, getIncrementalPageRange, clearIncrementalPDFData, PageRangeContext } from '../lib/pdfUtils';
 import { addToIncrementalHistory } from '../lib/history_utils';
 import { determineIncRemType } from '../lib/incRemHelpers';
 import { openRemInNewPane, openAndScrollToHighlight } from '../lib/remHelpers';
@@ -133,6 +133,9 @@ const EditorReviewInput: React.FC<{ plugin: RNPlugin; remId: string }> = ({ plug
   // PDF States
   const [pdfRemId, setPdfRemId] = useState<string | null>(null);
   const [isPdfNote, setIsPdfNote] = useState(false);
+  // PDFs on this IncRem (>1 enables the inline switcher). Switching pins the
+  // chosen PDF so handleStartTimer opens it and follows its bookmark.
+  const [pdfOptions, setPdfOptions] = useState<Array<{ remId: string; name: string; isPreferred: boolean }>>([]);
 
   const pdfControls = usePdfPageControls(plugin, remId, pdfRemId, 0);
 
@@ -155,6 +158,21 @@ const EditorReviewInput: React.FC<{ plugin: RNPlugin; remId: string }> = ({ plug
           setPdfRemId(pdfRem._id);
         } else {
           setIsPdfNote(false);
+        }
+
+        try {
+          const pdfs = await getAllPDFsInRem(plugin, rem);
+          const options = await Promise.all(
+            pdfs.map(async (p) => ({
+              remId: p.rem._id,
+              name: await safeRemTextToString(plugin, p.rem.text),
+              isPreferred: p.isPreferred,
+            }))
+          );
+          setPdfOptions(options);
+        } catch (e) {
+          console.error('[editor_review] Failed to load PDF options:', e);
+          setPdfOptions([]);
         }
       }
 
@@ -200,6 +218,13 @@ const EditorReviewInput: React.FC<{ plugin: RNPlugin; remId: string }> = ({ plug
         await plugin.widget.closePopup();
       }
     }
+  };
+
+  const handlePdfSwitch = async (newPdfId: string) => {
+    if (newPdfId === pdfRemId) return;
+    await setActivePdfForIncRem(plugin, remId, newPdfId);
+    setPdfRemId(newPdfId);
+    setIsPdfNote(true);
   };
 
   const handleStartTimer = async () => {
@@ -315,6 +340,34 @@ const EditorReviewInput: React.FC<{ plugin: RNPlugin; remId: string }> = ({ plug
           <div className="text-xs text-blue-600 dark:text-blue-400 mt-1">
             {ancestorInfo.ancestorName}
           </div>
+        </div>
+      )}
+
+      {pdfOptions.length > 1 && pdfRemId && (
+        <div className="flex items-center gap-2 my-2 p-2 border rounded shadow-sm bg-gray-50 dark:bg-gray-800 dark:border-gray-700">
+          <label className="text-xs font-semibold" htmlFor="pdf-switch">📄 PDF:</label>
+          <select
+            id="pdf-switch"
+            value={pdfRemId}
+            onChange={(e) => handlePdfSwitch(e.target.value)}
+            className="text-xs px-2 py-1 rounded flex-1"
+            style={{
+              border: '1px solid var(--rn-clr-border-primary)',
+              backgroundColor: 'var(--rn-clr-background-primary)',
+              color: 'var(--rn-clr-content-primary)',
+              maxWidth: '320px',
+            }}
+            title="Switch active PDF for this IncRem"
+          >
+            {pdfOptions.map((opt) => (
+              <option key={opt.remId} value={opt.remId}>
+                {opt.name}{opt.isPreferred ? ' ★' : ''}
+              </option>
+            ))}
+          </select>
+          <span className="text-xs" style={{ color: 'var(--rn-clr-content-tertiary)' }}>
+            ★ = #preferthispdf
+          </span>
         </div>
       )}
 

--- a/src/widgets/editor_review.tsx
+++ b/src/widgets/editor_review.tsx
@@ -13,7 +13,7 @@ import { powerupCode, prioritySlotCode, pageRangeWidgetId } from '../lib/consts'
 import { IncrementalRep } from '../lib/incremental_rem';
 import dayjs from 'dayjs';
 import { findClosestIncrementalAncestor } from '../lib/priority_inheritance';
-import { safeRemTextToString, findPDFinRem, findHTMLinRem, getIncrementalReadingPosition, addPageToHistory, getPageHistory, getIncrementalPageRange, clearIncrementalPDFData, PageRangeContext } from '../lib/pdfUtils';
+import { safeRemTextToString, getActivePdfForIncRem, findHTMLinRem, getIncrementalReadingPosition, addPageToHistory, getPageHistory, getIncrementalPageRange, clearIncrementalPDFData, PageRangeContext } from '../lib/pdfUtils';
 import { addToIncrementalHistory } from '../lib/history_utils';
 import { determineIncRemType } from '../lib/incRemHelpers';
 import { openRemInNewPane, openAndScrollToHighlight } from '../lib/remHelpers';
@@ -49,7 +49,7 @@ async function handleEditorReview(
   const reviewTimeSeconds = Math.round(reviewTimeMinutes * 60);
 
   // Synchronize time spent reading directly to the PDF reading history tracker
-  const pdfRem = await findPDFinRem(plugin, rem);
+  const pdfRem = await getActivePdfForIncRem(plugin, rem);
   if (pdfRem && reviewTimeSeconds > 0) {
     const activePage = await getIncrementalReadingPosition(plugin, remId, pdfRem._id);
     await addPageToHistory(plugin, remId, pdfRem._id, activePage || 1, reviewTimeSeconds);
@@ -149,7 +149,7 @@ const EditorReviewInput: React.FC<{ plugin: RNPlugin; remId: string }> = ({ plug
         const name = await safeRemTextToString(plugin, rem.text);
         setRemName(name);
 
-        const pdfRem = await findPDFinRem(plugin, rem);
+        const pdfRem = await getActivePdfForIncRem(plugin, rem);
         if (pdfRem) {
           setIsPdfNote(true);
           setPdfRemId(pdfRem._id);
@@ -230,7 +230,7 @@ const EditorReviewInput: React.FC<{ plugin: RNPlugin; remId: string }> = ({ plug
       }
 
       // Host resolution: PDF first, then HTML article (Reader Mode source).
-      const pdfRem = await findPDFinRem(plugin, rem);
+      const pdfRem = await getActivePdfForIncRem(plugin, rem);
       const hostRem = pdfRem ?? (await findHTMLinRem(plugin, rem));
       const incRemType = await determineIncRemType(plugin, rem);
 

--- a/src/widgets/editor_review_timer.tsx
+++ b/src/widgets/editor_review_timer.tsx
@@ -13,7 +13,7 @@ import { handleCardPriorityInheritance } from '../lib/card_priority/card_priorit
 import { addToIncrementalHistory } from '../lib/history_utils';
 import { IncrementalRep } from '../lib/incremental_rem';
 import { determineIncRemType } from '../lib/incRemHelpers';
-import { getActivePdfForIncRem, findHTMLinRem, clearIncrementalPDFData, PageRangeContext, addPageToHistory, getPageHistory, safeRemTextToString } from '../lib/pdfUtils';
+import { getActivePdfForIncRem, setActivePdfForIncRem, getAllPDFsInRem, findHTMLinRem, clearIncrementalPDFData, PageRangeContext, addPageToHistory, getPageHistory, safeRemTextToString } from '../lib/pdfUtils';
 import { openAndScrollToHighlight } from '../lib/remHelpers';
 import { PageControls } from '../components/reader/ui';
 import { usePdfPageControls } from '../components/reader/usePdfPageControls';
@@ -35,6 +35,9 @@ function EditorReviewTimer() {
   const [hostRemId, setHostRemId] = useState<string | null>(null);
   const [hostKind, setHostKind] = useState<'pdf' | 'html' | null>(null);
   const [bookmarkHighlightId, setBookmarkHighlightId] = useState<string | null>(null);
+  // PDFs available on the timer's IncRem. When length > 1 a small switcher
+  // appears next to the page controls.
+  const [pdfOptions, setPdfOptions] = useState<Array<{ remId: string; name: string; isPreferred: boolean }>>([]);
 
   const timerData = useTrackerPlugin(
     async (rp) => {
@@ -106,6 +109,7 @@ function EditorReviewTimer() {
         setHostRemId(null);
         setHostKind(null);
         setBookmarkHighlightId(null);
+        setPdfOptions([]);
         return;
       }
 
@@ -132,9 +136,43 @@ function EditorReviewTimer() {
         setHostKind(null);
         setBookmarkHighlightId(null);
       }
+
+      // Populate PDF selector options (shown only when >1 PDF)
+      try {
+        const pdfs = await getAllPDFsInRem(plugin, rem);
+        const options = await Promise.all(
+          pdfs.map(async (p) => ({
+            remId: p.rem._id,
+            name: await safeRemTextToString(plugin, p.rem.text),
+            isPreferred: p.isPreferred,
+          }))
+        );
+        setPdfOptions(options);
+      } catch (e) {
+        console.error('[editor_review_timer] Failed to load PDF options:', e);
+        setPdfOptions([]);
+      }
     };
     loadHostData();
   }, [timerData?.remId, plugin]);
+
+  // Switch the active PDF for the timer's IncRem. Pins the choice, then
+  // updates the in-widget host state so PageControls, the Scroll bookmark,
+  // and any subsequent reading-time records target the new PDF.
+  const handlePdfSwitch = useCallback(async (newPdfId: string) => {
+    if (!timerData?.remId || newPdfId === pdfRemId) return;
+
+    await setActivePdfForIncRem(plugin, timerData.remId, newPdfId);
+
+    setPdfRemId(newPdfId);
+    setHostRemId(newPdfId);
+    setHostKind('pdf');
+    setIsPdfNote(true);
+
+    const history = await getPageHistory(plugin, timerData.remId, newPdfId);
+    const lastEntry = history[history.length - 1];
+    setBookmarkHighlightId(lastEntry?.highlightId ?? null);
+  }, [plugin, timerData?.remId, pdfRemId]);
 
   const isPaused = !!(timerData?.pausedAt);
 
@@ -578,6 +616,30 @@ function EditorReviewTimer() {
 
       {(isPdfNote || (hostRemId && bookmarkHighlightId)) && (
         <div style={{ display: 'flex', alignItems: 'center', gap: '8px', marginRight: '8px', paddingRight: '12px', borderRight: '1px solid #93c5fd' }}>
+          {/* PDF switcher — only when the IncRem has >1 PDF source. */}
+          {pdfOptions.length > 1 && pdfRemId && (
+            <select
+              value={pdfRemId}
+              onChange={(e) => handlePdfSwitch(e.target.value)}
+              title="Switch active PDF for this IncRem"
+              style={{
+                fontSize: '12px',
+                padding: '3px 6px',
+                borderRadius: '4px',
+                border: '1px solid #3b82f6',
+                backgroundColor: 'white',
+                color: '#1e40af',
+                maxWidth: '180px',
+                fontWeight: 600,
+              }}
+            >
+              {pdfOptions.map((opt) => (
+                <option key={opt.remId} value={opt.remId}>
+                  {opt.name}{opt.isPreferred ? ' ★' : ''}
+                </option>
+              ))}
+            </select>
+          )}
           {/* Page controls only apply to PDF hosts. */}
           {isPdfNote && pdfRemId && (
             <PageControls

--- a/src/widgets/editor_review_timer.tsx
+++ b/src/widgets/editor_review_timer.tsx
@@ -13,7 +13,7 @@ import { handleCardPriorityInheritance } from '../lib/card_priority/card_priorit
 import { addToIncrementalHistory } from '../lib/history_utils';
 import { IncrementalRep } from '../lib/incremental_rem';
 import { determineIncRemType } from '../lib/incRemHelpers';
-import { findPDFinRem, findHTMLinRem, clearIncrementalPDFData, PageRangeContext, addPageToHistory, getPageHistory, safeRemTextToString } from '../lib/pdfUtils';
+import { getActivePdfForIncRem, findHTMLinRem, clearIncrementalPDFData, PageRangeContext, addPageToHistory, getPageHistory, safeRemTextToString } from '../lib/pdfUtils';
 import { openAndScrollToHighlight } from '../lib/remHelpers';
 import { PageControls } from '../components/reader/ui';
 import { usePdfPageControls } from '../components/reader/usePdfPageControls';
@@ -109,7 +109,7 @@ function EditorReviewTimer() {
         return;
       }
 
-      const pdfRem = await findPDFinRem(plugin, rem);
+      const pdfRem = await getActivePdfForIncRem(plugin, rem);
       const htmlRem = pdfRem ? null : await findHTMLinRem(plugin, rem);
       const host = pdfRem ?? htmlRem;
 

--- a/src/widgets/inc_rem_main_view.tsx
+++ b/src/widgets/inc_rem_main_view.tsx
@@ -25,27 +25,40 @@ import {
 
 interface GraphDataPoint {
   range: string;
-  incRem: number;
-  card: number;
+  incRemDue: number;
+  incRemNotDue: number;
+  cardDue: number;
+  cardNotDue: number;
 }
+
+const INC_REM_DUE_COLOR = '#3b82f6';
+const INC_REM_NOT_DUE_COLOR = '#bfdbfe';
+const CARD_DUE_COLOR = '#ef4444';
+const CARD_NOT_DUE_COLOR = '#fecaca';
 
 /**
  * Computes absolute priority bins from all KB IncRems and card infos.
+ * Each bin splits items into "due" (nextRepDate <= now for IncRems; dueCards > 0
+ * for rems with cards) and "not due" (already processed, scheduled forward).
  */
 function computeKbGraphBins(
   allIncRems: IncrementalRem[],
   allCardInfos: CardPriorityInfo[],
 ): GraphDataPoint[] {
+  const now = Date.now();
   const bins: GraphDataPoint[] = Array(20).fill(0).map((_, i) => ({
     range: `${i * 5}-${(i + 1) * 5}`,
-    incRem: 0,
-    card: 0,
+    incRemDue: 0,
+    incRemNotDue: 0,
+    cardDue: 0,
+    cardNotDue: 0,
   }));
 
   for (const item of allIncRems) {
     const p = Math.max(0, Math.min(100, item.priority));
     const idx = Math.min(Math.floor(p / 5), 19);
-    bins[idx].incRem++;
+    if (item.nextRepDate <= now) bins[idx].incRemDue++;
+    else bins[idx].incRemNotDue++;
   }
 
   // Filter out inheritance-only rems (cardCount === 0) that hold the powerup
@@ -54,10 +67,51 @@ function computeKbGraphBins(
     if (item.cardCount !== undefined && item.cardCount <= 0) continue;
     const p = Math.max(0, Math.min(100, item.priority));
     const idx = Math.min(Math.floor(p / 5), 19);
-    bins[idx].card++;
+    if ((item.dueCards ?? 0) > 0) bins[idx].cardDue++;
+    else bins[idx].cardNotDue++;
   }
 
   return bins;
+}
+
+function PriorityBinTooltip({ active, payload, label }: any) {
+  if (!active || !payload || payload.length === 0) return null;
+  const data = payload[0]?.payload as GraphDataPoint | undefined;
+  if (!data) return null;
+
+  const incTotal = data.incRemDue + data.incRemNotDue;
+  const cardTotal = data.cardDue + data.cardNotDue;
+  const incPct = incTotal > 0 ? Math.round((data.incRemNotDue / incTotal) * 100) : 0;
+  const cardPct = cardTotal > 0 ? Math.round((data.cardNotDue / cardTotal) * 100) : 0;
+
+  return (
+    <div
+      style={{
+        borderRadius: 8,
+        border: 'none',
+        boxShadow: '0 4px 6px -1px rgba(0,0,0,0.1)',
+        background: 'white',
+        padding: '8px 10px',
+        fontSize: 12,
+        color: '#374151',
+        lineHeight: 1.4,
+      }}
+    >
+      <div style={{ fontWeight: 600, marginBottom: 4 }}>{label}</div>
+      <div style={{ color: INC_REM_DUE_COLOR, fontWeight: 600 }}>
+        Incremental Rems: {incTotal}
+      </div>
+      <div style={{ marginLeft: 8 }}>
+        Due: {data.incRemDue} · Processed: {data.incRemNotDue} ({incPct}%)
+      </div>
+      <div style={{ color: CARD_DUE_COLOR, fontWeight: 600, marginTop: 4 }}>
+        Rems with Cards: {cardTotal}
+      </div>
+      <div style={{ marginLeft: 8 }}>
+        Due: {data.cardDue} · Processed: {data.cardNotDue} ({cardPct}%)
+      </div>
+    </div>
+  );
 }
 
 const INC_REM_MAIN_VIEW_STATE_KEY = 'inc-rem-main-view-state';
@@ -381,8 +435,8 @@ export function IncRemMainView() {
               </span>
             </h4>
 
-            <div style={{ width: '100%', height: 250 }}>
-              <ResponsiveContainer width="100%" height="100%" minHeight={250} minWidth={100}>
+            <div style={{ width: '100%', height: 350 }}>
+              <ResponsiveContainer width="100%" height="100%" minHeight={350} minWidth={100}>
                 <BarChart
                   data={graphBins}
                   margin={{ top: 5, right: 10, left: 0, bottom: 5 }}
@@ -412,12 +466,12 @@ export function IncRemMainView() {
                     tickFormatter={(v: number) => v >= 1000 ? `${(v / 1000).toFixed(v % 1000 === 0 ? 0 : 1)}k` : String(v)}
                     label={{ value: 'Rems with Cards', angle: 90, position: 'insideRight', fill: '#ef4444', fontSize: 10 }}
                   />
-                  <Tooltip
-                    contentStyle={{ borderRadius: '8px', border: 'none', boxShadow: '0 4px 6px -1px rgba(0, 0, 0, 0.1)' }}
-                  />
+                  <Tooltip content={<PriorityBinTooltip />} />
                   <Legend verticalAlign="top" height={36} />
-                  <Bar yAxisId="left" dataKey="incRem" name="Incremental Rems" fill="#3b82f6" />
-                  <Bar yAxisId="right" dataKey="card" name="Rems with Cards" fill="#ef4444" />
+                  <Bar yAxisId="left" stackId="incRem" dataKey="incRemNotDue" name="IncRems · Processed" fill={INC_REM_NOT_DUE_COLOR} />
+                  <Bar yAxisId="left" stackId="incRem" dataKey="incRemDue" name="IncRems · Due" fill={INC_REM_DUE_COLOR} />
+                  <Bar yAxisId="right" stackId="card" dataKey="cardNotDue" name="Cards · Processed" fill={CARD_NOT_DUE_COLOR} />
+                  <Bar yAxisId="right" stackId="card" dataKey="cardDue" name="Cards · Due" fill={CARD_DUE_COLOR} />
                 </BarChart>
               </ResponsiveContainer>
             </div>

--- a/src/widgets/page-range.tsx
+++ b/src/widgets/page-range.tsx
@@ -19,6 +19,7 @@ import {
   addPageToHistory,
   getReadingStatistics,
   getAllPDFsInRem,
+  getActivePdfForIncRem,
   setActivePdfForIncRem,
   safeRemTextToString,
   PageHistoryEntry,
@@ -63,8 +64,12 @@ function PageRangeWidget() {
 
   // PDFs available on the IncRem context (computed after IncRem resolves).
   // When length > 1 the header renders a selector that switches the panel's
-  // PDF view and pins the chosen PDF as active for this IncRem.
+  // PDF *view*. Pinning the viewed PDF as active is a separate action
+  // (the "📌 Set as active" button next to the selector).
   const [pdfOptions, setPdfOptions] = useState<Array<{ remId: string; name: string; isPreferred: boolean }>>([]);
+  // Currently-pinned active PDF for the IncRem, used to mark the option in
+  // the dropdown and decide whether the "Set as active" button is visible.
+  const [activePdfId, setActivePdfId] = useState<string | null>(null);
 
   const handleInitIncrementalRem = async (remId: string) => {
     try {
@@ -406,8 +411,8 @@ function PageRangeWidget() {
           setIsCurrentRemIncremental(isIncremental);
 
           // Build the PDF selector options for this IncRem. Hidden in the UI
-          // when length <= 1; otherwise lets the user switch the panel's view
-          // and pin the chosen PDF as active.
+          // when length <= 1. Also resolve the currently-active PDF so we can
+          // mark it in the dropdown with 📌.
           try {
             const pdfs = await getAllPDFsInRem(plugin, currentRem);
             const options = await Promise.all(
@@ -418,9 +423,12 @@ function PageRangeWidget() {
               }))
             );
             setPdfOptions(options);
+            const activePdf = await getActivePdfForIncRem(plugin, currentRem);
+            setActivePdfId(activePdf?._id ?? null);
           } catch (e) {
             console.error('[page-range] Failed to load PDF options:', e);
             setPdfOptions([]);
+            setActivePdfId(null);
           }
         }
 
@@ -523,18 +531,24 @@ function PageRangeWidget() {
 
   const handleClose = () => plugin.widget.closePopup();
 
-  // Switch which PDF the panel is viewing for the current IncRem.
-  // Pins the chosen PDF as active so future opens of this IncRem (queue,
-  // Reader, Priority Editor) follow the same choice.
+  // Switch which PDF the panel is viewing. View-only — does NOT change the
+  // active pin. The user pins explicitly via the "📌 Set as active" button.
   const handlePdfChange = async (newPdfId: string) => {
     if (!contextData || newPdfId === contextData.pdfRemId) return;
-    if (contextData.incrementalRemId) {
-      await setActivePdfForIncRem(plugin, contextData.incrementalRemId, newPdfId);
-    }
     await plugin.storage.setSession('pageRangeContext', {
       ...contextData,
       pdfRemId: newPdfId,
     });
+  };
+
+  // Pin the currently-viewed PDF as the IncRem's active PDF. Shown only
+  // while viewing a non-active PDF; hidden once the view matches the pin.
+  const handleSetActive = async () => {
+    if (!contextData?.incrementalRemId || !contextData.pdfRemId) return;
+    if (contextData.pdfRemId === activePdfId) return;
+    await setActivePdfForIncRem(plugin, contextData.incrementalRemId, contextData.pdfRemId);
+    setActivePdfId(contextData.pdfRemId);
+    await plugin.app.toast('Active PDF updated');
   };
 
 
@@ -793,7 +807,10 @@ function PageRangeWidget() {
       </div>
 
       {/* PDF Selector — only shown when the IncRem has >1 PDF source.
-          Selecting an option pins it as active and reloads the panel for that PDF. */}
+          Selecting an option changes only what the panel displays. To pin a
+          PDF as active for the IncRem, use the "📌 Set as active" button
+          (appears whenever the viewed PDF is not already the active one).
+          ★ = #preferthispdf · 📌 = currently active for this IncRem. */}
       {pdfOptions.length > 1 && (
         <div
           className="flex items-center gap-2 px-4 py-1.5 shrink-0"
@@ -813,16 +830,28 @@ function PageRangeWidget() {
               border: '1px solid var(--rn-clr-border-primary)',
               maxWidth: '360px',
             }}
-            title="Switch which PDF the panel is managing — pins it as active for this Rem"
+            title="Switch which PDF the panel is displaying (view-only — use the 📌 button to pin)"
           >
             {pdfOptions.map((opt) => (
               <option key={opt.remId} value={opt.remId}>
-                {opt.name}{opt.isPreferred ? ' ★' : ''}
+                {opt.name}{opt.isPreferred ? ' ★' : ''}{opt.remId === activePdfId ? ' 📌' : ''}
               </option>
             ))}
           </select>
+          {contextData?.pdfRemId && contextData.pdfRemId !== activePdfId && (
+            <button
+              onClick={handleSetActive}
+              className="px-2 py-1 text-xs rounded transition-colors whitespace-nowrap"
+              style={{ backgroundColor: '#3b82f6', color: 'white', border: 'none' }}
+              onMouseEnter={(e) => { e.currentTarget.style.backgroundColor = '#2563eb'; }}
+              onMouseLeave={(e) => { e.currentTarget.style.backgroundColor = '#3b82f6'; }}
+              title="Pin this PDF as the active one for this Inc Rem"
+            >
+              📌 Set as active
+            </button>
+          )}
           <span className="text-xs" style={{ color: 'var(--rn-clr-content-tertiary)' }}>
-            ★ = #preferthispdf · selecting pins this PDF as active
+            ★ #preferthispdf · 📌 active
           </span>
         </div>
       )}

--- a/src/widgets/page-range.tsx
+++ b/src/widgets/page-range.tsx
@@ -18,6 +18,9 @@ import {
   setIncrementalReadingPosition,
   addPageToHistory,
   getReadingStatistics,
+  getAllPDFsInRem,
+  setActivePdfForIncRem,
+  safeRemTextToString,
   PageHistoryEntry,
   PageRangeContext,
 } from '../lib/pdfUtils';
@@ -57,6 +60,11 @@ function PageRangeWidget() {
   const [editingState, setEditingState] = useState<EditingState>({ type: 'none' });
   const [totalPdfReadingTime, setTotalPdfReadingTime] = useState<number>(0);
   const [isBackgroundRefreshing, setIsBackgroundRefreshing] = useState(false);
+
+  // PDFs available on the IncRem context (computed after IncRem resolves).
+  // When length > 1 the header renders a selector that switches the panel's
+  // PDF view and pins the chosen PDF as active for this IncRem.
+  const [pdfOptions, setPdfOptions] = useState<Array<{ remId: string; name: string; isPreferred: boolean }>>([]);
 
   const handleInitIncrementalRem = async (remId: string) => {
     try {
@@ -396,6 +404,24 @@ function PageRangeWidget() {
           const isIncremental = await currentRem.hasPowerup(powerupCode);
           setCurrentRemName(remText);
           setIsCurrentRemIncremental(isIncremental);
+
+          // Build the PDF selector options for this IncRem. Hidden in the UI
+          // when length <= 1; otherwise lets the user switch the panel's view
+          // and pin the chosen PDF as active.
+          try {
+            const pdfs = await getAllPDFsInRem(plugin, currentRem);
+            const options = await Promise.all(
+              pdfs.map(async (p) => ({
+                remId: p.rem._id,
+                name: await safeRemTextToString(plugin, p.rem.text),
+                isPreferred: p.isPreferred,
+              }))
+            );
+            setPdfOptions(options);
+          } catch (e) {
+            console.error('[page-range] Failed to load PDF options:', e);
+            setPdfOptions([]);
+          }
         }
 
         // Load page range for current rem
@@ -496,6 +522,20 @@ function PageRangeWidget() {
   };
 
   const handleClose = () => plugin.widget.closePopup();
+
+  // Switch which PDF the panel is viewing for the current IncRem.
+  // Pins the chosen PDF as active so future opens of this IncRem (queue,
+  // Reader, Priority Editor) follow the same choice.
+  const handlePdfChange = async (newPdfId: string) => {
+    if (!contextData || newPdfId === contextData.pdfRemId) return;
+    if (contextData.incrementalRemId) {
+      await setActivePdfForIncRem(plugin, contextData.incrementalRemId, newPdfId);
+    }
+    await plugin.storage.setSession('pageRangeContext', {
+      ...contextData,
+      pdfRemId: newPdfId,
+    });
+  };
 
 
 
@@ -751,6 +791,41 @@ function PageRangeWidget() {
           ✕
         </button>
       </div>
+
+      {/* PDF Selector — only shown when the IncRem has >1 PDF source.
+          Selecting an option pins it as active and reloads the panel for that PDF. */}
+      {pdfOptions.length > 1 && (
+        <div
+          className="flex items-center gap-2 px-4 py-1.5 shrink-0"
+          style={{
+            borderBottom: '1px solid var(--rn-clr-border-primary)',
+            backgroundColor: 'var(--rn-clr-background-secondary)',
+          }}
+        >
+          <span className="text-xs" style={{ color: 'var(--rn-clr-content-secondary)' }}>📄 PDF:</span>
+          <select
+            value={contextData?.pdfRemId ?? ''}
+            onChange={(e) => handlePdfChange(e.target.value)}
+            className="text-xs px-2 py-1 rounded"
+            style={{
+              backgroundColor: 'var(--rn-clr-background-primary)',
+              color: 'var(--rn-clr-content-primary)',
+              border: '1px solid var(--rn-clr-border-primary)',
+              maxWidth: '360px',
+            }}
+            title="Switch which PDF the panel is managing — pins it as active for this Rem"
+          >
+            {pdfOptions.map((opt) => (
+              <option key={opt.remId} value={opt.remId}>
+                {opt.name}{opt.isPreferred ? ' ★' : ''}
+              </option>
+            ))}
+          </select>
+          <span className="text-xs" style={{ color: 'var(--rn-clr-content-tertiary)' }}>
+            ★ = #preferthispdf · selecting pins this PDF as active
+          </span>
+        </div>
+      )}
 
       <div className="flex-1 overflow-y-auto px-3 py-2" style={{ minHeight: 0 }}>
 

--- a/src/widgets/priority.tsx
+++ b/src/widgets/priority.tsx
@@ -72,6 +72,11 @@ function Priority() {
   // RelPriority moved to useMemo below derivedData to ensure synchronous updates (fixing flicker)
   const [showConfirmation, setShowConfirmation] = useState(false);
   const [showInheritanceForIncRem, setShowInheritanceForIncRem] = useState(false);
+  // Optimistic flag: flipped instantly when the user clicks "Convert to Manual"
+  // so the UI reflects the new source before the background tracker's DB write
+  // propagates back through useTrackerPlugin. Auto-cleared below once the raw
+  // cardInfo.source resolves to 'manual'.
+  const [convertedToManual, setConvertedToManual] = useState(false);
   const incSliderRef = useRef<PrioritySliderRef>(null);
   const cardSliderRef = useRef<PrioritySliderRef>(null);
   const isSaving = useRef(false);
@@ -264,7 +269,17 @@ function Priority() {
 
   // Then use:
   const hasCards = cardData?.hasCards ?? undefined;
-  const cardInfo = cardData?.cardInfo ?? undefined;
+  // Apply the optimistic 'Convert to Manual' override on top of the raw fetched
+  // cardInfo so every downstream consumer (badge, label, button visibility,
+  // confirmation dialog gating) sees the new source immediately.
+  const cardInfo = useMemo(() => {
+    const raw = cardData?.cardInfo;
+    if (!raw) return undefined;
+    if (convertedToManual && raw.source === 'inherited') {
+      return { ...raw, source: 'manual' as CardPriorityInfo['source'] };
+    }
+    return raw;
+  }, [cardData?.cardInfo, convertedToManual]);
   const hasCardPriorityPowerup = cardData?.hasCardPriorityPowerup ?? false;
 
   // This tracker is fast (direct Rem lookup) so it can run in both modes,
@@ -424,10 +439,21 @@ function Priority() {
   useEffect(() => {
     incIsDirty.current = false;
     cardIsDirty.current = false;
+    setConvertedToManual(false);
     // We don't necessarily want to set priorities to null here because other hooks
     // might be about to set them, and setting null might cause a flash.
     // However, for cleanliness on ID swap, we should relying on the data hooks to fire again.
   }, [rem?._id]);
+
+  // Auto-clear the 'Convert to Manual' override once useTrackerPlugin re-fetches
+  // cardInfo with source='manual' from the DB. We key off the RAW source from
+  // cardData (not the derived cardInfo.source, which is always 'manual' while
+  // the override is on) to avoid a flip-flop.
+  useEffect(() => {
+    if (convertedToManual && cardData?.cardInfo?.source === 'manual') {
+      setConvertedToManual(false);
+    }
+  }, [cardData?.cardInfo?.source, convertedToManual]);
 
   useEffect(() => {
     if (isSaving.current) return;
@@ -700,10 +726,14 @@ function Priority() {
   const convertToManual = useCallback(() => {
     if (!rem || !cardInfo) return;
 
-    // 1. Optimistic cache update + descendant cascade trigger.
+    // 1. Flip the UI to 'manual' immediately. The override self-clears once the
+    //    DB write propagates back via useTrackerPlugin (see the auto-clear effect).
+    setConvertedToManual(true);
+
+    // 2. Optimistic cache update + descendant cascade trigger.
     saveCardPriority(cardInfo.priority).catch(console.error);
 
-    // 2. Persist source='manual' to the DB via the background tracker.
+    // 3. Persist source='manual' to the DB via the background tracker.
     //    triggerCascade=false because saveCardPriority already scheduled one.
     plugin.storage.setSession(pendingPrioritySaveKey, {
       remId: rem._id,

--- a/src/widgets/priority.tsx
+++ b/src/widgets/priority.tsx
@@ -692,6 +692,29 @@ function Priority() {
 
   }, [rem, plugin, sessionCache, originalScopeId, performanceMode, cardInfo, hasCardPriorityPowerup]); // 🔌 Add performanceMode
 
+  // Convert an inherited card priority to manual without changing its numeric value.
+  // saveCardPriority alone only patches the session cache; the SOURCE_SLOT in the DB
+  // is only written by the background tracker watching pendingPrioritySaveKey. Without
+  // this dual write, the optimistic 'manual' flip is immediately overwritten the next
+  // time getCardPriority reads SOURCE_SLOT from the DB.
+  const convertToManual = useCallback(() => {
+    if (!rem || !cardInfo) return;
+
+    // 1. Optimistic cache update + descendant cascade trigger.
+    saveCardPriority(cardInfo.priority).catch(console.error);
+
+    // 2. Persist source='manual' to the DB via the background tracker.
+    //    triggerCascade=false because saveCardPriority already scheduled one.
+    plugin.storage.setSession(pendingPrioritySaveKey, {
+      remId: rem._id,
+      incPriority: null,
+      cardPriority: cardInfo.priority,
+      cardSource: 'manual',
+      needsAddPowerup: !hasCardPriorityPowerup,
+      triggerCascade: false,
+    }).catch(console.error);
+  }, [rem, cardInfo, hasCardPriorityPowerup, saveCardPriority, plugin]);
+
   const showInheritanceSection =
     (!showIncSection && !showCardSection) ||
     (showIncSection && !hasCards && cardInfo?.source === 'manual') ||
@@ -1217,7 +1240,7 @@ function Priority() {
                   <span>Source: <strong>{cardInfo?.source}</strong> • Due: {cardInfo?.dueCards}/{cardInfo?.cardCount}</span>
                   {cardInfo?.source === 'inherited' && (
                     <button
-                      onClick={() => saveCardPriority(cardInfo.priority)}
+                      onClick={convertToManual}
                       className="text-xs hover:underline"
                       style={{ color: '#3b82f6' }}
                     >

--- a/src/widgets/priority_distribution_graph.tsx
+++ b/src/widgets/priority_distribution_graph.tsx
@@ -14,14 +14,61 @@ import { PRIORITY_GRAPH_DATA_KEY_PREFIX } from '../lib/consts';
 
 interface GraphDataPoint {
   range: string;
-  incRem: number;
-  card: number;
+  incRemDue: number;
+  incRemNotDue: number;
+  cardDue: number;
+  cardNotDue: number;
 }
 
 interface PriorityGraphData {
   bins: GraphDataPoint[];
   binsKbRelative?: GraphDataPoint[];
   lastUpdated?: string;
+}
+
+const INC_REM_DUE_COLOR = '#3b82f6';
+const INC_REM_NOT_DUE_COLOR = '#bfdbfe';
+const CARD_DUE_COLOR = '#ef4444';
+const CARD_NOT_DUE_COLOR = '#fecaca';
+
+function PriorityBinTooltip({ active, payload, label }: any) {
+  if (!active || !payload || payload.length === 0) return null;
+  const data = payload[0]?.payload as GraphDataPoint | undefined;
+  if (!data) return null;
+
+  const incTotal = (data.incRemDue ?? 0) + (data.incRemNotDue ?? 0);
+  const cardTotal = (data.cardDue ?? 0) + (data.cardNotDue ?? 0);
+  const incPct = incTotal > 0 ? Math.round((data.incRemNotDue / incTotal) * 100) : 0;
+  const cardPct = cardTotal > 0 ? Math.round((data.cardNotDue / cardTotal) * 100) : 0;
+
+  return (
+    <div
+      style={{
+        borderRadius: 8,
+        border: 'none',
+        boxShadow: '0 4px 6px -1px rgba(0,0,0,0.1)',
+        background: 'white',
+        padding: '8px 10px',
+        fontSize: 12,
+        color: '#374151',
+        lineHeight: 1.4,
+      }}
+    >
+      <div style={{ fontWeight: 600, marginBottom: 4 }}>{label}</div>
+      <div style={{ color: INC_REM_DUE_COLOR, fontWeight: 600 }}>
+        Incremental Rems: {incTotal}
+      </div>
+      <div style={{ marginLeft: 8 }}>
+        Due: {data.incRemDue ?? 0} · Processed: {data.incRemNotDue ?? 0} ({incPct}%)
+      </div>
+      <div style={{ color: CARD_DUE_COLOR, fontWeight: 600, marginTop: 4 }}>
+        Rems with Cards: {cardTotal}
+      </div>
+      <div style={{ marginLeft: 8 }}>
+        Due: {data.cardDue ?? 0} · Processed: {data.cardNotDue ?? 0} ({cardPct}%)
+      </div>
+    </div>
+  );
 }
 
 // Export as a reusable component, not just a widget
@@ -109,28 +156,28 @@ export function PriorityDistributionGraphComponent({ documentId }: { documentId:
             <YAxis
               yAxisId="left"
               orientation="left"
-              stroke="#3b82f6"
+              stroke={INC_REM_DUE_COLOR}
               allowDecimals={false}
-              label={{ value: 'IncRems', angle: -90, position: 'insideLeft', fill: '#3b82f6', fontSize: 10 }}
+              label={{ value: 'IncRems', angle: -90, position: 'insideLeft', fill: INC_REM_DUE_COLOR, fontSize: 10 }}
             />
 
             {/* Right Y-Axis for Rems with Cards */}
             <YAxis
               yAxisId="right"
               orientation="right"
-              stroke="#ef4444"
+              stroke={CARD_DUE_COLOR}
               allowDecimals={false}
-              label={{ value: 'Rems with Cards', angle: 90, position: 'insideRight', fill: '#ef4444', fontSize: 10 }}
+              label={{ value: 'Rems with Cards', angle: 90, position: 'insideRight', fill: CARD_DUE_COLOR, fontSize: 10 }}
             />
 
-            <Tooltip
-              contentStyle={{ borderRadius: '8px', border: 'none', boxShadow: '0 4px 6px -1px rgba(0, 0, 0, 0.1)' }}
-            />
+            <Tooltip content={<PriorityBinTooltip />} />
             <Legend verticalAlign="top" height={36} />
 
-            {/* Bars linked to specific axes */}
-            <Bar yAxisId="left" dataKey="incRem" name="Incremental Rems" fill="#3b82f6" />
-            <Bar yAxisId="right" dataKey="card" name="Rems with Cards" fill="#ef4444" />
+            {/* Stacked bars: processed (bottom, lighter), due (top, saturated) */}
+            <Bar yAxisId="left" stackId="incRem" dataKey="incRemNotDue" name="IncRems · Processed" fill={INC_REM_NOT_DUE_COLOR} />
+            <Bar yAxisId="left" stackId="incRem" dataKey="incRemDue" name="IncRems · Due" fill={INC_REM_DUE_COLOR} />
+            <Bar yAxisId="right" stackId="card" dataKey="cardNotDue" name="Cards · Processed" fill={CARD_NOT_DUE_COLOR} />
+            <Bar yAxisId="right" stackId="card" dataKey="cardDue" name="Cards · Due" fill={CARD_DUE_COLOR} />
 
           </BarChart>
         </ResponsiveContainer>

--- a/src/widgets/priority_editor.tsx
+++ b/src/widgets/priority_editor.tsx
@@ -4,7 +4,7 @@ import {
   useRunAsync,
   useTrackerPlugin,
 } from '@remnote/plugin-sdk';
-import { useMemo, useState, useCallback, useRef } from 'react';
+import { useEffect, useMemo, useState, useCallback, useRef } from 'react';
 import { getIncrementalRemFromRem } from '../lib/incremental_rem';
 import { updateIncrementalRemCache } from '../lib/incremental_rem/cache';
 import { getCardPriority, setCardPriority, CardPriorityInfo } from '../lib/card_priority';
@@ -15,6 +15,8 @@ import { updateCardPriorityCache } from '../lib/card_priority/cache';
 import { PriorityBadge } from '../components';
 import {
   getActivePdfForIncRem,
+  setActivePdfForIncRem,
+  getAllPDFsInRem,
   findHTMLinRem,
   getIncrementalPageRange,
   getPageHistory,
@@ -61,30 +63,94 @@ export function PriorityEditor() {
     []
   );
 
-  // Host (PDF or HTML) resolution. Keyed on `remId` only so it does NOT refetch
-  // when the card priority cache flushes — host structure doesn't change with
-  // priority. The state name `pdfRemId` is kept for backwards compat — it now
-  // stores either a PDF or an HTML host id.
-  const hostInfo = useRunAsync(async () => {
+  // Bumped after the user pins a new active PDF, so the host-info refetch
+  // picks up the new active-PDF resolution. Otherwise `useRunAsync` keyed on
+  // `remId` alone would not re-fire.
+  const [pinRefreshCounter, setPinRefreshCounter] = useState(0);
+
+  // Host (PDF or HTML) resolution. Returns the full PDF option list and the
+  // current active-PDF id so the inline selector below can render. Keyed on
+  // `remId` (+ pinRefreshCounter) to avoid refetching when the card priority
+  // cache flushes — host structure doesn't change with priority.
+  type HostInfo =
+    | { hostKind: 'pdf'; pdfOptions: Array<{ remId: string; name: string; isPreferred: boolean }>; activePdfId: string | null; htmlRemId: null; htmlRemName: null }
+    | { hostKind: 'html'; pdfOptions: []; activePdfId: null; htmlRemId: string; htmlRemName: string | null }
+    | { hostKind: null; pdfOptions: []; activePdfId: null; htmlRemId: null; htmlRemName: null };
+
+  const hostInfo = useRunAsync(async (): Promise<HostInfo | null> => {
     if (!remId) return null;
     const rem = await plugin.rem.findOne(remId);
     if (!rem) return null;
-    const pdfRem = await getActivePdfForIncRem(plugin as any, rem);
-    const hostRem = pdfRem ?? await findHTMLinRem(plugin as any, rem);
-    if (!hostRem) {
-      return { pdfRemId: null, pdfRemName: null, hostKind: null as 'pdf' | 'html' | null };
-    }
-    const pdfRemName = hostRem.text ? await safeRemTextToString(plugin as any, hostRem.text) : null;
-    return {
-      pdfRemId: hostRem._id,
-      pdfRemName,
-      hostKind: (pdfRem ? 'pdf' : 'html') as 'pdf' | 'html',
-    };
-  }, [remId]);
 
-  const hostPdfRemId = hostInfo?.pdfRemId ?? null;
-  const hostPdfRemName = hostInfo?.pdfRemName ?? null;
+    const pdfs = await getAllPDFsInRem(plugin as any, rem);
+
+    if (pdfs.length > 0) {
+      const pdfOptions = await Promise.all(
+        pdfs.map(async (p) => ({
+          remId: p.rem._id,
+          name: await safeRemTextToString(plugin as any, p.rem.text),
+          isPreferred: p.isPreferred,
+        }))
+      );
+      const activePdf = await getActivePdfForIncRem(plugin as any, rem);
+      return {
+        hostKind: 'pdf',
+        pdfOptions,
+        activePdfId: activePdf?._id ?? null,
+        htmlRemId: null,
+        htmlRemName: null,
+      };
+    }
+
+    const htmlRem = await findHTMLinRem(plugin as any, rem);
+    if (!htmlRem) {
+      return { hostKind: null, pdfOptions: [], activePdfId: null, htmlRemId: null, htmlRemName: null };
+    }
+    const htmlRemName = htmlRem.text ? await safeRemTextToString(plugin as any, htmlRem.text) : null;
+    return {
+      hostKind: 'html',
+      pdfOptions: [],
+      activePdfId: null,
+      htmlRemId: htmlRem._id,
+      htmlRemName,
+    };
+  }, [remId, pinRefreshCounter]);
+
+  const pdfOptions = hostInfo?.pdfOptions ?? [];
+  const activePdfId = hostInfo?.activePdfId ?? null;
   const hostKind = hostInfo?.hostKind ?? null;
+
+  // User-chosen view-only override. null = follow the active pin. Resets when
+  // the rem changes so each IncRem starts at its own active PDF.
+  const [selectedPdfRemId, setSelectedPdfRemId] = useState<string | null>(null);
+  useEffect(() => { setSelectedPdfRemId(null); }, [remId]);
+
+  // The host id whose data the panel currently displays.
+  const viewedPdfRemId =
+    hostKind === 'pdf'
+      ? (selectedPdfRemId && pdfOptions.some((o) => o.remId === selectedPdfRemId)
+          ? selectedPdfRemId
+          : activePdfId)
+      : hostInfo?.htmlRemId ?? null;
+
+  const viewedHostName =
+    hostKind === 'pdf'
+      ? pdfOptions.find((o) => o.remId === viewedPdfRemId)?.name ?? null
+      : hostInfo?.htmlRemName ?? null;
+
+  // Kept names for downstream code that already reads these.
+  const hostPdfRemId = viewedPdfRemId;
+  const hostPdfRemName = viewedHostName;
+
+  // Pin the currently-viewed PDF as the IncRem's active PDF.
+  const handleSetActive = useCallback(async () => {
+    if (!remId || !viewedPdfRemId || viewedPdfRemId === activePdfId) return;
+    await setActivePdfForIncRem(plugin as any, remId, viewedPdfRemId);
+    setPinRefreshCounter((c) => c + 1);
+    // Clear the local override now that the pin matches what we were viewing.
+    setSelectedPdfRemId(null);
+    await plugin.app.toast('Active PDF updated');
+  }, [plugin, remId, viewedPdfRemId, activePdfId]);
 
   // SUPER OPTIMIZED: Combine priority queries into a single hook.
   // Host range/history/stats are fetched in a separate tracker below so that
@@ -233,14 +299,19 @@ export function PriorityEditor() {
 
   const openPdfPanel = useCallback(async () => {
     if (!remId || !hostPdfRemId) return;
+    // Carry over the currently-viewed PDF (not just the active one) so the
+    // PDF Control Panel opens on the same PDF the user was inspecting here.
+    // Also pre-populate `allPdfRemIds` so the panel's selector renders
+    // immediately without re-deriving the list.
     await plugin.storage.setSession('pageRangeContext', {
       incrementalRemId: remId,
       pdfRemId: hostPdfRemId,
       totalPages: undefined,
       currentPage: undefined,
+      allPdfRemIds: pdfOptions.length > 0 ? pdfOptions.map((o) => o.remId) : undefined,
     });
     await plugin.widget.openPopup(pageRangeWidgetId, { remId });
-  }, [remId, hostPdfRemId, plugin]);
+  }, [remId, hostPdfRemId, plugin, pdfOptions]);
 
   // Memoize computed values
   const showCardEditor = useMemo(
@@ -518,7 +589,9 @@ export function PriorityEditor() {
                 <div className="flex items-center gap-1.5">
                   <span className="text-xs">📄</span>
                   <span className="text-xs font-semibold" style={{ color: 'var(--rn-clr-content-primary)' }}>PDF Range</span>
-                  {hostPdfRemName && (
+                  {/* Single-PDF case: show the name inline. Multi-PDF case: the
+                      name is shown in the selector below, so we omit it here. */}
+                  {hostPdfRemName && pdfOptions.length <= 1 && (
                     <span className="text-[10px] truncate max-w-[100px]" style={{ color: 'var(--rn-clr-content-tertiary)' }}
                       title={hostPdfRemName}>{hostPdfRemName}</span>
                   )}
@@ -545,6 +618,45 @@ export function PriorityEditor() {
                   <span className="text-[10px]" style={{ color: 'var(--rn-clr-content-tertiary)', opacity: 0.6 }}>No range</span>
                 )}
               </div>
+
+              {/* PDF Selector — appears only when the IncRem has multiple PDFs.
+                  Selecting an option changes what the panel displays (range,
+                  position, history, stats) but does NOT pin. The "📌 Set as
+                  active" button (only visible while viewing a non-pinned PDF)
+                  is the explicit pin action. ★ = #preferthispdf · 📌 = active. */}
+              {pdfOptions.length > 1 && (
+                <div className="flex items-center gap-1 mb-2">
+                  <select
+                    value={viewedPdfRemId ?? ''}
+                    onChange={(e) => setSelectedPdfRemId(e.target.value)}
+                    title="View this PDF's data (does not change the active PDF)"
+                    className="text-[11px] px-1.5 py-1 rounded flex-1 min-w-0"
+                    style={{
+                      border: '1px solid var(--rn-clr-border-primary)',
+                      backgroundColor: 'var(--rn-clr-background-primary)',
+                      color: 'var(--rn-clr-content-primary)',
+                    }}
+                  >
+                    {pdfOptions.map((opt) => (
+                      <option key={opt.remId} value={opt.remId}>
+                        {opt.name}{opt.isPreferred ? ' ★' : ''}{opt.remId === activePdfId ? ' 📌' : ''}
+                      </option>
+                    ))}
+                  </select>
+                  {viewedPdfRemId && viewedPdfRemId !== activePdfId && (
+                    <button
+                      onClick={handleSetActive}
+                      title="Pin this PDF as the active one for this Inc Rem"
+                      className="px-2 py-1 text-[11px] rounded whitespace-nowrap transition-colors"
+                      style={{ backgroundColor: '#3b82f6', color: 'white', border: 'none' }}
+                      onMouseEnter={(e) => { e.currentTarget.style.backgroundColor = '#2563eb'; }}
+                      onMouseLeave={(e) => { e.currentTarget.style.backgroundColor = '#3b82f6'; }}
+                    >
+                      📌 Set as active
+                    </button>
+                  )}
+                </div>
+              )}
 
               {/* Editing area */}
               {pdfEdit.mode === 'range' && (

--- a/src/widgets/priority_editor.tsx
+++ b/src/widgets/priority_editor.tsx
@@ -14,7 +14,7 @@ import { calculateRelativePercentile, formatDuration } from '../lib/utils';
 import { updateCardPriorityCache } from '../lib/card_priority/cache';
 import { PriorityBadge } from '../components';
 import {
-  findPreferredPDFInRem,
+  getActivePdfForIncRem,
   findHTMLinRem,
   getIncrementalPageRange,
   getPageHistory,
@@ -69,7 +69,7 @@ export function PriorityEditor() {
     if (!remId) return null;
     const rem = await plugin.rem.findOne(remId);
     if (!rem) return null;
-    const pdfRem = await findPreferredPDFInRem(plugin as any, rem, false);
+    const pdfRem = await getActivePdfForIncRem(plugin as any, rem);
     const hostRem = pdfRem ?? await findHTMLinRem(plugin as any, rem);
     if (!hostRem) {
       return { pdfRemId: null, pdfRemName: null, hostKind: null as 'pdf' | 'html' | null };


### PR DESCRIPTION
## v0.2.218 - May 12th, 2026

### ✨ New: Multi-PDF Support — Switch & Pin the Active PDF Per Inc Rem

Inc Rems can now have **multiple PDF sources** and you can switch between them on the fly in every surface that touches a PDF. Previously, a multi-PDF IncRem had to single out one PDF via the `#preferthispdf` tag, and IncRems without that tag fell through to the ExtractViewer — bypassing the Reader entirely. Multi-PDF Inc Rems are now first-class citizens, with a unified **active-PDF pin** persisted per Inc Rem.

**Where the switcher appears:**
- **Reader (in the queue)** — a PDF dropdown next to the 📝 Document Notes icon. Switching pins the chosen PDF as active for this Inc Rem; the queue re-renders Reader against the new PDF immediately.
- **Editor Review Timer widget** — a small PDF dropdown next to the page controls. Switching mid-session re-targets the 🔖 Scroll button, the Page Controls, and any subsequent reading-time writes to the new PDF.
- **Execute Repetition popup** (`Ctrl+Shift+J` in the editor) — a PDF dropdown above the Page Controls picks which PDF "Start Timer" will open and scroll to.
- **PDF Control Panel** — a PDF dropdown in the header showing every PDF for the current Inc Rem, with `★` marking `#preferthispdf` and `📌` marking the active pin. Selecting changes the panel's *view*; a separate **📌 Set as active** button (only visible while inspecting a non-active PDF) commits the pin.
- **Editor Toolbar (rem sidebar)** — same dropdown + **📌 Set as active** button inside the PDF Range section. Switching changes which PDF's range, current position, history, and scroll button are shown; the explicit button pins.

**Resolution model (applied uniformly everywhere):**
1. **Explicit pin** stored under `active_pdf_for_<remId>` (auto-cleared if the referenced PDF is no longer a source).
2. **`#preferthispdf` tag** — used when no pin is set; if multiple PDFs carry the tag, the first preferred wins gracefully (no more blocking toast).
3. **First PDF source** — final fallback.

**Behavior changes worth knowing:**
- A multi-PDF Inc Rem with no `#preferthispdf` tag now opens the **first PDF in the Reader** instead of falling back to the ExtractViewer. From there the new switcher lets you pick a different one and pin it. The `#extractviewer` tag remains the explicit way to opt into the ExtractViewer.
- The "PDF Control Panel" document-menu item now respects the IncRem it was triggered from. Previously, when many Inc Rems shared the same PDF (e.g. book chapters under one textbook), the menu sometimes silently routed to the parent PDF document.
- View vs. pin: **active-reading surfaces** (Reader, Timer, Execute Repetition popup) pin on switch — switching means "I'm reading this one now." **Management surfaces** (PDF Control Panel, Priority Editor) split view from pin so you can inspect any PDF's data without committing to a pin.

### ✨ Improved: Priority Distribution Graphs — Stacked Due / Processed Bars

Both priority distribution graphs — the **KB Priority Distribution Graph** (All Inc Rems main view) and the **Document Priority Distribution Graph** (IncRem Counter badge) — now use **stacked bars** that split each priority bucket into due and processed items.

Previously, each bar showed only the total count for a priority bucket (e.g. 6309 Rems with Cards in the 35–40 range). You now see at a glance how much of that bucket is still outstanding versus already reviewed and scheduled forward:

| Sub-bar | Color | Meaning |
|---------|-------|---------|
| **Due** (top, saturated) | 🔵 Blue (IncRems) / 🔴 Red (Cards) | Items currently due for review (`nextRepDate ≤ now` for IncRems; at least one due card for flashcard Rems) |
| **Processed** (bottom, light) | 🩵 Light blue / 🩷 Light red | Items already reviewed and scheduled forward — not yet due |

The **tooltip** now shows the full breakdown for each series: total count, due count, processed count, and **% processed** (degree of processing within that bucket).

<img src="./assets/priority-graph-KB-2.png" width="600" alt="KB Priority Distribution Graph with stacked due/processed bars" />

<img src="./assets/priority-graph-doc-2.png" width="600" alt="Document Priority Distribution Graph with stacked due/processed bars" />

#Closes 238
