### PR TITLE
Stacked Graphs; Rogue CardPriority Sanitization Tool

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "search.exclude": {
+        "**/node_modules": false
+    },
+    "search.useIgnoreFiles": false
+}

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -7,7 +7,7 @@
   "version": {
     "major": 0,
     "minor": 2,
-    "patch": 227
+    "patch": 228
   },
   "unlisted": false,
   "theme": [],

--- a/src/lib/card_priority/batch.ts
+++ b/src/lib/card_priority/batch.ts
@@ -562,47 +562,54 @@ export async function removeCardPriorityFromRem(plugin: RNPlugin, rem: PluginRem
 }
 
 /**
- * Sanitizes a Rem's children by removing the CardPriority powerup from Rems that should not have it.
- * - Removes from property slots (isPowerupProp / isProp).
- * - Removes from regular rems that do not have any flashcards.
- * - PRESERVES legitimate descendant flashcards to avoid losing manual priority ratings.
+ * Scans a Rem's children to find Rems that have the CardPriority powerup but no flashcards natively.
  */
-export async function sanitizeCardPriorityFromDescendants(plugin: RNPlugin, rem: PluginRem, recursive: boolean = false) {
-  let cleanedCount = 0;
-  let preservedCount = 0;
+export async function getSpuriousCardPriorityTags(plugin: RNPlugin, rem: PluginRem, recursive: boolean = false) {
+  const rogueRems: { id: string; name: string }[] = [];
 
-  async function processRem(target: PluginRem) {
+  async function scanRem(target: PluginRem) {
     const children = await target.getChildrenRem();
     for (const child of children) {
       const hasPowerup = await child.hasPowerup('cardPriority');
-
       if (hasPowerup) {
         const cards = await child.getCards();
-        if (cards && cards.length > 0) {
-          console.log(`[Sanitize] Preserving CardPriority on legitimate flashcard: ${child._id}`);
-          preservedCount++;
-        } else {
-          console.log(`[Sanitize] Removing CardPriority from non-flashcard rem: ${child._id}`);
-          await child.removePowerup('cardPriority');
-          cleanedCount++;
+        if (!cards || cards.length === 0) {
+          const textRaw = await child.text;
+          const textString = textRaw ? await plugin.richText.toString(textRaw) : 'Untitled';
+          rogueRems.push({ id: child._id, name: textString || 'Untitled' });
         }
       }
-
-      // If recursive is on, dive deeper
       if (recursive) {
-        await processRem(child);
+        await scanRem(child);
       }
     }
   }
 
+  await scanRem(rem);
+  return rogueRems;
+}
+
+/**
+ * Removes the CardPriority powerup from a specific list of Rem IDs.
+ */
+export async function removeCardPriorityFromSpecificRems(plugin: RNPlugin, remIds: string[]) {
+  let cleanedCount = 0;
+  
   console.log(`\n======================================================`);
-  console.log(`[Sanitize] Starting safe sanitize for Rem: ${rem._id}`);
+  console.log(`[Sanitize] Starting safe sanitize for ${remIds.length} Rems`);
   await plugin.storage.setSession('plugin_operation_active', true);
 
   try {
-    await processRem(rem);
-    console.log(`[Sanitize] Completed. Cleaned: ${cleanedCount}, Preserved: ${preservedCount}`);
-    return { success: true, cleanedCount, preservedCount };
+    for (const id of remIds) {
+      const child = await plugin.rem.findOne(id);
+      if (child) {
+        console.log(`[Sanitize] Removing CardPriority from non-flashcard rem: ${child._id}`);
+        await child.removePowerup('cardPriority');
+        cleanedCount++;
+      }
+    }
+    console.log(`[Sanitize] Completed. Cleaned: ${cleanedCount}`);
+    return { success: true, cleanedCount };
   } catch (error) {
     console.error(`[Sanitize] Error:`, error);
     return { success: false, error };

--- a/src/lib/card_priority/batch.ts
+++ b/src/lib/card_priority/batch.ts
@@ -1,4 +1,4 @@
-import { RNPlugin } from '@remnote/plugin-sdk';
+import { RNPlugin, PluginRem } from '@remnote/plugin-sdk';
 import {
   allCardPriorityInfoKey,
   cardPriorityShieldHistoryKey,
@@ -8,7 +8,7 @@ import {
 import { CardPriorityInfo } from './types';
 import { calculateNewPriority, setCardPriority } from './index';
 import * as _ from 'remeda';
-import { PluginRem } from '@remnote/plugin-sdk';
+import { safeRemTextToString } from '../pdfUtils';
 
 export async function removeAllCardPriorityTags(plugin: RNPlugin) {
   const confirmed = confirm(
@@ -561,22 +561,77 @@ export async function removeCardPriorityFromRem(plugin: RNPlugin, rem: PluginRem
   }
 }
 
+export interface RogueTagResult {
+  id: string;
+  name: string;
+  parentId?: string;
+  parentName?: string;
+}
+
 /**
  * Scans a Rem's children to find Rems that have the CardPriority powerup but no flashcards natively.
  */
 export async function getSpuriousCardPriorityTags(plugin: RNPlugin, rem: PluginRem, recursive: boolean = false) {
-  const rogueRems: { id: string; name: string }[] = [];
+  const guaranteedRogue: RogueTagResult[] = [];
+  const suspicious: RogueTagResult[] = [];
+
+  // Fetch slot DEFINITION Rems (templates, not instances) — this is read-only and safe.
+  // Each slot definition has an _id that RemNote uses to tag the actual slot instances on rems.
+  const slotDefs = [
+    { powerup: 'incremental', slot: 'repHist' },
+    { powerup: 'incremental', slot: 'originalIncDate' },
+    { powerup: 'incremental', slot: 'nextRepDate' },
+    { powerup: 'incremental', slot: 'priority' },
+    { powerup: 'cardPriority', slot: 'priority' },
+    { powerup: 'cardPriority', slot: 'prioritySource' },
+    { powerup: 'cardPriority', slot: 'lastUpdated' },
+    { powerup: 'videoExtract', slot: 'videoUrl' },
+    { powerup: 'videoExtract', slot: 'startTime' },
+    { powerup: 'videoExtract', slot: 'endTime' },
+    { powerup: 'dismissed', slot: 'dismissedHistory' },
+    { powerup: 'dismissed', slot: 'dismissedDate' },
+  ];
+
+  const ownSlotDefinitionIds = new Set<string>();
+  for (const { powerup, slot } of slotDefs) {
+    const defRem = await plugin.powerup.getPowerupSlotByCode(powerup, slot);
+    if (defRem) {
+      ownSlotDefinitionIds.add(defRem._id);
+    }
+  }
 
   async function scanRem(target: PluginRem) {
     const children = await target.getChildrenRem();
+    const targetName = await safeRemTextToString(plugin, target.text);
+
     for (const child of children) {
       const hasPowerup = await child.hasPowerup('cardPriority');
       if (hasPowerup) {
-        const cards = await child.getCards();
-        if (!cards || cards.length === 0) {
-          const textRaw = await child.text;
-          const textString = textRaw ? await plugin.richText.toString(textRaw) : 'Untitled';
-          rogueRems.push({ id: child._id, name: textString || 'Untitled' });
+        const isProp = await child.isProperty();
+        const isPowerupProp = await child.isPowerupProperty();
+        
+        // ONLY target property nodes. Structural rems (folders/documents) used for inheritance MUST be preserved.
+        if (isProp || isPowerupProp) {
+          const cards = await child.getCards();
+          if (!cards || cards.length === 0) {
+            const textRaw = await child.text;
+            const textString = await safeRemTextToString(plugin, textRaw);
+            
+            // Check if this child's text references one of our own slot definitions.
+            // RemNote links slot instances to their definitions via a reference in the
+            // rich text content: text[0]._id points to the slot definition Rem.
+            const isOwnSlot = textRaw 
+              && textRaw.length > 0 
+              && typeof textRaw[0] === 'object' 
+              && (textRaw[0] as any)?._id 
+              && ownSlotDefinitionIds.has((textRaw[0] as any)._id);
+            
+            if (isOwnSlot) {
+              guaranteedRogue.push({ id: child._id, name: textString, parentId: target._id, parentName: targetName });
+            } else {
+              suspicious.push({ id: child._id, name: textString, parentId: target._id, parentName: targetName });
+            }
+          }
         }
       }
       if (recursive) {
@@ -586,7 +641,7 @@ export async function getSpuriousCardPriorityTags(plugin: RNPlugin, rem: PluginR
   }
 
   await scanRem(rem);
-  return rogueRems;
+  return { guaranteedRogue, suspicious };
 }
 
 /**
@@ -612,7 +667,7 @@ export async function removeCardPriorityFromSpecificRems(plugin: RNPlugin, remId
     return { success: true, cleanedCount };
   } catch (error) {
     console.error(`[Sanitize] Error:`, error);
-    return { success: false, error };
+    return { success: false, error, cleanedCount: 0 };
   } finally {
     setTimeout(async () => {
       await plugin.storage.setSession('plugin_operation_active', false);
@@ -620,71 +675,72 @@ export async function removeCardPriorityFromSpecificRems(plugin: RNPlugin, remId
   }
 }
 
-export async function cleanUpDuplicateCardPrioritySlots(plugin: RNPlugin) {
-  const confirmed = confirm(
-    '⚠️ Clean Up Duplicate CardPriority Slots\n\n' +
-    'This will detect and remove the cardPriority powerup and all its slots from any Rem that has duplicate slots.\n\n' +
-    'You can then run "Update all inherited Card Priorities" to recalculate them.\n\n' +
-    'Continue?'
-  );
+export async function sanitizeAllRogueCardPriorityTags(plugin: RNPlugin) {
+  await plugin.app.toast('Scanning knowledge base for rogue CardPriority tags...');
+  
+  const cardPriorityPowerup = await plugin.powerup.getPowerupByCode('cardPriority');
+  const taggedRems = (await cardPriorityPowerup?.taggedRem()) || [];
+  
+  let allGuaranteed: RogueTagResult[] = [];
+  let allSuspicious: RogueTagResult[] = [];
+  
+  for (const rem of taggedRems) {
+    const { guaranteedRogue, suspicious } = await getSpuriousCardPriorityTags(plugin, rem, false);
+    allGuaranteed.push(...guaranteedRogue);
+    allSuspicious.push(...suspicious);
+  }
 
-  if (!confirmed) return;
+  if (allGuaranteed.length === 0 && allSuspicious.length === 0) {
+    await plugin.app.toast('No rogue tags found. Your database is clean!');
+    return;
+  }
 
-  await plugin.app.toast('Scanning for duplicate slots...');
-  await plugin.storage.setSession('plugin_operation_active', true);
+  let totalCleaned = 0;
+  const CHUNK_SIZE = 20;
 
-  try {
-    const cardPriorityPowerup = await plugin.powerup.getPowerupByCode('cardPriority');
-    const taggedRems = (await cardPriorityPowerup?.taggedRem()) || [];
-
-    const prioritySlot = await plugin.powerup.getPowerupSlotByCode('cardPriority', 'priority');
-    const sourceSlot = await plugin.powerup.getPowerupSlotByCode('cardPriority', 'prioritySource');
-    const updatedSlot = await plugin.powerup.getPowerupSlotByCode('cardPriority', 'lastUpdated');
-
-    const slotIds = new Set(
-      [prioritySlot?._id, sourceSlot?._id, updatedSlot?._id].filter(Boolean)
-    );
-
-    let remsWithDuplicates = 0;
-    const cpPowerupId = cardPriorityPowerup?._id;
-
-    for (const rem of taggedRems) {
-      const children = await rem.getChildrenRem();
-      const slotCounts = new Map<string, number>();
-
-      for (const child of children) {
-        const isProp = await child.isProperty();
-        const isPowerupProp = await child.isPowerupProperty();
+  if (allGuaranteed.length > 0) {
+    for (let i = 0; i < allGuaranteed.length; i += CHUNK_SIZE) {
+      const chunk = allGuaranteed.slice(i, i + CHUNK_SIZE);
+      const listString = chunk.map(r => `- ${r.name} (${r.id})`).join('\n');
+      
+      const chunkMsg = allGuaranteed.length > CHUNK_SIZE 
+        ? `(Batch ${Math.floor(i/CHUNK_SIZE) + 1} of ${Math.ceil(allGuaranteed.length/CHUNK_SIZE)})` 
+        : '';
         
-        if (isProp || isPowerupProp) {
-          const tags = await child.getTagRems();
-          const tagIds = tags.map(t => t._id);
-          for (const tagId of tagIds) {
-            if (slotIds.has(tagId) || tagId === cpPowerupId) {
-              const countKey = slotIds.has(tagId) ? tagId : 'general_powerup_tag';
-              slotCounts.set(countKey, (slotCounts.get(countKey) || 0) + 1);
-            }
+      const confirmed = confirm(`Found ${allGuaranteed.length} GUARANTEED rogue properties. This will safely remove CardPriority from ${chunk.length} of them ${chunkMsg}:\n\n${listString}\n\nContinue?`);
+      
+      if (!confirmed) {
+        if (totalCleaned > 0) await plugin.app.toast(`Sanitize aborted. Cleaned ${totalCleaned} rogue tags total.`);
+        return;
+      }
+      
+      await plugin.app.toast(`Sanitizing ${chunk.length} guaranteed rogue properties...`);
+      const result = await removeCardPriorityFromSpecificRems(plugin, chunk.map(r => r.id));
+      if (result.success) {
+        totalCleaned += result.cleanedCount;
+      } else {
+        await plugin.app.toast('Sanitize failed during batch. Check console.');
+        return;
+      }
+    }
+  }
+
+  if (allSuspicious.length > 0) {
+    const proceed = confirm(`We successfully processed the guaranteed tags.\n\nHowever, we also found ${allSuspicious.length} SUSPICIOUS properties.\nThese are property nodes from other plugins that have CardPriority but 0 flashcards. They might be bugs, or they might be intentional.\n\nDo you want to review them one by one?`);
+    
+    if (proceed) {
+      for (const rem of allSuspicious) {
+        const confirmDelete = confirm(`⚠️ Suspicious Property Found\n\nProperty Text: "${rem.name}"\nParent Rem: "${rem.parentName}"\n\nThis property has no flashcards. Do you want to remove CardPriority from it?`);
+        
+        if (confirmDelete) {
+          const result = await removeCardPriorityFromSpecificRems(plugin, [rem.id]);
+          if (result.success) {
+            totalCleaned += result.cleanedCount;
           }
         }
       }
-
-      const hasDuplicates = Array.from(slotCounts.values()).some((count) => count > 1);
-
-      if (hasDuplicates) {
-        await removeCardPriorityFromRem(plugin, rem);
-        remsWithDuplicates++;
-      }
     }
-
-    if (remsWithDuplicates > 0) {
-      await plugin.app.toast(`✅ Cleaned up ${remsWithDuplicates} rems with duplicate slots.`);
-    } else {
-      await plugin.app.toast('No duplicate slots found. Your database is clean!');
-    }
-  } catch (error) {
-    console.error('Error during duplicate slots cleanup:', error);
-    await plugin.app.toast('❌ Error during cleanup. Check console for details.');
-  } finally {
-    await plugin.storage.setSession('plugin_operation_active', false);
   }
+
+  await plugin.app.toast(`Sanitized! Cleaned ${totalCleaned} rogue tags across your KB.`);
 }

--- a/src/lib/card_priority/batch.ts
+++ b/src/lib/card_priority/batch.ts
@@ -8,6 +8,7 @@ import {
 import { CardPriorityInfo } from './types';
 import { calculateNewPriority, setCardPriority } from './index';
 import * as _ from 'remeda';
+import { PluginRem } from '@remnote/plugin-sdk';
 
 export async function removeAllCardPriorityTags(plugin: RNPlugin) {
   const confirmed = confirm(
@@ -464,3 +465,219 @@ async function removeOrphanCards(plugin: RNPlugin, orphanRemIds: string[]): Prom
   alert(resultMessage);
 }
 
+export async function removeCardPriorityFromRem(plugin: RNPlugin, rem: PluginRem) {
+  console.log(`\n======================================================`);
+  console.log(`[CardPriority Cleanup] Starting cleanup for rem: ${rem._id}`);
+  
+  // Set flag to block GlobalRemChanged overriding us
+  await plugin.storage.setSession('plugin_operation_active', true);
+  try {
+    const cardPriorityPowerup = await plugin.powerup.getPowerupByCode('cardPriority');
+    const cpPowerupId = cardPriorityPowerup?._id;
+
+    const prioritySlot = await plugin.powerup.getPowerupSlotByCode('cardPriority', 'priority');
+    const sourceSlot = await plugin.powerup.getPowerupSlotByCode('cardPriority', 'prioritySource');
+    const updatedSlot = await plugin.powerup.getPowerupSlotByCode('cardPriority', 'lastUpdated');
+
+    const slotIds = new Set(
+      [prioritySlot?._id, sourceSlot?._id, updatedSlot?._id].filter(Boolean)
+    );
+    console.log(`[CardPriority Cleanup] Extracted slot IDs:`, Array.from(slotIds), `Powerup ID:`, cpPowerupId);
+
+    const children = await rem.getChildrenRem();
+    console.log(`[CardPriority Cleanup] Found ${children.length} total children on rem ${rem._id}`);
+
+    let removedSlotsCount = 0;
+    const removedChildIds: string[] = [];
+
+    // First pass: identify and delete all explicit CardPriority properties
+    for (const child of children) {
+      const isProp = await child.isProperty();
+      const isPowerupProp = await child.isPowerupProperty();
+      
+      // CRITICAL: Do not touch regular children (e.g. descendant flashcards)
+      if (!isPowerupProp && !isProp) {
+        continue;
+      }
+
+      const tags = await child.getTagRems();
+      const tagIds = tags.map(t => t._id);
+      
+      const textRaw = await child.text;
+      const textString = textRaw ? await plugin.richText.toString(textRaw) : '';
+      const tagsMapped = await Promise.all(tags.map(async t => t.text ? await plugin.richText.toString(t.text) : t._id));
+      
+      const hasSlotTag = tagIds.some(id => slotIds.has(id));
+      const hasPowerupTag = cpPowerupId ? tagIds.includes(cpPowerupId) : false;
+      
+      console.log(`[CardPriority Cleanup] Child ${child._id}: text="${textString}", isProp=${isProp}, isPowerupProp=${isPowerupProp}, tags=[${tagsMapped.join(', ')}], hasSlotTag=${hasSlotTag}`);
+      
+      if (hasSlotTag || hasPowerupTag) {
+        console.log(`[CardPriority Cleanup] Deleting known CardPriority property child: ${child._id} (text: "${textString}")`);
+        await child.remove();
+        removedSlotsCount++;
+        removedChildIds.push(child._id);
+      } else if (isPowerupProp && tagIds.length === 0) {
+        // Look closely at untagged properties to see if they look like priority values (e.g. "12", "14")
+        const text = await child.text;
+        const isNumericValue = text && text.length === 1 && typeof text[0] === 'string' && !isNaN(Number(text[0])) && text[0].trim() !== '';
+        const isTextValue = text && text.length === 1 && typeof text[0] === 'string' && ['manual', 'incremental', 'default', 'inherited'].includes(text[0].trim().toLowerCase());
+        
+        if (isNumericValue || isTextValue) {
+          console.log(`[CardPriority Cleanup] Deleting untagged zombie property child: ${child._id} (Value: "${text![0]}")`);
+          await child.remove();
+          removedSlotsCount++;
+          removedChildIds.push(child._id);
+        } else {
+          console.log(`[CardPriority Cleanup] WARNING: Ignored untagged powerup property ${child._id} (Value did not look like CardPriority data)`);
+        }
+      }
+    }
+
+    console.log(`[CardPriority Cleanup] Deleting cardPriority powerup tag from parent...`);
+    await rem.removePowerup('cardPriority');
+    
+    console.log(`[CardPriority Cleanup] Emptying properties via setPowerupProperty as fallback...`);
+    try {
+      await rem.setPowerupProperty('cardPriority', 'priority', []);
+      await rem.setPowerupProperty('cardPriority', 'prioritySource', []);
+      await rem.setPowerupProperty('cardPriority', 'lastUpdated', []);
+    } catch (e) {}
+    
+    console.log(`[CardPriority Cleanup] SUCCESS. Removed powerup and ${removedSlotsCount} slots: [${removedChildIds.join(', ')}]`);
+    console.log(`[CardPriority Cleanup] NOTE: GlobalRemChanged will likely recreate the powerup instantly because the rem has cards. This is EXPECTED and will result in a clean powerup. `);
+    console.log(`======================================================\n`);
+    
+    return { success: true, removedSlotsCount, removedChildIds };
+  } catch (error) {
+    console.error(`[CardPriority Cleanup] ERROR removing cardPriority from rem ${rem._id}:`, error);
+    console.log(`======================================================\n`);
+    return { success: false, error };
+  } finally {
+    setTimeout(async () => {
+      await plugin.storage.setSession('plugin_operation_active', false);
+      console.log(`[CardPriority Cleanup] Released plugin_operation_active flag.`);
+    }, 100);
+  }
+}
+
+/**
+ * Sanitizes a Rem's children by removing the CardPriority powerup from Rems that should not have it.
+ * - Removes from property slots (isPowerupProp / isProp).
+ * - Removes from regular rems that do not have any flashcards.
+ * - PRESERVES legitimate descendant flashcards to avoid losing manual priority ratings.
+ */
+export async function sanitizeCardPriorityFromDescendants(plugin: RNPlugin, rem: PluginRem, recursive: boolean = false) {
+  let cleanedCount = 0;
+  let preservedCount = 0;
+
+  async function processRem(target: PluginRem) {
+    const children = await target.getChildrenRem();
+    for (const child of children) {
+      const hasPowerup = await child.hasPowerup('cardPriority');
+
+      if (hasPowerup) {
+        const cards = await child.getCards();
+        if (cards && cards.length > 0) {
+          console.log(`[Sanitize] Preserving CardPriority on legitimate flashcard: ${child._id}`);
+          preservedCount++;
+        } else {
+          console.log(`[Sanitize] Removing CardPriority from non-flashcard rem: ${child._id}`);
+          await child.removePowerup('cardPriority');
+          cleanedCount++;
+        }
+      }
+
+      // If recursive is on, dive deeper
+      if (recursive) {
+        await processRem(child);
+      }
+    }
+  }
+
+  console.log(`\n======================================================`);
+  console.log(`[Sanitize] Starting safe sanitize for Rem: ${rem._id}`);
+  await plugin.storage.setSession('plugin_operation_active', true);
+
+  try {
+    await processRem(rem);
+    console.log(`[Sanitize] Completed. Cleaned: ${cleanedCount}, Preserved: ${preservedCount}`);
+    return { success: true, cleanedCount, preservedCount };
+  } catch (error) {
+    console.error(`[Sanitize] Error:`, error);
+    return { success: false, error };
+  } finally {
+    setTimeout(async () => {
+      await plugin.storage.setSession('plugin_operation_active', false);
+    }, 100);
+  }
+}
+
+export async function cleanUpDuplicateCardPrioritySlots(plugin: RNPlugin) {
+  const confirmed = confirm(
+    '⚠️ Clean Up Duplicate CardPriority Slots\n\n' +
+    'This will detect and remove the cardPriority powerup and all its slots from any Rem that has duplicate slots.\n\n' +
+    'You can then run "Update all inherited Card Priorities" to recalculate them.\n\n' +
+    'Continue?'
+  );
+
+  if (!confirmed) return;
+
+  await plugin.app.toast('Scanning for duplicate slots...');
+  await plugin.storage.setSession('plugin_operation_active', true);
+
+  try {
+    const cardPriorityPowerup = await plugin.powerup.getPowerupByCode('cardPriority');
+    const taggedRems = (await cardPriorityPowerup?.taggedRem()) || [];
+
+    const prioritySlot = await plugin.powerup.getPowerupSlotByCode('cardPriority', 'priority');
+    const sourceSlot = await plugin.powerup.getPowerupSlotByCode('cardPriority', 'prioritySource');
+    const updatedSlot = await plugin.powerup.getPowerupSlotByCode('cardPriority', 'lastUpdated');
+
+    const slotIds = new Set(
+      [prioritySlot?._id, sourceSlot?._id, updatedSlot?._id].filter(Boolean)
+    );
+
+    let remsWithDuplicates = 0;
+    const cpPowerupId = cardPriorityPowerup?._id;
+
+    for (const rem of taggedRems) {
+      const children = await rem.getChildrenRem();
+      const slotCounts = new Map<string, number>();
+
+      for (const child of children) {
+        const isProp = await child.isProperty();
+        const isPowerupProp = await child.isPowerupProperty();
+        
+        if (isProp || isPowerupProp) {
+          const tags = await child.getTagRems();
+          const tagIds = tags.map(t => t._id);
+          for (const tagId of tagIds) {
+            if (slotIds.has(tagId) || tagId === cpPowerupId) {
+              const countKey = slotIds.has(tagId) ? tagId : 'general_powerup_tag';
+              slotCounts.set(countKey, (slotCounts.get(countKey) || 0) + 1);
+            }
+          }
+        }
+      }
+
+      const hasDuplicates = Array.from(slotCounts.values()).some((count) => count > 1);
+
+      if (hasDuplicates) {
+        await removeCardPriorityFromRem(plugin, rem);
+        remsWithDuplicates++;
+      }
+    }
+
+    if (remsWithDuplicates > 0) {
+      await plugin.app.toast(`✅ Cleaned up ${remsWithDuplicates} rems with duplicate slots.`);
+    } else {
+      await plugin.app.toast('No duplicate slots found. Your database is clean!');
+    }
+  } catch (error) {
+    console.error('Error during duplicate slots cleanup:', error);
+    await plugin.app.toast('❌ Error during cleanup. Check console for details.');
+  } finally {
+    await plugin.storage.setSession('plugin_operation_active', false);
+  }
+}

--- a/src/lib/consts.ts
+++ b/src/lib/consts.ts
@@ -141,6 +141,9 @@ export const pendingScrollRequestKey = 'pending-scroll-request';
 // Priority Review Graph
 export const priorityGraphPowerupCode = 'priority_review_graph';
 export const GRAPH_DATA_KEY_PREFIX = 'priority_review_graph_data_';
+// Synced index of every graph Rem ID we've written graph data for. Used to find
+// orphaned `GRAPH_DATA_KEY_PREFIX + remId` entries on startup so they can be cleared.
+export const REVIEW_GRAPH_INDEX_KEY = 'priority_review_graph_index';
 
 // Priority Graph (document-scope, inline in inc_rem_counter)
 export const PRIORITY_GRAPH_DATA_KEY_PREFIX = 'priority_graph_data_';

--- a/src/lib/priority_graph_data.ts
+++ b/src/lib/priority_graph_data.ts
@@ -30,11 +30,21 @@ export interface PriorityGraphData {
 /**
  * Creates 20 empty bins covering priority ranges 0-5, 5-10, ..., 95-100.
  */
-function createBins(): GraphDataPoint[] {
+type BinLabelStyle = 'integer' | 'range';
+
+/**
+ * @param style 'integer' for discrete priority values (`0-4, 5-9, ..., 95-100`),
+ *              'range' for continuous percentile space with half-open bins
+ *              (`0-5, 5-10, ..., 95-100`).
+ */
+function createBins(style: BinLabelStyle = 'integer'): GraphDataPoint[] {
     return Array(20).fill(0).map((_, i) => ({
-        // Integer-priority labels. Last bucket spans [95, 100] inclusive because
-        // priority is clamped to 100 when binning.
-        range: i === 19 ? '95-100' : `${i * 5}-${i * 5 + 4}`,
+        range: style === 'integer'
+            // Discrete integer labels. Last bucket spans [95, 100] inclusive
+            // because priority is clamped to 100 when binning.
+            ? (i === 19 ? '95-100' : `${i * 5}-${i * 5 + 4}`)
+            // Continuous half-open ranges for percentile-space binning.
+            : `${i * 5}-${(i + 1) * 5}`,
         incRemDue: 0,
         incRemNotDue: 0,
         cardDue: 0,
@@ -66,8 +76,8 @@ export function computePriorityGraphData(
     const kbIncRemPercentiles = calculateAllPercentiles(allKbIncRems);
     const kbCardPercentiles = calculateAllPercentiles(validKbCardInfos);
 
-    const binsAbsolute = createBins();
-    const binsKbRelative = createBins();
+    const binsAbsolute = createBins('integer');
+    const binsKbRelative = createBins('range');
     const now = Date.now();
 
     // Fill bins from document-scoped IncRems

--- a/src/lib/priority_graph_data.ts
+++ b/src/lib/priority_graph_data.ts
@@ -32,7 +32,9 @@ export interface PriorityGraphData {
  */
 function createBins(): GraphDataPoint[] {
     return Array(20).fill(0).map((_, i) => ({
-        range: `${i * 5}-${(i + 1) * 5}`,
+        // Integer-priority labels. Last bucket spans [95, 100] inclusive because
+        // priority is clamped to 100 when binning.
+        range: i === 19 ? '95-100' : `${i * 5}-${i * 5 + 4}`,
         incRemDue: 0,
         incRemNotDue: 0,
         cardDue: 0,

--- a/src/lib/priority_review_document/cleanup.ts
+++ b/src/lib/priority_review_document/cleanup.ts
@@ -1,0 +1,70 @@
+import { RNPlugin } from '@remnote/plugin-sdk';
+import { GRAPH_DATA_KEY_PREFIX, REVIEW_GRAPH_INDEX_KEY } from '../consts';
+
+interface ReviewGraphIndexEntry {
+  remId: string;
+  createdAt: number;
+}
+
+/**
+ * Registers a newly-written review-graph data entry in the synced index.
+ * Call this immediately after `setSynced(GRAPH_DATA_KEY_PREFIX + graphRemId, ...)`.
+ * The index is what allows the startup sweep to find orphaned keys later —
+ * the SDK has no way to enumerate synced storage keys.
+ */
+export async function registerReviewGraphKey(
+  plugin: RNPlugin,
+  graphRemId: string,
+): Promise<void> {
+  try {
+    const list = (await plugin.storage.getSynced<ReviewGraphIndexEntry[]>(REVIEW_GRAPH_INDEX_KEY)) || [];
+    const without = list.filter((e) => e.remId !== graphRemId);
+    without.push({ remId: graphRemId, createdAt: Date.now() });
+    await plugin.storage.setSynced(REVIEW_GRAPH_INDEX_KEY, without);
+  } catch (err) {
+    console.warn('[ReviewGraphCleanup] Failed to register key', graphRemId, err);
+  }
+}
+
+/**
+ * Walks the synced index and clears any review-graph data whose graph Rem no
+ * longer exists. Designed to run once on plugin activation; cheap because
+ * the index typically holds tens of entries (one per Priority Review Document
+ * the user has ever created).
+ *
+ * @returns Count of cleared orphan entries.
+ */
+export async function cleanupOrphanedReviewGraphs(plugin: RNPlugin): Promise<number> {
+  let cleared = 0;
+  try {
+    const index = (await plugin.storage.getSynced<ReviewGraphIndexEntry[]>(REVIEW_GRAPH_INDEX_KEY)) || [];
+    if (index.length === 0) return 0;
+
+    const live: ReviewGraphIndexEntry[] = [];
+    for (const entry of index) {
+      try {
+        const rem = await plugin.rem.findOne(entry.remId);
+        if (rem) {
+          live.push(entry);
+        } else {
+          // Rem gone (review doc was deleted) → clear the orphan data entry.
+          // SDK has no removeSynced; setSynced(..., null) is the documented pattern.
+          await plugin.storage.setSynced(GRAPH_DATA_KEY_PREFIX + entry.remId, null);
+          cleared++;
+        }
+      } catch (err) {
+        // If findOne itself throws, keep the entry so we retry on next activation.
+        console.warn('[ReviewGraphCleanup] findOne failed for', entry.remId, err);
+        live.push(entry);
+      }
+    }
+
+    if (cleared > 0) {
+      await plugin.storage.setSynced(REVIEW_GRAPH_INDEX_KEY, live);
+      console.log(`[ReviewGraphCleanup] Cleared ${cleared} orphaned review-graph data entries`);
+    }
+  } catch (err) {
+    console.warn('[ReviewGraphCleanup] Sweep failed', err);
+  }
+  return cleared;
+}

--- a/src/lib/priority_review_document/index.ts
+++ b/src/lib/priority_review_document/index.ts
@@ -11,6 +11,7 @@ import {
 import { CardPriorityInfo } from '../card_priority';
 import { calculateAllPercentiles } from '../utils';
 import { buildComprehensiveScope } from '../scope_helpers';
+import { registerReviewGraphKey } from './cleanup';
 import * as _ from 'remeda'; // Ensure remeda is imported for uniqBy if available, or use custom
 
 // Possible powerup codes for the Card Cluster built-in powerup.
@@ -490,6 +491,9 @@ Created: ${timestamp}`;
     };
 
     await plugin.storage.setSynced(GRAPH_DATA_KEY_PREFIX + graphRem._id, graphData);
+    // Track this graph Rem so the startup sweep can clear its data later
+    // if the user deletes the Priority Review Document.
+    await registerReviewGraphKey(plugin, graphRem._id);
   }
 
 

--- a/src/lib/priority_review_document/index.ts
+++ b/src/lib/priority_review_document/index.ts
@@ -435,15 +435,20 @@ Created: ${timestamp}`;
 
   // 7. Generate Graph Data and Insert Graph Widget
 
-  // Initialize bins (0-5, 5-10, ... 95-100)
-  const createBins = () => Array(20).fill(0).map((_, i) => ({
-    range: `${i * 5}-${(i + 1) * 5}`,
+  // Initialize bins. Two label styles:
+  //   'integer' for discrete absolute-priority values → `0-4, 5-9, ..., 95-100`
+  //   'range'   for continuous percentile space      → `0-5, 5-10, ..., 95-100`
+  // Last bucket is inclusive of 100 in both styles (priority/percentile is clamped).
+  const createBins = (style: 'integer' | 'range') => Array(20).fill(0).map((_, i) => ({
+    range: style === 'integer'
+      ? (i === 19 ? '95-100' : `${i * 5}-${i * 5 + 4}`)
+      : `${i * 5}-${(i + 1) * 5}`,
     incRem: 0,
     card: 0,
   }));
 
-  const binsAbsolute = createBins();
-  const binsRelative = createBins();
+  const binsAbsolute = createBins('integer');
+  const binsRelative = createBins('range');
 
   for (const item of mixedItems) {
     // Fill Absolute Bins

--- a/src/register/commands.ts
+++ b/src/register/commands.ts
@@ -46,6 +46,7 @@ import {
 import { handleQuickPriorityChange } from '../lib/quick_priority';
 import {
   removeAllCardPriorityTags,
+  cleanUpDuplicateCardPrioritySlots,
   updateAllCardPriorities,
   setCardPriority,
 } from '../lib/card_priority';
@@ -1290,6 +1291,17 @@ export async function registerCommands(plugin: ReactRNPlugin) {
       'Completely remove all CardPriority powerup tags and data from your knowledge base',
     action: async () => {
       await removeAllCardPriorityTags(plugin);
+    },
+  });
+
+  // Cleanup duplicates command
+  await plugin.app.registerCommand({
+    id: 'cleanup-duplicate-card-priority-slots',
+    name: 'Clean Up Duplicate CardPriority Slots',
+    description:
+      'Detect and remove the cardPriority powerup and all its slots from any Rem that has duplicate slots',
+    action: async () => {
+      await cleanUpDuplicateCardPrioritySlots(plugin);
     },
   });
 

--- a/src/register/commands.ts
+++ b/src/register/commands.ts
@@ -46,7 +46,7 @@ import {
 import { handleQuickPriorityChange } from '../lib/quick_priority';
 import {
   removeAllCardPriorityTags,
-  cleanUpDuplicateCardPrioritySlots,
+  sanitizeAllRogueCardPriorityTags,
   updateAllCardPriorities,
   setCardPriority,
 } from '../lib/card_priority';
@@ -1294,14 +1294,14 @@ export async function registerCommands(plugin: ReactRNPlugin) {
     },
   });
 
-  // Cleanup duplicates command
+  // Sanitize rogue tags command
   await plugin.app.registerCommand({
-    id: 'cleanup-duplicate-card-priority-slots',
-    name: 'Clean Up Duplicate CardPriority Slots',
+    id: 'sanitize-rogue-card-priority-tags',
+    name: 'Sanitize Rogue CardPriority Tags',
     description:
-      'Detect and remove the cardPriority powerup and all its slots from any Rem that has duplicate slots',
+      'Detects and removes the CardPriority powerup from properties and non-flashcards across your KB',
     action: async () => {
-      await cleanUpDuplicateCardPrioritySlots(plugin);
+      await sanitizeAllRogueCardPriorityTags(plugin);
     },
   });
 

--- a/src/register/widgets.ts
+++ b/src/register/widgets.ts
@@ -66,7 +66,7 @@ export async function registerWidgets(plugin: ReactRNPlugin) {
 
   plugin.app.registerWidget('debug', WidgetLocation.Popup, {
     dimensions: {
-      width: 400,
+      width: 450,
       height: 800,
     },
   });

--- a/src/widgets/debug.tsx
+++ b/src/widgets/debug.tsx
@@ -57,8 +57,8 @@ function Debug() {
          currentParent = await currentParent.getParentRem();
       }
 
-      const spuriousRems = await getSpuriousCardPriorityTags(rp, rem, false);
-      const hasSpuriousTags = spuriousRems.length > 0;
+      const { guaranteedRogue, suspicious } = await getSpuriousCardPriorityTags(rp, rem, false);
+      const hasSpuriousTags = guaranteedRogue.length > 0 || suspicious.length > 0;
 
       return {
         incrementalRem,
@@ -67,7 +67,8 @@ function Debug() {
         isCardDisabledLocally,
         isCardDisabledInAncestors,
         hasSpuriousTags,
-        spuriousRems,
+        guaranteedRogue,
+        suspicious,
         rem
       };
     },
@@ -76,7 +77,7 @@ function Debug() {
 
   if (!debugData) return null;
 
-  const { incrementalRem, cardPriority, dismissed, isCardDisabledLocally, isCardDisabledInAncestors, hasSpuriousTags, spuriousRems, rem } = debugData;
+  const { incrementalRem, cardPriority, dismissed, isCardDisabledLocally, isCardDisabledInAncestors, hasSpuriousTags, guaranteedRogue, suspicious, rem } = debugData;
 
   const handleDeepLog = async () => {
     console.log(`\n=================== DEEP LOG REM: ${rem._id} ===================`);
@@ -117,33 +118,52 @@ function Debug() {
   };
 
   const handleSanitize = async () => {
-    if (!spuriousRems || spuriousRems.length === 0) return;
+    if (!hasSpuriousTags) return;
     
     let totalCleaned = 0;
     const CHUNK_SIZE = 20;
     
-    for (let i = 0; i < spuriousRems.length; i += CHUNK_SIZE) {
-      const chunk = spuriousRems.slice(i, i + CHUNK_SIZE);
-      const listString = chunk.map((r: any) => `- ${r.name} (${r.id})`).join('\n');
-      
-      const chunkMsg = spuriousRems.length > CHUNK_SIZE 
-        ? `(Batch ${Math.floor(i/CHUNK_SIZE) + 1} of ${Math.ceil(spuriousRems.length/CHUNK_SIZE)})` 
-        : '';
+    if (guaranteedRogue.length > 0) {
+      for (let i = 0; i < guaranteedRogue.length; i += CHUNK_SIZE) {
+        const chunk = guaranteedRogue.slice(i, i + CHUNK_SIZE);
+        const listString = chunk.map((r: any) => `- ${r.name}`).join('\n');
         
-      const confirmed = confirm(`This will remove CardPriority from ${chunk.length} non-flashcard rem(s) ${chunkMsg}:\n\n${listString}\n\nContinue?`);
-      
-      if (!confirmed) {
-        if (totalCleaned > 0) await plugin.app.toast(`Sanitize aborted. Cleaned ${totalCleaned} rogue tags total.`);
-        return;
+        const chunkMsg = guaranteedRogue.length > CHUNK_SIZE 
+          ? `(Batch ${Math.floor(i/CHUNK_SIZE) + 1} of ${Math.ceil(guaranteedRogue.length/CHUNK_SIZE)})` 
+          : '';
+          
+        const confirmed = confirm(`Found ${guaranteedRogue.length} GUARANTEED rogue properties. This will safely remove CardPriority from ${chunk.length} of them ${chunkMsg}:\n\n${listString}\n\nContinue?`);
+        
+        if (!confirmed) {
+          if (totalCleaned > 0) await plugin.app.toast(`Sanitize aborted. Cleaned ${totalCleaned} rogue tags total.`);
+          return;
+        }
+        
+        await plugin.app.toast(`Sanitizing ${chunk.length} guaranteed rogue properties...`);
+        const result = await removeCardPriorityFromSpecificRems(plugin, chunk.map((r: any) => r.id));
+        if (result.success) {
+          totalCleaned += result.cleanedCount;
+        } else {
+          await plugin.app.toast('Sanitize failed during batch. Check console.');
+          return;
+        }
       }
+    }
+
+    if (suspicious.length > 0) {
+      const proceed = confirm(`We found ${suspicious.length} SUSPICIOUS properties.\nThese are property nodes from other plugins that have CardPriority but 0 flashcards. They might be bugs, or they might be intentional.\n\nDo you want to review them one by one?`);
       
-      await plugin.app.toast(`Sanitizing ${chunk.length} rogue properties...`);
-      const result = await removeCardPriorityFromSpecificRems(plugin, chunk.map((r: any) => r.id));
-      if (result.success) {
-        totalCleaned += result.cleanedCount;
-      } else {
-        await plugin.app.toast('Sanitize failed during batch. Check console.');
-        return;
+      if (proceed) {
+        for (const r of suspicious) {
+          const confirmDelete = confirm(`⚠️ Suspicious Property Found\n\nProperty Text: "${r.name}"\nParent Rem: "${r.parentName}"\n\nThis property has no flashcards. Do you want to remove CardPriority from it?`);
+          
+          if (confirmDelete) {
+            const result = await removeCardPriorityFromSpecificRems(plugin, [r.id]);
+            if (result.success) {
+              totalCleaned += result.cleanedCount;
+            }
+          }
+        }
       }
     }
     

--- a/src/widgets/debug.tsx
+++ b/src/widgets/debug.tsx
@@ -8,6 +8,7 @@ import {
 } from '@remnote/plugin-sdk';
 import { getIncrementalRemFromRem } from '../lib/incremental_rem';
 import { getCardPriority } from '../lib/card_priority';
+import { sanitizeCardPriorityFromDescendants } from '../lib/card_priority/batch';
 import { getDismissedHistoryFromRem } from '../lib/dismissed';
 import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
@@ -56,12 +57,26 @@ function Debug() {
          currentParent = await currentParent.getParentRem();
       }
 
+      let hasSpuriousTags = false;
+      const children = await rem.getChildrenRem();
+      for (const child of children) {
+        if (await child.hasPowerup('cardPriority')) {
+          const cards = await child.getCards();
+          if (!cards || cards.length === 0) {
+            hasSpuriousTags = true;
+            break;
+          }
+        }
+      }
+
       return {
         incrementalRem,
         cardPriority,
         dismissed,
         isCardDisabledLocally,
-        isCardDisabledInAncestors
+        isCardDisabledInAncestors,
+        hasSpuriousTags,
+        rem
       };
     },
     [remId]
@@ -69,13 +84,80 @@ function Debug() {
 
   if (!debugData) return null;
 
-  const { incrementalRem, cardPriority, dismissed, isCardDisabledLocally, isCardDisabledInAncestors } = debugData;
+  const { incrementalRem, cardPriority, dismissed, isCardDisabledLocally, isCardDisabledInAncestors, hasSpuriousTags, rem } = debugData;
+
+  const handleDeepLog = async () => {
+    console.log(`\n=================== DEEP LOG REM: ${rem._id} ===================`);
+    const tags = await rem.getTagRems();
+    const mainTagsMapped = await Promise.all(tags.map(async t => ({ 
+      id: t._id, 
+      name: t.text ? await plugin.richText.toString(t.text) : '' 
+    })));
+    const mainTagsStr = mainTagsMapped.length > 0
+      ? mainTagsMapped.map(t => t.name || t.id).join(', ')
+      : 'None';
+    console.log(`Tags: [${mainTagsStr}]`);
+    
+    const children = await rem.getChildrenRem();
+    console.log(`Found ${children.length} total children.`);
+    
+    for (let i = 0; i < children.length; i++) {
+      const child = children[i];
+      const isProp = await child.isProperty();
+      const isPowerupProp = await child.isPowerupProperty();
+      const childTags = await child.getTagRems();
+      const textRaw = await child.text;
+      const textString = textRaw ? await plugin.richText.toString(textRaw) : '';
+      
+      const childTagsMapped = await Promise.all(childTags.map(async t => ({ 
+        id: t._id, 
+        name: t.text ? await plugin.richText.toString(t.text) : '' 
+      })));
+      
+      const tagsStr = childTagsMapped.length > 0 
+        ? childTagsMapped.map(t => t.name || t.id).join(', ') 
+        : 'None';
+        
+      console.log(`Child ${i + 1} (${child._id}): text="${textString}", isProp=${isProp}, isPowerupProp=${isPowerupProp}, tags=[${tagsStr}]`);
+    }
+    console.log(`=================================================================\n`);
+    await plugin.app.toast('Deep log printed to console! Please check Developer Tools.');
+  };
+
+  const handleSanitize = async () => {
+    const confirmed = confirm('Are you sure you want to sanitize this rem? This will safely remove the CardPriority powerup from its property slots and any non-flashcard descendants, while preserving legitimate flashcards.');
+    if (!confirmed) return;
+    
+    await plugin.app.toast('Sanitizing rogue properties...');
+    const result = await sanitizeCardPriorityFromDescendants(plugin, rem, false);
+    if (result.success) {
+       await plugin.app.toast(`Sanitized! Cleaned ${result.cleanedCount} rogue tags. Preserved ${result.preservedCount} flashcards.`);
+    } else {
+       await plugin.app.toast('Sanitize failed. Check console.');
+    }
+  };
 
   const preStyle = { backgroundColor: 'var(--rn-clr-background-secondary)', padding: '8px', borderRadius: '4px', marginTop: '4px', fontSize: '11px', overflowX: 'auto' as 'auto' };
 
   return (
-    <div className="incremental-everything-debug p-4 w-[100%] max-h-[80vh] overflow-y-auto" style={{ fontFamily: 'system-ui, -apple-system, sans-serif', color: 'var(--rn-clr-content-primary)' }}>
-      <h2 style={{ fontSize: '14px', fontWeight: 'bold', marginBottom: '12px', paddingBottom: '4px', borderBottom: '1px solid var(--rn-clr-background-tertiary)' }}>General Data</h2>
+    <div className="incremental-everything-debug p-4 max-h-[80vh] overflow-y-auto" style={{ fontFamily: 'system-ui, -apple-system, sans-serif', color: 'var(--rn-clr-content-primary)', boxSizing: 'border-box' }}>
+      <h2 style={{ fontSize: '14px', fontWeight: 'bold', marginBottom: '12px', paddingBottom: '4px', borderBottom: '1px solid var(--rn-clr-background-tertiary)', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+         General Data
+         <button
+           onClick={handleDeepLog}
+           style={{
+             fontSize: '11px',
+             padding: '2px 8px',
+             backgroundColor: 'var(--rn-clr-background-secondary)',
+             color: 'var(--rn-clr-content-primary)',
+             border: '1px solid var(--rn-clr-border)',
+             borderRadius: '4px',
+             cursor: 'pointer'
+           }}
+         >
+           Deep Log Structure
+         </button>
+      </h2>
       <Info className="rem-id" label="Rem ID" data={<code>{remId}</code>} />
       <div className="flex gap-4">
         <Info className="card-disabled" label="Cards Disabled (Locally)" data={isCardDisabledLocally ? <span style={{color: '#ef4444', fontWeight: 600}}>YES</span> : 'No'} />
@@ -116,7 +198,28 @@ function Debug() {
 
       {cardPriority && (
         <div style={{ marginTop: '16px' }}>
-           <h2 style={{ fontSize: '14px', fontWeight: 'bold', marginBottom: '12px', paddingBottom: '4px', borderBottom: '1px solid var(--rn-clr-background-tertiary)' }}>Card Priority Powerup</h2>
+           <h2 style={{ fontSize: '14px', fontWeight: 'bold', marginBottom: '12px', paddingBottom: '4px', borderBottom: '1px solid var(--rn-clr-background-tertiary)', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+             Card Priority Powerup
+             <button
+               onClick={handleSanitize}
+               style={{
+                 fontSize: '11px',
+                 padding: '2px 8px',
+                 backgroundColor: 'var(--rn-clr-background-warning)',
+                 color: 'var(--rn-clr-content-warning)',
+                 border: '1px solid var(--rn-clr-border-warning)',
+                 borderRadius: '4px',
+                 cursor: 'pointer'
+               }}
+             >
+               Sanitize Rogue Tags
+             </button>
+           </h2>
+           {hasSpuriousTags && (
+             <div style={{ marginBottom: '12px', padding: '8px', backgroundColor: 'var(--rn-clr-background-warning)', color: 'var(--rn-clr-content-warning)', borderRadius: '4px', fontSize: '12px', border: '1px solid var(--rn-clr-border-warning)' }}>
+               ⚠️ <strong>Spurious Tags Detected:</strong> Rogue CardPriority tags were found on non-flashcard children. Please click "Sanitize Rogue Tags" to cure this rem.
+             </div>
+           )}
            <div className="flex gap-4 mb-2">
              <Info className="cp-priority" label="Priority" data={cardPriority.priority} />
              <Info className="cp-source" label="Source" data={<span style={{ textTransform: 'capitalize' }}>{cardPriority.source}</span>} />

--- a/src/widgets/debug.tsx
+++ b/src/widgets/debug.tsx
@@ -8,7 +8,7 @@ import {
 } from '@remnote/plugin-sdk';
 import { getIncrementalRemFromRem } from '../lib/incremental_rem';
 import { getCardPriority } from '../lib/card_priority';
-import { sanitizeCardPriorityFromDescendants } from '../lib/card_priority/batch';
+import { getSpuriousCardPriorityTags, removeCardPriorityFromSpecificRems } from '../lib/card_priority/batch';
 import { getDismissedHistoryFromRem } from '../lib/dismissed';
 import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
@@ -57,17 +57,8 @@ function Debug() {
          currentParent = await currentParent.getParentRem();
       }
 
-      let hasSpuriousTags = false;
-      const children = await rem.getChildrenRem();
-      for (const child of children) {
-        if (await child.hasPowerup('cardPriority')) {
-          const cards = await child.getCards();
-          if (!cards || cards.length === 0) {
-            hasSpuriousTags = true;
-            break;
-          }
-        }
-      }
+      const spuriousRems = await getSpuriousCardPriorityTags(rp, rem, false);
+      const hasSpuriousTags = spuriousRems.length > 0;
 
       return {
         incrementalRem,
@@ -76,6 +67,7 @@ function Debug() {
         isCardDisabledLocally,
         isCardDisabledInAncestors,
         hasSpuriousTags,
+        spuriousRems,
         rem
       };
     },
@@ -84,7 +76,7 @@ function Debug() {
 
   if (!debugData) return null;
 
-  const { incrementalRem, cardPriority, dismissed, isCardDisabledLocally, isCardDisabledInAncestors, hasSpuriousTags, rem } = debugData;
+  const { incrementalRem, cardPriority, dismissed, isCardDisabledLocally, isCardDisabledInAncestors, hasSpuriousTags, spuriousRems, rem } = debugData;
 
   const handleDeepLog = async () => {
     console.log(`\n=================== DEEP LOG REM: ${rem._id} ===================`);
@@ -125,16 +117,37 @@ function Debug() {
   };
 
   const handleSanitize = async () => {
-    const confirmed = confirm('Are you sure you want to sanitize this rem? This will safely remove the CardPriority powerup from its property slots and any non-flashcard descendants, while preserving legitimate flashcards.');
-    if (!confirmed) return;
+    if (!spuriousRems || spuriousRems.length === 0) return;
     
-    await plugin.app.toast('Sanitizing rogue properties...');
-    const result = await sanitizeCardPriorityFromDescendants(plugin, rem, false);
-    if (result.success) {
-       await plugin.app.toast(`Sanitized! Cleaned ${result.cleanedCount} rogue tags. Preserved ${result.preservedCount} flashcards.`);
-    } else {
-       await plugin.app.toast('Sanitize failed. Check console.');
+    let totalCleaned = 0;
+    const CHUNK_SIZE = 20;
+    
+    for (let i = 0; i < spuriousRems.length; i += CHUNK_SIZE) {
+      const chunk = spuriousRems.slice(i, i + CHUNK_SIZE);
+      const listString = chunk.map((r: any) => `- ${r.name} (${r.id})`).join('\n');
+      
+      const chunkMsg = spuriousRems.length > CHUNK_SIZE 
+        ? `(Batch ${Math.floor(i/CHUNK_SIZE) + 1} of ${Math.ceil(spuriousRems.length/CHUNK_SIZE)})` 
+        : '';
+        
+      const confirmed = confirm(`This will remove CardPriority from ${chunk.length} non-flashcard rem(s) ${chunkMsg}:\n\n${listString}\n\nContinue?`);
+      
+      if (!confirmed) {
+        if (totalCleaned > 0) await plugin.app.toast(`Sanitize aborted. Cleaned ${totalCleaned} rogue tags total.`);
+        return;
+      }
+      
+      await plugin.app.toast(`Sanitizing ${chunk.length} rogue properties...`);
+      const result = await removeCardPriorityFromSpecificRems(plugin, chunk.map((r: any) => r.id));
+      if (result.success) {
+        totalCleaned += result.cleanedCount;
+      } else {
+        await plugin.app.toast('Sanitize failed during batch. Check console.');
+        return;
+      }
     }
+    
+    await plugin.app.toast(`Sanitized! Cleaned ${totalCleaned} rogue tags total.`);
   };
 
   const preStyle = { backgroundColor: 'var(--rn-clr-background-secondary)', padding: '8px', borderRadius: '4px', marginTop: '4px', fontSize: '11px', overflowX: 'auto' as 'auto' };

--- a/src/widgets/inc_rem_main_view.tsx
+++ b/src/widgets/inc_rem_main_view.tsx
@@ -128,6 +128,9 @@ export function IncRemMainView() {
   // Track in-flight priority changes so cache reloads don't overwrite them with stale data.
   const pendingPriorityChanges = useRef<Record<string, number>>({});
 
+  // Container ref used to locate the rendered <svg> for export.
+  const chartContainerRef = useRef<HTMLDivElement>(null);
+
   // Track current filter/sort state for "Back to IncRem List" flow
   const currentListState = useRef<IncRemListState | null>(null);
 
@@ -349,6 +352,157 @@ export function IncRemMainView() {
     currentListState.current = state;
   };
 
+  const handleExportGraphSvg = () => {
+    const container = chartContainerRef.current;
+    if (!container || !graphBins) return;
+
+    const liveSvg = container.querySelector('svg');
+    if (!liveSvg) return;
+
+    const SVG_NS = 'http://www.w3.org/2000/svg';
+    const svg = liveSvg.cloneNode(true) as SVGSVGElement;
+    svg.setAttribute('xmlns', SVG_NS);
+    svg.setAttribute('xmlns:xlink', 'http://www.w3.org/1999/xlink');
+
+    const chartWidth = parseFloat(svg.getAttribute('width') || '') || liveSvg.clientWidth || 800;
+    const chartHeight = parseFloat(svg.getAttribute('height') || '') || liveSvg.clientHeight || 350;
+    const titleBandHeight = 56;
+    const legendBandHeight = 32;
+    const headerHeight = titleBandHeight + legendBandHeight;
+    const padding = 12;
+
+    const tooltipFor = (bin: GraphDataPoint): string => {
+      const incTotal = bin.incRemDue + bin.incRemNotDue;
+      const cardTotal = bin.cardDue + bin.cardNotDue;
+      const incPct = incTotal > 0 ? Math.round((bin.incRemNotDue / incTotal) * 100) : 0;
+      const cardPct = cardTotal > 0 ? Math.round((bin.cardNotDue / cardTotal) * 100) : 0;
+      return (
+        `Priority ${bin.range}\n` +
+        `Incremental Rems: ${incTotal}  (Due ${bin.incRemDue} · Processed ${bin.incRemNotDue} = ${incPct}%)\n` +
+        `Rems with Cards:  ${cardTotal}  (Due ${bin.cardDue} · Processed ${bin.cardNotDue} = ${cardPct}%)`
+      );
+    };
+
+    // Inject <title> per bar so native browser tooltips show the bucket breakdown on hover.
+    // The <title> MUST be a direct child of the element that receives the pointer event
+    // (Chrome/Safari don't walk up to ancestors), so we attach it to the <path> shape
+    // inside each <g class="recharts-bar-rectangle">, not to the group itself.
+    const barSeries = svg.querySelectorAll('.recharts-bar');
+    barSeries.forEach((series) => {
+      const rects = series.querySelectorAll('.recharts-bar-rectangle');
+      rects.forEach((rectGroup, idx) => {
+        const bin = graphBins[idx];
+        if (!bin) return;
+        const titleText = tooltipFor(bin);
+        rectGroup.querySelectorAll('path, rect').forEach((shape) => {
+          const titleEl = document.createElementNS(SVG_NS, 'title');
+          titleEl.textContent = titleText;
+          shape.insertBefore(titleEl, shape.firstChild);
+        });
+      });
+    });
+
+    // Wrap all existing children so we can prepend a header band with the title.
+    const wrapperG = document.createElementNS(SVG_NS, 'g');
+    wrapperG.setAttribute('transform', `translate(0, ${headerHeight})`);
+    while (svg.firstChild) wrapperG.appendChild(svg.firstChild);
+
+    const totalHeight = chartHeight + headerHeight + padding;
+    svg.setAttribute('width', String(chartWidth));
+    svg.setAttribute('height', String(totalHeight));
+    svg.setAttribute('viewBox', `0 0 ${chartWidth} ${totalHeight}`);
+
+    // White background so the file looks correct when opened anywhere (incl. dark mode browsers).
+    const bg = document.createElementNS(SVG_NS, 'rect');
+    bg.setAttribute('x', '0');
+    bg.setAttribute('y', '0');
+    bg.setAttribute('width', String(chartWidth));
+    bg.setAttribute('height', String(totalHeight));
+    bg.setAttribute('fill', '#ffffff');
+    svg.appendChild(bg);
+
+    const incCount = allIncRems?.length || 0;
+    const cardCount = allCardInfos?.filter(c => c.cardCount === undefined || c.cardCount > 0).length || 0;
+
+    const titleEl = document.createElementNS(SVG_NS, 'text');
+    titleEl.setAttribute('x', String(chartWidth / 2));
+    titleEl.setAttribute('y', '24');
+    titleEl.setAttribute('text-anchor', 'middle');
+    titleEl.setAttribute('font-family', 'system-ui, -apple-system, "Segoe UI", sans-serif');
+    titleEl.setAttribute('font-size', '14');
+    titleEl.setAttribute('font-weight', '600');
+    titleEl.setAttribute('fill', '#374151');
+    titleEl.textContent = 'KB Priority Distribution';
+    svg.appendChild(titleEl);
+
+    const subtitleEl = document.createElementNS(SVG_NS, 'text');
+    subtitleEl.setAttribute('x', String(chartWidth / 2));
+    subtitleEl.setAttribute('y', '44');
+    subtitleEl.setAttribute('text-anchor', 'middle');
+    subtitleEl.setAttribute('font-family', 'system-ui, -apple-system, "Segoe UI", sans-serif');
+    subtitleEl.setAttribute('font-size', '11');
+    subtitleEl.setAttribute('fill', '#9ca3af');
+    subtitleEl.textContent = `(${incCount.toLocaleString()} IncRems, ${cardCount.toLocaleString()} Rems with Cards)`;
+    svg.appendChild(subtitleEl);
+
+    // Manual legend row — Recharts renders <Legend> as HTML outside the SVG, so it's
+    // not in the cloned tree. We draw it directly into the SVG here.
+    const legendEntries: Array<{ label: string; color: string }> = [
+      { label: 'IncRems · Due', color: INC_REM_DUE_COLOR },
+      { label: 'IncRems · Processed', color: INC_REM_NOT_DUE_COLOR },
+      { label: 'Cards · Due', color: CARD_DUE_COLOR },
+      { label: 'Cards · Processed', color: CARD_NOT_DUE_COLOR },
+    ];
+    const legendY = titleBandHeight + legendBandHeight / 2;
+    const swatchSize = 12;
+    const gapAfterSwatch = 6;
+    const gapBetweenEntries = 18;
+    const legendFontFamily = 'system-ui, -apple-system, "Segoe UI", sans-serif';
+    const legendFontSize = 11;
+    // Approximate char width to lay out horizontally without measuring DOM
+    const approxCharWidth = 6.2;
+    const entryWidths = legendEntries.map(e => swatchSize + gapAfterSwatch + e.label.length * approxCharWidth);
+    const totalLegendWidth = entryWidths.reduce((s, w) => s + w, 0) + gapBetweenEntries * (legendEntries.length - 1);
+    let cursorX = (chartWidth - totalLegendWidth) / 2;
+
+    legendEntries.forEach((entry, i) => {
+      const swatch = document.createElementNS(SVG_NS, 'rect');
+      swatch.setAttribute('x', String(cursorX));
+      swatch.setAttribute('y', String(legendY - swatchSize / 2));
+      swatch.setAttribute('width', String(swatchSize));
+      swatch.setAttribute('height', String(swatchSize));
+      swatch.setAttribute('fill', entry.color);
+      swatch.setAttribute('rx', '2');
+      svg.appendChild(swatch);
+
+      const label = document.createElementNS(SVG_NS, 'text');
+      label.setAttribute('x', String(cursorX + swatchSize + gapAfterSwatch));
+      label.setAttribute('y', String(legendY));
+      label.setAttribute('dominant-baseline', 'central');
+      label.setAttribute('font-family', legendFontFamily);
+      label.setAttribute('font-size', String(legendFontSize));
+      label.setAttribute('fill', '#374151');
+      label.textContent = entry.label;
+      svg.appendChild(label);
+
+      cursorX += entryWidths[i] + gapBetweenEntries;
+    });
+
+    svg.appendChild(wrapperG);
+
+    const xml = new XMLSerializer().serializeToString(svg);
+    const blob = new Blob([`<?xml version="1.0" encoding="UTF-8"?>\n${xml}`], { type: 'image/svg+xml' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    const stamp = new Date().toISOString().slice(0, 10);
+    a.href = url;
+    a.download = `kb-priority-distribution-${stamp}.svg`;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  };
+
   const handleDocumentFilterChange = async (documentId: string | null) => {
     setSelectedDocumentId(documentId);
     if (documentId) {
@@ -404,9 +558,24 @@ export function IncRemMainView() {
     <div className="flex flex-col h-full" style={{ backgroundColor: 'var(--rn-clr-background-primary)' }}>
       {/* Graph toggle button in a small bar above the table */}
       <div
-        className="flex items-center justify-end px-4 py-1 shrink-0"
+        className="flex items-center justify-end gap-1 px-4 py-1 shrink-0"
         style={{ borderBottom: '1px solid var(--rn-clr-border-primary)' }}
       >
+        {showGraph && (
+          <button
+            onClick={handleExportGraphSvg}
+            className="px-2 py-1 text-xs rounded transition-colors"
+            style={{
+              backgroundColor: 'var(--rn-clr-background-primary)',
+              color: 'var(--rn-clr-content-tertiary)',
+            }}
+            onMouseEnter={(e) => { e.currentTarget.style.backgroundColor = 'var(--rn-clr-background-tertiary)'; }}
+            onMouseLeave={(e) => { e.currentTarget.style.backgroundColor = 'var(--rn-clr-background-primary)'; }}
+            title="Export graph as interactive SVG (hover over bars in your browser to see the bucket breakdown)"
+          >
+            ⬇️ Export SVG
+          </button>
+        )}
         <button
           onClick={() => setShowGraph(!showGraph)}
           className="px-2 py-1 text-xs rounded transition-colors"
@@ -435,7 +604,7 @@ export function IncRemMainView() {
               </span>
             </h4>
 
-            <div style={{ width: '100%', height: 350 }}>
+            <div ref={chartContainerRef} style={{ width: '100%', height: 350 }}>
               <ResponsiveContainer width="100%" height="100%" minHeight={350} minWidth={100}>
                 <BarChart
                   data={graphBins}

--- a/src/widgets/inc_rem_main_view.tsx
+++ b/src/widgets/inc_rem_main_view.tsx
@@ -47,7 +47,9 @@ function computeKbGraphBins(
 ): GraphDataPoint[] {
   const now = Date.now();
   const bins: GraphDataPoint[] = Array(20).fill(0).map((_, i) => ({
-    range: `${i * 5}-${(i + 1) * 5}`,
+    // Integer-priority labels. Last bucket spans [95, 100] inclusive because
+    // priority is clamped to 100 in the binning step below.
+    range: i === 19 ? '95-100' : `${i * 5}-${i * 5 + 4}`,
     incRemDue: 0,
     incRemNotDue: 0,
     cardDue: 0,
@@ -352,17 +354,25 @@ export function IncRemMainView() {
     currentListState.current = state;
   };
 
-  const handleExportGraphSvg = () => {
+  // Builds an annotated, exportable SVG with header band, legend, and bars converted
+  // from recharts <path> to plain <rect>. The `tooltipMode` controls how each bar
+  // carries its bucket data:
+  //   - 'native-title' → inject an SVG <title> child (for standalone .svg export)
+  //   - 'data-attr'    → set data-bin-index="N" (for HTML export with JS tooltips)
+  const buildAnnotatedSvg = (
+    tooltipMode: 'native-title' | 'data-attr',
+  ): { svg: SVGSVGElement; chartWidth: number; totalHeight: number } | null => {
     const container = chartContainerRef.current;
-    if (!container || !graphBins) return;
+    if (!container || !graphBins) return null;
 
     const liveSvg = container.querySelector('svg');
-    if (!liveSvg) return;
+    if (!liveSvg) return null;
 
     const SVG_NS = 'http://www.w3.org/2000/svg';
     const svg = liveSvg.cloneNode(true) as SVGSVGElement;
     svg.setAttribute('xmlns', SVG_NS);
     svg.setAttribute('xmlns:xlink', 'http://www.w3.org/1999/xlink');
+    svg.removeAttribute('style');
 
     const chartWidth = parseFloat(svg.getAttribute('width') || '') || liveSvg.clientWidth || 800;
     const chartHeight = parseFloat(svg.getAttribute('height') || '') || liveSvg.clientHeight || 350;
@@ -370,6 +380,28 @@ export function IncRemMainView() {
     const legendBandHeight = 32;
     const headerHeight = titleBandHeight + legendBandHeight;
     const padding = 12;
+
+    // Replace each recharts bar <path> with a proper <rect> (using the dimensions
+    // recharts already wrote on the path) — universally hoverable and well-behaved.
+    const barPaths = svg.querySelectorAll('path.recharts-rectangle');
+    barPaths.forEach((path) => {
+      const x = path.getAttribute('x');
+      const y = path.getAttribute('y');
+      const width = path.getAttribute('width');
+      const height = path.getAttribute('height');
+      const fill = path.getAttribute('fill') || 'currentColor';
+      if (!x || !y || !width || !height) return;
+
+      const rect = document.createElementNS(SVG_NS, 'rect');
+      rect.setAttribute('x', x);
+      rect.setAttribute('y', y);
+      rect.setAttribute('width', width);
+      rect.setAttribute('height', height);
+      rect.setAttribute('fill', fill);
+      rect.setAttribute('class', 'recharts-rectangle');
+      rect.setAttribute('pointer-events', 'all');
+      path.parentNode?.replaceChild(rect, path);
+    });
 
     const tooltipFor = (bin: GraphDataPoint): string => {
       const incTotal = bin.incRemDue + bin.incRemNotDue;
@@ -383,26 +415,26 @@ export function IncRemMainView() {
       );
     };
 
-    // Inject <title> per bar so native browser tooltips show the bucket breakdown on hover.
-    // The <title> MUST be a direct child of the element that receives the pointer event
-    // (Chrome/Safari don't walk up to ancestors), so we attach it to the <path> shape
-    // inside each <g class="recharts-bar-rectangle">, not to the group itself.
+    // Annotate each bar with either a <title> or a data-bin-index.
     const barSeries = svg.querySelectorAll('.recharts-bar');
     barSeries.forEach((series) => {
-      const rects = series.querySelectorAll('.recharts-bar-rectangle');
-      rects.forEach((rectGroup, idx) => {
+      const barCells = series.querySelectorAll('.recharts-bar-rectangle');
+      barCells.forEach((cell, idx) => {
         const bin = graphBins[idx];
         if (!bin) return;
-        const titleText = tooltipFor(bin);
-        rectGroup.querySelectorAll('path, rect').forEach((shape) => {
-          const titleEl = document.createElementNS(SVG_NS, 'title');
-          titleEl.textContent = titleText;
-          shape.insertBefore(titleEl, shape.firstChild);
+        cell.querySelectorAll('rect, path').forEach((shape) => {
+          if (tooltipMode === 'native-title') {
+            const titleEl = document.createElementNS(SVG_NS, 'title');
+            titleEl.textContent = tooltipFor(bin);
+            shape.insertBefore(titleEl, shape.firstChild);
+          } else {
+            shape.setAttribute('data-bin-index', String(idx));
+          }
         });
       });
     });
 
-    // Wrap all existing children so we can prepend a header band with the title.
+    // Wrap existing children so we can prepend a header band.
     const wrapperG = document.createElementNS(SVG_NS, 'g');
     wrapperG.setAttribute('transform', `translate(0, ${headerHeight})`);
     while (svg.firstChild) wrapperG.appendChild(svg.firstChild);
@@ -412,7 +444,6 @@ export function IncRemMainView() {
     svg.setAttribute('height', String(totalHeight));
     svg.setAttribute('viewBox', `0 0 ${chartWidth} ${totalHeight}`);
 
-    // White background so the file looks correct when opened anywhere (incl. dark mode browsers).
     const bg = document.createElementNS(SVG_NS, 'rect');
     bg.setAttribute('x', '0');
     bg.setAttribute('y', '0');
@@ -445,8 +476,7 @@ export function IncRemMainView() {
     subtitleEl.textContent = `(${incCount.toLocaleString()} IncRems, ${cardCount.toLocaleString()} Rems with Cards)`;
     svg.appendChild(subtitleEl);
 
-    // Manual legend row — Recharts renders <Legend> as HTML outside the SVG, so it's
-    // not in the cloned tree. We draw it directly into the SVG here.
+    // Manual legend row.
     const legendEntries: Array<{ label: string; color: string }> = [
       { label: 'IncRems · Due', color: INC_REM_DUE_COLOR },
       { label: 'IncRems · Processed', color: INC_REM_NOT_DUE_COLOR },
@@ -459,7 +489,6 @@ export function IncRemMainView() {
     const gapBetweenEntries = 18;
     const legendFontFamily = 'system-ui, -apple-system, "Segoe UI", sans-serif';
     const legendFontSize = 11;
-    // Approximate char width to lay out horizontally without measuring DOM
     const approxCharWidth = 6.2;
     const entryWidths = legendEntries.map(e => swatchSize + gapAfterSwatch + e.label.length * approxCharWidth);
     const totalLegendWidth = entryWidths.reduce((s, w) => s + w, 0) + gapBetweenEntries * (legendEntries.length - 1);
@@ -490,17 +519,191 @@ export function IncRemMainView() {
 
     svg.appendChild(wrapperG);
 
-    const xml = new XMLSerializer().serializeToString(svg);
-    const blob = new Blob([`<?xml version="1.0" encoding="UTF-8"?>\n${xml}`], { type: 'image/svg+xml' });
+    return { svg, chartWidth, totalHeight };
+  };
+
+  const triggerDownload = (blob: Blob, filename: string) => {
     const url = URL.createObjectURL(blob);
     const a = document.createElement('a');
-    const stamp = new Date().toISOString().slice(0, 10);
     a.href = url;
-    a.download = `kb-priority-distribution-${stamp}.svg`;
+    a.download = filename;
     document.body.appendChild(a);
     a.click();
     document.body.removeChild(a);
     URL.revokeObjectURL(url);
+  };
+
+  const handleExportGraphSvg = () => {
+    const built = buildAnnotatedSvg('native-title');
+    if (!built) return;
+    const xml = new XMLSerializer().serializeToString(built.svg);
+    const blob = new Blob([`<?xml version="1.0" encoding="UTF-8"?>\n${xml}`], { type: 'image/svg+xml' });
+    const stamp = new Date().toISOString().slice(0, 10);
+    triggerDownload(blob, `kb-priority-distribution-${stamp}.svg`);
+  };
+
+  const handleExportGraphHtml = () => {
+    const built = buildAnnotatedSvg('data-attr');
+    if (!built || !graphBins) return;
+    const { svg, chartWidth, totalHeight } = built;
+
+    const svgMarkup = new XMLSerializer().serializeToString(svg);
+    const stamp = new Date().toISOString().slice(0, 10);
+
+    // Tooltip rendering is done in JS; data lives in a JSON island.
+    const dataJson = JSON.stringify(graphBins);
+    const colors = {
+      incDue: INC_REM_DUE_COLOR,
+      incNotDue: INC_REM_NOT_DUE_COLOR,
+      cardDue: CARD_DUE_COLOR,
+      cardNotDue: CARD_NOT_DUE_COLOR,
+    };
+    const colorsJson = JSON.stringify(colors);
+
+    const html = `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<title>KB Priority Distribution — ${stamp}</title>
+<style>
+  html, body { margin: 0; padding: 0; background: #f3f4f6; font-family: system-ui, -apple-system, "Segoe UI", sans-serif; color: #374151; }
+  .wrap { max-width: ${chartWidth + 40}px; margin: 24px auto; padding: 16px; background: #ffffff; border-radius: 8px; box-shadow: 0 1px 3px rgba(0,0,0,0.08); }
+  .chart-host { position: relative; width: 100%; }
+  .chart-host svg { display: block; width: 100%; height: auto; max-width: ${chartWidth}px; }
+  rect.recharts-rectangle[data-bin-index] { cursor: pointer; transition: opacity 120ms ease; }
+  rect.recharts-rectangle[data-bin-index]:hover { opacity: 0.78; }
+  .bin-hover-overlay { fill: transparent; cursor: pointer; }
+  .tooltip {
+    position: fixed; pointer-events: none; z-index: 1000;
+    background: #ffffff; color: #374151;
+    border-radius: 8px; border: none;
+    box-shadow: 0 4px 6px -1px rgba(0,0,0,0.1);
+    padding: 8px 10px;
+    font-size: 12px; line-height: 1.4;
+    opacity: 0; transform: translate(0, 0);
+    transition: opacity 80ms ease;
+    max-width: 320px;
+  }
+  .tooltip.visible { opacity: 1; }
+  .tooltip .range { font-weight: 600; margin-bottom: 4px; }
+  .tooltip .series-header { font-weight: 600; margin-top: 4px; }
+  .tooltip .series-detail { margin-left: 8px; }
+  .footer { text-align: center; color: #9ca3af; font-size: 11px; margin-top: 12px; }
+</style>
+</head>
+<body>
+<div class="wrap">
+  <div class="chart-host" id="chart-host" style="height:${totalHeight}px;">${svgMarkup}</div>
+  <div class="footer">Exported ${stamp} · Hover any bar for the bucket breakdown</div>
+</div>
+<div class="tooltip" id="tooltip" role="tooltip" aria-hidden="true"></div>
+<script>
+(function () {
+  var bins = ${dataJson};
+  var colors = ${colorsJson};
+  var tooltip = document.getElementById('tooltip');
+  var host = document.getElementById('chart-host');
+
+  function buildTooltipHtml(bin) {
+    var incTotal = bin.incRemDue + bin.incRemNotDue;
+    var cardTotal = bin.cardDue + bin.cardNotDue;
+    var incPct = incTotal > 0 ? Math.round(bin.incRemNotDue / incTotal * 100) : 0;
+    var cardPct = cardTotal > 0 ? Math.round(bin.cardNotDue / cardTotal * 100) : 0;
+    return ''
+      + '<div class="range">Priority ' + bin.range + '</div>'
+      + '<div class="series-header" style="color:' + colors.incDue + '">Incremental Rems: ' + incTotal + '</div>'
+      + '<div class="series-detail">Due: ' + bin.incRemDue + ' · Processed: ' + bin.incRemNotDue + ' (' + incPct + '%)</div>'
+      + '<div class="series-header" style="color:' + colors.cardDue + '">Rems with Cards: ' + cardTotal + '</div>'
+      + '<div class="series-detail">Due: ' + bin.cardDue + ' · Processed: ' + bin.cardNotDue + ' (' + cardPct + '%)</div>';
+  }
+
+  function showTooltip(e, idx) {
+    var bin = bins[idx];
+    if (!bin) return;
+    tooltip.innerHTML = buildTooltipHtml(bin);
+    tooltip.classList.add('visible');
+    tooltip.setAttribute('aria-hidden', 'false');
+    positionTooltip(e);
+  }
+
+  function positionTooltip(e) {
+    var x = e.clientX + 14;
+    var y = e.clientY + 14;
+    var rect = tooltip.getBoundingClientRect();
+    if (x + rect.width > window.innerWidth - 8) x = e.clientX - rect.width - 14;
+    if (y + rect.height > window.innerHeight - 8) y = e.clientY - rect.height - 14;
+    tooltip.style.left = x + 'px';
+    tooltip.style.top = y + 'px';
+  }
+
+  function hideTooltip() {
+    tooltip.classList.remove('visible');
+    tooltip.setAttribute('aria-hidden', 'true');
+  }
+
+  // Attach hover listeners to each bar rect.
+  var bars = host.querySelectorAll('rect.recharts-rectangle[data-bin-index]');
+  bars.forEach(function (rect) {
+    var idx = parseInt(rect.getAttribute('data-bin-index'), 10);
+    rect.addEventListener('mouseenter', function (e) { showTooltip(e, idx); });
+    rect.addEventListener('mousemove', positionTooltip);
+    rect.addEventListener('mouseleave', hideTooltip);
+  });
+
+  // Also add a full-bin invisible hover band over each X bucket so users can hover
+  // the entire vertical column (including empty space above the stack) and still
+  // see the tooltip — matches the in-app behavior more closely.
+  // We compute these bands from the rendered SVG's bar positions.
+  try {
+    var svg = host.querySelector('svg');
+    var nsResolver = null;
+    var binBuckets = {};
+    bars.forEach(function (r) {
+      var idx = r.getAttribute('data-bin-index');
+      var x = parseFloat(r.getAttribute('x'));
+      var w = parseFloat(r.getAttribute('width'));
+      if (!binBuckets[idx]) binBuckets[idx] = { minX: x, maxX: x + w };
+      else {
+        if (x < binBuckets[idx].minX) binBuckets[idx].minX = x;
+        if (x + w > binBuckets[idx].maxX) binBuckets[idx].maxX = x + w;
+      }
+    });
+    // Find the chart plot area for vertical extents from the cartesian grid clipPath.
+    var clip = svg.querySelector('clipPath rect');
+    if (clip) {
+      var plotY = parseFloat(clip.getAttribute('y'));
+      var plotH = parseFloat(clip.getAttribute('height'));
+      var plotTransform = svg.querySelector('g[transform^="translate(0,"]');
+      // The wrapper <g transform="translate(0, headerHeight)"> moves the plot down;
+      // we honor that by appending overlays as siblings inside the same wrapper.
+      var overlayParent = plotTransform || svg;
+      Object.keys(binBuckets).forEach(function (idx) {
+        var b = binBuckets[idx];
+        var pad = 8;
+        var overlay = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
+        overlay.setAttribute('x', String(b.minX - pad / 2));
+        overlay.setAttribute('y', String(plotY));
+        overlay.setAttribute('width', String((b.maxX - b.minX) + pad));
+        overlay.setAttribute('height', String(plotH));
+        overlay.setAttribute('class', 'bin-hover-overlay');
+        overlay.setAttribute('data-bin-index', idx);
+        overlay.addEventListener('mouseenter', function (e) { showTooltip(e, parseInt(idx, 10)); });
+        overlay.addEventListener('mousemove', positionTooltip);
+        overlay.addEventListener('mouseleave', hideTooltip);
+        overlayParent.appendChild(overlay);
+      });
+    }
+  } catch (err) {
+    // Overlay enhancement is best-effort; bar-only hover still works.
+    console.warn('bin overlay setup skipped:', err);
+  }
+})();
+</script>
+</body>
+</html>`;
+
+    const blob = new Blob([html], { type: 'text/html;charset=utf-8' });
+    triggerDownload(blob, `kb-priority-distribution-${stamp}.html`);
   };
 
   const handleDocumentFilterChange = async (documentId: string | null) => {
@@ -562,19 +765,34 @@ export function IncRemMainView() {
         style={{ borderBottom: '1px solid var(--rn-clr-border-primary)' }}
       >
         {showGraph && (
-          <button
-            onClick={handleExportGraphSvg}
-            className="px-2 py-1 text-xs rounded transition-colors"
-            style={{
-              backgroundColor: 'var(--rn-clr-background-primary)',
-              color: 'var(--rn-clr-content-tertiary)',
-            }}
-            onMouseEnter={(e) => { e.currentTarget.style.backgroundColor = 'var(--rn-clr-background-tertiary)'; }}
-            onMouseLeave={(e) => { e.currentTarget.style.backgroundColor = 'var(--rn-clr-background-primary)'; }}
-            title="Export graph as interactive SVG (hover over bars in your browser to see the bucket breakdown)"
-          >
-            ⬇️ Export SVG
-          </button>
+          <>
+            <button
+              onClick={handleExportGraphHtml}
+              className="px-2 py-1 text-xs rounded transition-colors"
+              style={{
+                backgroundColor: 'var(--rn-clr-background-primary)',
+                color: 'var(--rn-clr-content-tertiary)',
+              }}
+              onMouseEnter={(e) => { e.currentTarget.style.backgroundColor = 'var(--rn-clr-background-tertiary)'; }}
+              onMouseLeave={(e) => { e.currentTarget.style.backgroundColor = 'var(--rn-clr-background-primary)'; }}
+              title="Export graph as standalone HTML with JS-driven tooltips that match the in-app design"
+            >
+              ⬇️ Export HTML
+            </button>
+            <button
+              onClick={handleExportGraphSvg}
+              className="px-2 py-1 text-xs rounded transition-colors"
+              style={{
+                backgroundColor: 'var(--rn-clr-background-primary)',
+                color: 'var(--rn-clr-content-tertiary)',
+              }}
+              onMouseEnter={(e) => { e.currentTarget.style.backgroundColor = 'var(--rn-clr-background-tertiary)'; }}
+              onMouseLeave={(e) => { e.currentTarget.style.backgroundColor = 'var(--rn-clr-background-primary)'; }}
+              title="Export graph as SVG (uses native browser tooltips on bar hover; may not work in all browsers)"
+            >
+              ⬇️ Export SVG
+            </button>
+          </>
         )}
         <button
           onClick={() => setShowGraph(!showGraph)}

--- a/src/widgets/index.tsx
+++ b/src/widgets/index.tsx
@@ -23,6 +23,7 @@ import {
 } from '../register/queue_display_commands';
 import { enableHideInQueueIntegrationId } from '../lib/consts';
 import { registerIncrementalRemTracker } from '../register/tracker';
+import { cleanupOrphanedReviewGraphs } from '../lib/priority_review_document/cleanup';
 import { registerJumpToRemHelper } from '../register/window';
 import { registerPluginHidingCSS, registerPdfHighlightCSS, registerClozeExtractCSS } from '../lib/ui_helpers';
 
@@ -60,6 +61,11 @@ async function onActivate(plugin: ReactRNPlugin) {
   registerEventListeners(plugin, resetSessionItemCounter);
 
   registerIncrementalRemTracker(plugin);
+
+  // Fire-and-forget: clear synced graph-data entries whose Priority Review
+  // Document graph Rem was deleted. Errors are logged inside the helper and
+  // must not block activation.
+  void cleanupOrphanedReviewGraphs(plugin);
 
   registerCallbacks(plugin);
   await registerWidgets(plugin);

--- a/src/widgets/priority_review_graph.tsx
+++ b/src/widgets/priority_review_graph.tsx
@@ -35,7 +35,7 @@ function PriorityReviewGraph() {
 
   // Get the Rem ID this widget is attached to
   const context = useTrackerPlugin(async (rp) => {
-    return await rp.widget.getWidgetContext<{ widgetInstanceId: string; remId: string }>();
+    return await rp.widget.getWidgetContext<any>();
   }, []);
 
   const remId = context?.remId;


### PR DESCRIPTION
### ✨ New: Rogue CardPriority Sanitization Tool

Added a powerful new diagnostic command, **"Sanitize Rogue CardPriority Tags"**, to help clean up Knowledge Bases that have accumulated "rogue" priority tags on internal property slots.

**The Issue:** Over time, automated background processes could accidentally tag internal property slots (like `History` or `Created`, or property slots from other plugins) with the `cardPriority` powerup, leading to inflated processing times and cluttered databases.

**The Solution:** A robust, two-tier sanitization workflow:
- **Tier 1 (Guaranteed Rogue):** Safely auto-detects and batch-removes tags from our plugin's own structural slots using precise SDK definition ID matching.
- **Tier 2 (Suspicious):** Surfaces third-party property nodes that have `CardPriority` but 0 flashcards for a manual, one-by-one review, ensuring no data loss for legitimate external flashcard integrations.
- **Targeted Sanitization:** You can now also sanitize a specific Rem locally using the `/debug` widget, which will surface a "Sanitize" button if rogue tags are detected on its properties.
- **Safety First:** The scanner guarantees that any Rem with actual flashcards is completely ignored and protected.

### 🐛 Bug Fix: Crash on Rems with Malformed Text
Fixed an issue where the background batch processor could crash with a `richText.toString` error when encountering rems with empty or malformed rich-text structures. It now uses a battle-tested safe string converter to gracefully handle these edge cases without interrupting the batch.

-
**Stacked Graphs:** Instantly see *Due* vs. *Processed* items in your priority distribution graphs.