### PR TITLE
Skip Paused Documents in Priority Review Document

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -7,7 +7,7 @@
   "version": {
     "major": 0,
     "minor": 2,
-    "patch": 228
+    "patch": 229
   },
   "unlisted": false,
   "theme": [],

--- a/src/lib/card_priority/cache.ts
+++ b/src/lib/card_priority/cache.ts
@@ -416,7 +416,7 @@ export async function loadCardPriorityCache(plugin: RNPlugin) {
   console.log(`[Card Priority Cache] Found ${untaggedRemIds.length} untagged rems with cards for deferred processing`);
 
   if (enrichedTaggedPriorities.length > 0) {
-    await plugin.app.toast(`✅ Loaded ${enrichedTaggedPriorities.length} pre-tagged card priorities in ${phase1Time}s`);
+    await plugin.app.toast(`✅ Loaded ${enrichedTaggedPriorities.length} pre-tagged card priorities in ${totalTime}s`);
   }
 
   if (untaggedRemIds.length > 0) {

--- a/src/lib/card_priority/index.ts
+++ b/src/lib/card_priority/index.ts
@@ -67,6 +67,10 @@ export async function getCardPriority(
 
   const now = Date.now();
   const startOfToday = dayjs().startOf('day').valueOf();
+  // `?? Infinity`: disabled cards have nextRepetitionTime === null, which maps to
+  // Infinity and therefore never satisfies the <= now check. This implicitly excludes
+  // disabled cards from due counts and, consequently, from Priority Review Documents
+  // and the due-card-priority cache — without any explicit disabled-card filter.
   const dueCards = cards.filter((card) => (card.nextRepetitionTime ?? Infinity) <= now).length;
   const dueCardsOverdue = cards.filter((card) => (card.nextRepetitionTime ?? Infinity) <= startOfToday).length;
 
@@ -421,7 +425,8 @@ async function getDueCardsWithPrioritiesSlow(
   const allCards = await plugin.card.getAll();
   const now = Date.now();
 
-  // Build a map of remId -> due card count
+  // Build a map of remId -> due card count.
+  // Disabled cards (nextRepetitionTime === null → Infinity) are excluded implicitly.
   const remDueCardCount = new Map<RemId, number>();
   for (const card of allCards) {
     if ((card.nextRepetitionTime ?? Infinity) <= now) {

--- a/src/lib/priority_review_document/index.ts
+++ b/src/lib/priority_review_document/index.ts
@@ -1,4 +1,4 @@
-import { RNPlugin, PluginRem, RichTextInterface, RemId } from '@remnote/plugin-sdk';
+import { RNPlugin, PluginRem, RichTextInterface, RemId, BuiltInPowerupCodes } from '@remnote/plugin-sdk';
 import { IncrementalRem } from '../incremental_rem';
 import { getCardRandomness, getSortingRandomness, applySortingCriteria } from '../sorting';
 import { getDueCardsWithPriorities } from '../card_priority';
@@ -12,6 +12,7 @@ import { CardPriorityInfo } from '../card_priority';
 import { calculateAllPercentiles } from '../utils';
 import { buildComprehensiveScope } from '../scope_helpers';
 import { registerReviewGraphKey } from './cleanup';
+import { safeRemTextToString } from '../pdfUtils';
 import * as _ from 'remeda'; // Ensure remeda is imported for uniqBy if available, or use custom
 
 // Possible powerup codes for the Card Cluster built-in powerup.
@@ -132,10 +133,39 @@ export async function extractOriginalScopeFromPriorityReview(
   return undefined;
 }
 
+export interface SkippedPausedItem {
+  remId: string;
+  name: string;
+  priority: number;
+}
+
+/**
+ * Walks the ancestor chain of a rem to detect if it lives inside a paused
+ * document. A document is considered paused when its Deck powerup Status
+ * slot equals "Paused".
+ *
+ * Note: card.getAll() returns cards for paused-document rems (unlike
+ * rem.getCards() which returns []). This check is the reliable way to
+ * detect that state without relying on rem.getCards() behaviour.
+ */
+async function isInPausedDocument(rem: PluginRem): Promise<boolean> {
+  let cursor = await rem.getParentRem();
+  while (cursor) {
+    if (await cursor.hasPowerup(BuiltInPowerupCodes.Deck)) {
+      const status = await cursor.getPowerupProperty(BuiltInPowerupCodes.Deck, 'Status');
+      return status === 'Paused';
+    }
+    cursor = await cursor.getParentRem();
+  }
+  return false;
+}
+
 export interface ReviewDocumentConfig {
   scopeRemId: string | null;  // null = full KB
   itemCount: number;
   cardRatio: number | 'no-cards' | 'no-rem';
+  /** When true, flashcard rems inside paused documents are excluded and reported. Default: true. */
+  filterPaused: boolean;
 }
 
 /**
@@ -144,8 +174,8 @@ export interface ReviewDocumentConfig {
 export async function createPriorityReviewDocument(
   plugin: RNPlugin,
   config: ReviewDocumentConfig
-): Promise<{ doc: PluginRem; actualItemCount: number }> {
-  const { scopeRemId, itemCount, cardRatio } = config;
+): Promise<{ doc: PluginRem; actualItemCount: number; skippedPausedItems: SkippedPausedItem[] }> {
+  const { scopeRemId, itemCount, cardRatio, filterPaused } = config;
 
   // 1. Create the review document with rem reference in title
   const timestamp = new Date().toLocaleString('en-US', {
@@ -207,13 +237,48 @@ export async function createPriorityReviewDocument(
   const dueIncRems = scopedIncRems.filter(rem => rem.nextRepDate <= now);
 
   // Cards
-  // This fetches the actual cards we will use. 
+  // This fetches the actual cards we will use.
   // It might find cards NOT present in allCardInfos if the cache is stale.
   const cardsWithPriority = await getDueCardsWithPriorities(
     plugin,
     scopeRem,
     true
   );
+
+  // Filter out rems inside paused documents when requested.
+  // card.getAll() (used by the cache) returns cards for paused rems while
+  // rem.getCards() returns [] — so without this step paused past-due cards
+  // would appear in the PRD. We detect the paused state via the Deck powerup
+  // Status slot on the ancestor chain, which is reliable and requires no
+  // rem.getCards() call.
+  let skippedPausedItems: SkippedPausedItem[] = [];
+  let filteredCardsWithPriority = cardsWithPriority;
+
+  if (filterPaused && cardsWithPriority.length > 0) {
+    const pausedFlags = await Promise.all(
+      cardsWithPriority.map((item) => isInPausedDocument(item.rem))
+    );
+
+    filteredCardsWithPriority = cardsWithPriority.filter((_, i) => !pausedFlags[i]);
+    const skippedEntries = cardsWithPriority.filter((_, i) => pausedFlags[i]);
+
+    if (skippedEntries.length > 0) {
+      skippedPausedItems = (
+        await Promise.all(
+          skippedEntries.map(async (item) => ({
+            remId: item.rem._id,
+            name: await safeRemTextToString(plugin, item.rem.text),
+            priority: item.priority,
+          }))
+        )
+      ).sort((a, b) => a.priority - b.priority);
+
+      console.log(
+        `[PRD] Filtered ${skippedPausedItems.length} flashcard rems from paused documents:`,
+        skippedPausedItems.map((s) => `P${s.priority} — ${s.name}`)
+      );
+    }
+  }
 
   // --- DEBUG & FIX START ---
 
@@ -230,7 +295,7 @@ export async function createPriorityReviewDocument(
   // Safety merge: Identify cards that are Due but missing from the Universe Cache
   // This handles edge cases where getDueCardsWithPriorities logic differs slightly
   const universeRemIds = new Set(universeCardInfos.map(c => c.remId));
-  const missingCards = cardsWithPriority.filter(c => !universeRemIds.has(c.rem._id));
+  const missingCards = filteredCardsWithPriority.filter(c => !universeRemIds.has(c.rem._id));
 
   if (missingCards.length > 0) {
     // 2. Deduplicate missing items by RemId so we don't add the same Rem multiple times
@@ -269,7 +334,7 @@ export async function createPriorityReviewDocument(
   const cardRandomness = await getCardRandomness(plugin);
 
   const sortedIncRems = applySortingCriteria((dueIncRems as any[]), incRemRandomness);
-  const sortedCards = applySortingCriteria(cardsWithPriority, cardRandomness);
+  const sortedCards = applySortingCriteria(filteredCardsWithPriority, cardRandomness);
 
   // 5. Mix Items & Attach Pre-calculated Percentiles
   interface MixedItem {
@@ -420,9 +485,13 @@ export async function createPriorityReviewDocument(
     return sum + count;
   }, 0);
 
-  const metadataText = `Scope: ${scopeName} 
+  const skippedLine = skippedPausedItems.length > 0
+    ? `\nSkipped (paused docs): ${skippedPausedItems.length} flashcard rems`
+    : '';
+
+  const metadataText = `Scope: ${scopeName}
 Scope Size: ${scopedIncRems.length} IncRems, ${universeCardInfos.length} Rems with Cards, ${totalCardsInScope} Cards
-Selected Items: ${mixedItems.length} (${mixedItems.filter(i => i.type === 'incremental').length} IncRems, ${mixedItems.filter(i => i.type === 'flashcard').length} Rems with Cards)
+Selected Items: ${mixedItems.length} (${mixedItems.filter(i => i.type === 'incremental').length} IncRems, ${mixedItems.filter(i => i.type === 'flashcard').length} Rems with Cards)${skippedLine}
 Randomness: IncRem ${incRemRandPct}%, Cards ${cardRandPct}%
 Created: ${timestamp}`;
 
@@ -524,5 +593,5 @@ Created: ${timestamp}`;
     if (typeTag) { await childRem.addTag(typeTag); }
   }
 
-  return { doc: reviewDoc, actualItemCount: mixedItems.length };
+  return { doc: reviewDoc, actualItemCount: mixedItems.length, skippedPausedItems };
 }

--- a/src/lib/priority_review_document/index.ts
+++ b/src/lib/priority_review_document/index.ts
@@ -166,6 +166,8 @@ export interface ReviewDocumentConfig {
   cardRatio: number | 'no-cards' | 'no-rem';
   /** When true, flashcard rems inside paused documents are excluded and reported. Default: true. */
   filterPaused: boolean;
+  /** Items with priority ≤ this value are kept even when filterPaused is true. Default: 20. */
+  pausedPriorityThreshold: number;
 }
 
 /**
@@ -175,7 +177,7 @@ export async function createPriorityReviewDocument(
   plugin: RNPlugin,
   config: ReviewDocumentConfig
 ): Promise<{ doc: PluginRem; actualItemCount: number; skippedPausedItems: SkippedPausedItem[] }> {
-  const { scopeRemId, itemCount, cardRatio, filterPaused } = config;
+  const { scopeRemId, itemCount, cardRatio, filterPaused, pausedPriorityThreshold } = config;
 
   // 1. Create the review document with rem reference in title
   const timestamp = new Date().toLocaleString('en-US', {
@@ -360,7 +362,9 @@ export async function createPriorityReviewDocument(
 
     // Lazy paused-document check — only runs for cards actually pulled into
     // consideration, so ancestor walks are bounded by how many cards we need.
-    if (filterPaused && await isInPausedDocument(item.rem)) {
+    // High-priority items (priority ≤ pausedPriorityThreshold) bypass the filter
+    // and are always included regardless of pause status.
+    if (filterPaused && item.priority > pausedPriorityThreshold && await isInPausedDocument(item.rem)) {
       skippedPausedItems.push({
         remId: item.rem._id,
         name: await safeRemTextToString(plugin, item.rem.text),

--- a/src/lib/priority_review_document/index.ts
+++ b/src/lib/priority_review_document/index.ts
@@ -245,40 +245,12 @@ export async function createPriorityReviewDocument(
     true
   );
 
-  // Filter out rems inside paused documents when requested.
+  // Skipped paused items are collected lazily inside addCard as cards are pulled.
   // card.getAll() (used by the cache) returns cards for paused rems while
-  // rem.getCards() returns [] — so without this step paused past-due cards
-  // would appear in the PRD. We detect the paused state via the Deck powerup
-  // Status slot on the ancestor chain, which is reliable and requires no
-  // rem.getCards() call.
-  let skippedPausedItems: SkippedPausedItem[] = [];
-  let filteredCardsWithPriority = cardsWithPriority;
-
-  if (filterPaused && cardsWithPriority.length > 0) {
-    const pausedFlags = await Promise.all(
-      cardsWithPriority.map((item) => isInPausedDocument(item.rem))
-    );
-
-    filteredCardsWithPriority = cardsWithPriority.filter((_, i) => !pausedFlags[i]);
-    const skippedEntries = cardsWithPriority.filter((_, i) => pausedFlags[i]);
-
-    if (skippedEntries.length > 0) {
-      skippedPausedItems = (
-        await Promise.all(
-          skippedEntries.map(async (item) => ({
-            remId: item.rem._id,
-            name: await safeRemTextToString(plugin, item.rem.text),
-            priority: item.priority,
-          }))
-        )
-      ).sort((a, b) => a.priority - b.priority);
-
-      console.log(
-        `[PRD] Filtered ${skippedPausedItems.length} flashcard rems from paused documents:`,
-        skippedPausedItems.map((s) => `P${s.priority} — ${s.name} [${s.remId}]`)
-      );
-    }
-  }
+  // rem.getCards() returns [] — the Deck powerup Status slot is the reliable
+  // signal. We check only candidates actually considered for inclusion, so the
+  // list stays small and meaningful.
+  const skippedPausedItems: SkippedPausedItem[] = [];
 
   // --- DEBUG & FIX START ---
 
@@ -295,7 +267,7 @@ export async function createPriorityReviewDocument(
   // Safety merge: Identify cards that are Due but missing from the Universe Cache
   // This handles edge cases where getDueCardsWithPriorities logic differs slightly
   const universeRemIds = new Set(universeCardInfos.map(c => c.remId));
-  const missingCards = filteredCardsWithPriority.filter(c => !universeRemIds.has(c.rem._id));
+  const missingCards = cardsWithPriority.filter(c => !universeRemIds.has(c.rem._id));
 
   if (missingCards.length > 0) {
     // 2. Deduplicate missing items by RemId so we don't add the same Rem multiple times
@@ -334,7 +306,7 @@ export async function createPriorityReviewDocument(
   const cardRandomness = await getCardRandomness(plugin);
 
   const sortedIncRems = applySortingCriteria((dueIncRems as any[]), incRemRandomness);
-  const sortedCards = applySortingCriteria(filteredCardsWithPriority, cardRandomness);
+  const sortedCards = applySortingCriteria(cardsWithPriority, cardRandomness);
 
   // 5. Mix Items & Attach Pre-calculated Percentiles
   interface MixedItem {
@@ -385,6 +357,17 @@ export async function createPriorityReviewDocument(
 
     // Always advance past already-added rems so the caller can keep iterating
     if (addedRemIds.has(item.rem._id)) return true;
+
+    // Lazy paused-document check — only runs for cards actually pulled into
+    // consideration, so ancestor walks are bounded by how many cards we need.
+    if (filterPaused && await isInPausedDocument(item.rem)) {
+      skippedPausedItems.push({
+        remId: item.rem._id,
+        name: await safeRemTextToString(plugin, item.rem.text),
+        priority: item.priority,
+      });
+      return true; // advance index without adding to mixedItems
+    }
 
     // Lookup percentile with debug log if missing
     let percentile = cardPercentiles[item.rem._id];
@@ -466,6 +449,15 @@ export async function createPriorityReviewDocument(
     for (let i = 0; i < itemCount && i < sortedCards.length; i++) {
       await addCard(i);
     }
+  }
+
+  // 6. Finalise skipped list and log
+  if (skippedPausedItems.length > 0) {
+    skippedPausedItems.sort((a, b) => a.priority - b.priority);
+    console.log(
+      `[PRD] ${skippedPausedItems.length} flashcard rems skipped (paused documents):`,
+      skippedPausedItems.map((s) => `P${s.priority} — ${s.name} [${s.remId}]`)
+    );
   }
 
   // 6. Add metadata to document

--- a/src/lib/priority_review_document/index.ts
+++ b/src/lib/priority_review_document/index.ts
@@ -275,7 +275,7 @@ export async function createPriorityReviewDocument(
 
       console.log(
         `[PRD] Filtered ${skippedPausedItems.length} flashcard rems from paused documents:`,
-        skippedPausedItems.map((s) => `P${s.priority} — ${s.name}`)
+        skippedPausedItems.map((s) => `P${s.priority} — ${s.name} [${s.remId}]`)
       );
     }
   }

--- a/src/widgets/debug.tsx
+++ b/src/widgets/debug.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import {
   renderWidget,
   usePlugin,
@@ -5,6 +6,7 @@ import {
   useTrackerPlugin,
   WidgetLocation,
   BuiltInPowerupCodes,
+  Card,
 } from '@remnote/plugin-sdk';
 import { getIncrementalRemFromRem } from '../lib/incremental_rem';
 import { getCardPriority } from '../lib/card_priority';
@@ -75,9 +77,68 @@ function Debug() {
     [remId]
   );
 
+  const [cardCompare, setCardCompare] = useState<{
+    remCards: { id: string; type: string; nextRepTime?: number; historyLen: number }[];
+    filteredCards: { id: string; type: string; nextRepTime?: number; historyLen: number }[];
+    onlyInRem: string[];
+    onlyInAll: string[];
+    totalKb: number;
+    match: boolean;
+  } | null>(null);
+  const [isComparing, setIsComparing] = useState(false);
+
   if (!debugData) return null;
 
   const { incrementalRem, cardPriority, dismissed, isCardDisabledLocally, isCardDisabledInAncestors, hasSpuriousTags, guaranteedRogue, suspicious, rem } = debugData;
+
+  const handleCardCompare = async () => {
+    if (!remId) return;
+    setIsComparing(true);
+    try {
+      const rem = await plugin.rem.findOne(remId);
+      if (!rem) { await plugin.app.toast('No rem found!'); return; }
+
+      const remCards = await rem.getCards();
+      const allCards = await plugin.card.getAll();
+      const filteredCards = (allCards || []).filter((c: Card) => c.remId === remId);
+
+      const parse = (c: Card) => ({
+        id: c._id,
+        type: typeof c.type === 'object' && c.type !== null ? `cloze:${(c.type as { clozeId: string }).clozeId}` : String(c.type),
+        nextRepTime: c.nextRepetitionTime,
+        historyLen: c.repetitionHistory?.length ?? 0,
+      });
+
+      const remCardsParsed = remCards.map(parse);
+      const filteredCardsParsed = filteredCards.map(parse);
+      const remIdSet = new Set(remCards.map((c: Card) => c._id));
+      const filtIdSet = new Set(filteredCards.map((c: Card) => c._id));
+      const onlyInRem = remCards.filter((c: Card) => !filtIdSet.has(c._id)).map((c: Card) => c._id);
+      const onlyInAll = filteredCards.filter((c: Card) => !remIdSet.has(c._id)).map((c: Card) => c._id);
+
+      const result = {
+        remCards: remCardsParsed,
+        filteredCards: filteredCardsParsed,
+        onlyInRem,
+        onlyInAll,
+        totalKb: allCards?.length ?? 0,
+        match: onlyInRem.length === 0 && onlyInAll.length === 0,
+      };
+
+      console.log(`\n========== CARD COMPARE: ${remId} ==========`);
+      console.log('rem.getCards():', JSON.stringify(remCardsParsed, null, 2));
+      console.log('card.getAll() filtered:', JSON.stringify(filteredCardsParsed, null, 2));
+      console.log('Only in rem.getCards():', onlyInRem);
+      console.log('Only in card.getAll():', onlyInAll);
+      console.log('Total KB cards:', result.totalKb);
+      console.log('Match:', result.match);
+      console.log('===========================================\n');
+
+      setCardCompare(result);
+    } finally {
+      setIsComparing(false);
+    }
+  };
 
   const handleDeepLog = async () => {
     console.log(`\n=================== DEEP LOG REM: ${rem._id} ===================`);
@@ -99,7 +160,7 @@ function Debug() {
       const isProp = await child.isProperty();
       const isPowerupProp = await child.isPowerupProperty();
       const childTags = await child.getTagRems();
-      const textRaw = await child.text;
+      const textRaw = child.text;
       const textString = textRaw ? await plugin.richText.toString(textRaw) : '';
       
       const childTagsMapped = await Promise.all(childTags.map(async t => ({ 
@@ -276,6 +337,46 @@ function Debug() {
           />
         </div>
       )}
+
+      <div style={{ marginTop: '16px' }}>
+        <h2 style={{ fontSize: '14px', fontWeight: 'bold', marginBottom: '12px', paddingBottom: '4px', borderBottom: '1px solid var(--rn-clr-background-tertiary)', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+          Card API Comparison
+          <button
+            onClick={handleCardCompare}
+            disabled={isComparing}
+            style={{ fontSize: '11px', padding: '2px 8px', backgroundColor: 'var(--rn-clr-background-secondary)', color: 'var(--rn-clr-content-primary)', border: '1px solid var(--rn-clr-border)', borderRadius: '4px', cursor: isComparing ? 'wait' : 'pointer' }}
+          >
+            {isComparing ? 'Running…' : 'Run Comparison'}
+          </button>
+        </h2>
+        {!cardCompare && <div style={{ fontSize: '12px', color: 'var(--rn-clr-content-tertiary)' }}>Click "Run Comparison" to compare rem.getCards() vs card.getAll() for this rem.</div>}
+        {cardCompare && (
+          <div>
+            <div className="flex gap-4 mb-2">
+              <Info className="" label="rem.getCards()" data={<strong>{cardCompare.remCards.length}</strong>} />
+              <Info className="" label="card.getAll() filtered" data={<strong>{cardCompare.filteredCards.length}</strong>} />
+              <Info className="" label="Total KB Cards" data={cardCompare.totalKb} />
+            </div>
+            <Info className="" label="Match?" data={
+              cardCompare.match
+                ? <span style={{ color: '#22c55e', fontWeight: 600 }}>YES — counts and IDs agree</span>
+                : <span style={{ color: '#ef4444', fontWeight: 600 }}>NO — mismatch detected!</span>
+            } />
+            {!cardCompare.match && cardCompare.onlyInRem.length > 0 && (
+              <Info className="" label="Only in rem.getCards()" data={<pre style={preStyle}>{JSON.stringify(cardCompare.onlyInRem, null, 2)}</pre>} />
+            )}
+            {!cardCompare.match && cardCompare.onlyInAll.length > 0 && (
+              <Info className="" label="Only in card.getAll()" data={<pre style={preStyle}>{JSON.stringify(cardCompare.onlyInAll, null, 2)}</pre>} />
+            )}
+            <Info className="" label="rem.getCards() — cards" data={
+              <pre style={preStyle}>{JSON.stringify(cardCompare.remCards, null, 2)}</pre>
+            } />
+            <Info className="" label="card.getAll() filtered — cards" data={
+              <pre style={preStyle}>{JSON.stringify(cardCompare.filteredCards, null, 2)}</pre>
+            } />
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/src/widgets/debug.tsx
+++ b/src/widgets/debug.tsx
@@ -78,12 +78,16 @@ function Debug() {
   );
 
   const [cardCompare, setCardCompare] = useState<{
-    remCards: { id: string; type: string; nextRepTime?: number; historyLen: number }[];
-    filteredCards: { id: string; type: string; nextRepTime?: number; historyLen: number }[];
+    remCards: { id: string; type: string; nextRepTime: number | null; historyLen: number; disabled: boolean }[];
+    filteredCards: { id: string; type: string; nextRepTime: number | null; historyLen: number; disabled: boolean }[];
     onlyInRem: string[];
     onlyInAll: string[];
     totalKb: number;
     match: boolean;
+    documentStatus: string | null;
+    documentRemId: string | null;
+    deckStatus: string | null;
+    deckRemId: string | null;
   } | null>(null);
   const [isComparing, setIsComparing] = useState(false);
 
@@ -98,6 +102,27 @@ function Debug() {
       const rem = await plugin.rem.findOne(remId);
       if (!rem) { await plugin.app.toast('No rem found!'); return; }
 
+      // Walk ancestors to collect Document + Deck powerup status slots
+      let documentStatus: string | null = null;
+      let documentRemId: string | null = null;
+      let deckStatus: string | null = null;
+      let deckRemId: string | null = null;
+      let cursor = await rem.getParentRem();
+      while (cursor) {
+        if (documentRemId === null && await cursor.hasPowerup(BuiltInPowerupCodes.Document)) {
+          documentRemId = cursor._id;
+          const raw = await cursor.getPowerupProperty(BuiltInPowerupCodes.Document, 'Status');
+          documentStatus = raw != null ? String(raw) : '(null)';
+        }
+        if (deckRemId === null && await cursor.hasPowerup(BuiltInPowerupCodes.Deck)) {
+          deckRemId = cursor._id;
+          const raw = await cursor.getPowerupProperty(BuiltInPowerupCodes.Deck, 'Status');
+          deckStatus = raw != null ? String(raw) : '(null)';
+        }
+        if (documentRemId && deckRemId) break;
+        cursor = await cursor.getParentRem();
+      }
+
       const remCards = await rem.getCards();
       const allCards = await plugin.card.getAll();
       const filteredCards = (allCards || []).filter((c: Card) => c.remId === remId);
@@ -105,8 +130,9 @@ function Debug() {
       const parse = (c: Card) => ({
         id: c._id,
         type: typeof c.type === 'object' && c.type !== null ? `cloze:${(c.type as { clozeId: string }).clozeId}` : String(c.type),
-        nextRepTime: c.nextRepetitionTime,
+        nextRepTime: c.nextRepetitionTime ?? null,
         historyLen: c.repetitionHistory?.length ?? 0,
+        disabled: c.nextRepetitionTime == null,
       });
 
       const remCardsParsed = remCards.map(parse);
@@ -123,9 +149,15 @@ function Debug() {
         onlyInAll,
         totalKb: allCards?.length ?? 0,
         match: onlyInRem.length === 0 && onlyInAll.length === 0,
+        documentStatus,
+        documentRemId,
+        deckStatus,
+        deckRemId,
       };
 
       console.log(`\n========== CARD COMPARE: ${remId} ==========`);
+      console.log('Document ancestor:', documentRemId, '| Status slot:', documentStatus);
+      console.log('Deck ancestor:', deckRemId, '| Status slot:', deckStatus);
       console.log('rem.getCards():', JSON.stringify(remCardsParsed, null, 2));
       console.log('card.getAll() filtered:', JSON.stringify(filteredCardsParsed, null, 2));
       console.log('Only in rem.getCards():', onlyInRem);
@@ -362,11 +394,36 @@ function Debug() {
                 ? <span style={{ color: '#22c55e', fontWeight: 600 }}>YES — counts and IDs agree</span>
                 : <span style={{ color: '#ef4444', fontWeight: 600 }}>NO — mismatch detected!</span>
             } />
+            <Info className="" label="Document ancestor Status" data={
+              cardCompare.documentRemId
+                ? <span><code>{cardCompare.documentStatus ?? '(null/empty)'}</code><span style={{ color: 'var(--rn-clr-content-tertiary)', fontSize: '10px', marginLeft: '6px' }}>{cardCompare.documentRemId}</span></span>
+                : <span style={{ color: 'var(--rn-clr-content-tertiary)', fontStyle: 'italic' }}>No Document ancestor found</span>
+            } />
+            <Info className="" label="Deck ancestor Status" data={
+              cardCompare.deckRemId
+                ? <span><code>{cardCompare.deckStatus ?? '(null/empty)'}</code><span style={{ color: 'var(--rn-clr-content-tertiary)', fontSize: '10px', marginLeft: '6px' }}>{cardCompare.deckRemId}</span></span>
+                : <span style={{ color: 'var(--rn-clr-content-tertiary)', fontStyle: 'italic' }}>No Deck ancestor found</span>
+            } />
             {!cardCompare.match && cardCompare.onlyInRem.length > 0 && (
               <Info className="" label="Only in rem.getCards()" data={<pre style={preStyle}>{JSON.stringify(cardCompare.onlyInRem, null, 2)}</pre>} />
             )}
             {!cardCompare.match && cardCompare.onlyInAll.length > 0 && (
-              <Info className="" label="Only in card.getAll()" data={<pre style={preStyle}>{JSON.stringify(cardCompare.onlyInAll, null, 2)}</pre>} />
+              <Info className="" label="Only in card.getAll() — missing from rem.getCards()" data={
+                <pre style={preStyle}>{JSON.stringify(
+                  cardCompare.filteredCards.filter(c => cardCompare.onlyInAll.includes(c.id)).map(c => {
+                    let diagnosis: string;
+                    if (c.disabled) {
+                      diagnosis = 'DISABLED (nextRepTime=null)';
+                    } else if (cardCompare.deckStatus === 'Paused') {
+                      diagnosis = 'PAUSED (Deck Status="Paused")';
+                    } else {
+                      diagnosis = `UNKNOWN — nextRepTime set, not in rem.getCards; Deck Status="${cardCompare.deckStatus ?? 'not set'}"`;
+                    }
+                    return { ...c, diagnosis };
+                  }),
+                  null, 2
+                )}</pre>
+              } />
             )}
             <Info className="" label="rem.getCards() — cards" data={
               <pre style={preStyle}>{JSON.stringify(cardCompare.remCards, null, 2)}</pre>

--- a/src/widgets/review_document_creator.tsx
+++ b/src/widgets/review_document_creator.tsx
@@ -4,7 +4,7 @@ import {
   useTrackerPlugin,
 } from '@remnote/plugin-sdk';
 import React, { useState, useRef, useEffect } from 'react';
-import { createPriorityReviewDocument } from '../lib/priority_review_document';
+import { createPriorityReviewDocument, SkippedPausedItem } from '../lib/priority_review_document';
 import { getCardsPerRem } from '../lib/sorting';
 
 function ReviewDocumentCreator() {
@@ -28,9 +28,11 @@ function ReviewDocumentCreator() {
   // Form state
   const [itemCount, setItemCount] = useState(50);
   const [useFullKB, setUseFullKB] = useState(false);
+  const [filterPaused, setFilterPaused] = useState(true);
   const [isCreating, setIsCreating] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string>('');
   const [successMessage, setSuccessMessage] = useState<string>('');
+  const [skippedItems, setSkippedItems] = useState<SkippedPausedItem[]>([]);
   const [focusedSection, setFocusedSection] = useState<'scope' | 'number' | null>(null);
 
   const scopeFirstRadioRef = useRef<HTMLInputElement>(null);
@@ -59,17 +61,19 @@ function ReviewDocumentCreator() {
     setIsCreating(true);
     setErrorMessage('');
     setSuccessMessage('');
+    setSkippedItems([]);
 
     try {
       const config = {
         scopeRemId: useFullKB ? null : context?.scopeRemId || null,
         itemCount: itemCount,
         cardRatio: flashcardRatio || 6,
+        filterPaused,
       };
 
       setSuccessMessage('Creating review document...');
 
-      const { doc, actualItemCount } = await createPriorityReviewDocument(plugin, config);
+      const { doc, actualItemCount, skippedPausedItems } = await createPriorityReviewDocument(plugin, config);
 
       // Wait for document to be fully created
       await new Promise(resolve => setTimeout(resolve, 200));
@@ -88,10 +92,14 @@ function ReviewDocumentCreator() {
         setSuccessMessage(`✅ Successfully created review document with ${actualItemCount} items`);
       }
 
-      // Close the popup after a short delay so user sees the success message
-      setTimeout(() => {
-        plugin.widget.closePopup();
-      }, 2000);
+      setSkippedItems(skippedPausedItems);
+
+      // Auto-close only when there are no skipped items to review
+      if (skippedPausedItems.length === 0) {
+        setTimeout(() => {
+          plugin.widget.closePopup();
+        }, 2000);
+      }
 
     } catch (error) {
       console.error('Error creating review document:', error);
@@ -167,7 +175,7 @@ function ReviewDocumentCreator() {
   }
 
   return (
-    <div className="p-5 flex flex-col gap-4" style={{ fontFamily: 'system-ui, -apple-system, sans-serif', maxWidth: '800px', margin: '0 auto' }} onKeyDown={handleWrapperKeyDown}>
+    <div className="p-5 flex flex-col gap-4" style={{ fontFamily: 'system-ui, -apple-system, sans-serif', maxWidth: '800px', margin: '0 auto', maxHeight: '90vh', overflowY: 'auto' }} onKeyDown={handleWrapperKeyDown}>
 
       {/* Header */}
       <div>
@@ -288,6 +296,25 @@ function ReviewDocumentCreator() {
         </button>
       </div>
 
+      {/* Paused Documents Filter */}
+      <div className="rn-clr-background-secondary rounded-lg p-4" style={{ border: '1px solid var(--rn-clr-border, #e5e7eb)' }}>
+        <label className="flex items-start gap-3 cursor-pointer">
+          <input
+            type="checkbox"
+            checked={filterPaused}
+            onChange={(e) => setFilterPaused(e.target.checked)}
+            disabled={isCreating}
+            style={{ marginTop: '2px', flexShrink: 0 }}
+          />
+          <div>
+            <div className="font-semibold text-sm">Skip paused documents</div>
+            <div className="rn-clr-content-secondary text-xs mt-1">
+              Exclude flashcard rems from documents with Deck Status = "Paused". Skipped high-priority items will trigger a warning.
+            </div>
+          </div>
+        </label>
+      </div>
+
       {/* Info Box */}
       <div
         className="rounded-lg"
@@ -353,6 +380,34 @@ function ReviewDocumentCreator() {
       )}
       {successMessage && (
         <div style={{ color: '#10b981', fontSize: '14px' }}>{successMessage}</div>
+      )}
+
+      {skippedItems.length > 0 && (
+        <div style={{ padding: '12px', backgroundColor: 'rgba(245, 158, 11, 0.12)', border: '1px solid rgba(245, 158, 11, 0.45)', borderRadius: '8px', fontSize: '13px' }}>
+          <div style={{ fontWeight: 600, marginBottom: '6px' }}>
+            ⚠️ {skippedItems.length} flashcard rem{skippedItems.length !== 1 ? 's' : ''} skipped — inside paused documents
+            {skippedItems.some(i => i.priority < 20) && (
+              <span style={{ color: '#ef4444', marginLeft: '8px' }}>— includes HIGH PRIORITY items!</span>
+            )}
+          </div>
+          <div style={{ color: 'var(--rn-clr-content-secondary)', fontSize: '11px', marginBottom: '8px' }}>
+            These items were excluded from the review document. Consider unpausing their documents or reviewing them separately.
+          </div>
+          <div style={{ maxHeight: '180px', overflowY: 'auto', display: 'flex', flexDirection: 'column', gap: '2px' }}>
+            {skippedItems.map((item) => (
+              <div key={item.remId} style={{ display: 'flex', alignItems: 'baseline', gap: '8px', padding: '3px 0', borderBottom: '1px solid rgba(0,0,0,0.06)', fontSize: '12px', color: item.priority < 20 ? '#ef4444' : 'var(--rn-clr-content-primary)' }}>
+                <span style={{ fontFamily: 'monospace', fontWeight: 600, flexShrink: 0 }}>P{item.priority}</span>
+                <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{item.name || item.remId}</span>
+              </div>
+            ))}
+          </div>
+          <button
+            onClick={() => plugin.widget.closePopup()}
+            style={{ marginTop: '10px', padding: '6px 14px', borderRadius: '6px', border: 'none', fontSize: '12px', cursor: 'pointer', backgroundColor: '#6b7280', color: 'white' }}
+          >
+            Close
+          </button>
+        </div>
       )}
     </div>
   );

--- a/src/widgets/review_document_creator.tsx
+++ b/src/widgets/review_document_creator.tsx
@@ -175,7 +175,7 @@ function ReviewDocumentCreator() {
   }
 
   return (
-    <div className="p-5 flex flex-col gap-4" style={{ fontFamily: 'system-ui, -apple-system, sans-serif', maxWidth: '800px', margin: '0 auto', maxHeight: '90vh', overflowY: 'auto' }} onKeyDown={handleWrapperKeyDown}>
+    <div className="p-5 flex flex-col gap-4" style={{ fontFamily: 'system-ui, -apple-system, sans-serif', maxWidth: '800px', margin: '0 auto' }} onKeyDown={handleWrapperKeyDown}>
 
       {/* Header */}
       <div>

--- a/src/widgets/review_document_creator.tsx
+++ b/src/widgets/review_document_creator.tsx
@@ -333,8 +333,8 @@ function ReviewDocumentCreator() {
         </label>
       </div>
 
-      {/* Info Box */}
-      <div
+      {/* Info Box — hidden when warning panel is shown */}
+      {skippedItems.length === 0 && <div
         className="rounded-lg"
         style={{
           padding: '12px',
@@ -352,7 +352,7 @@ function ReviewDocumentCreator() {
         • Practice RemNote regular document-scope queue from this Priority Review document<br />
         • After finishing the review of all Cards/IncRems, delete the created document<br />
         • You can find all your Priority Review Documents searching for the tag "Priority Review Queue"
-      </div>
+      </div>}
 
       {/* Summary and Actions */}
       <div className="flex items-center gap-2 flex-wrap mt-1">

--- a/src/widgets/review_document_creator.tsx
+++ b/src/widgets/review_document_creator.tsx
@@ -29,6 +29,7 @@ function ReviewDocumentCreator() {
   const [itemCount, setItemCount] = useState(50);
   const [useFullKB, setUseFullKB] = useState(false);
   const [filterPaused, setFilterPaused] = useState(true);
+  const [pausedPriorityThreshold, setPausedPriorityThreshold] = useState(20);
   const [isCreating, setIsCreating] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string>('');
   const [successMessage, setSuccessMessage] = useState<string>('');
@@ -69,6 +70,7 @@ function ReviewDocumentCreator() {
         itemCount: itemCount,
         cardRatio: flashcardRatio || 6,
         filterPaused,
+        pausedPriorityThreshold,
       };
 
       setSuccessMessage('Creating review document...');
@@ -306,11 +308,27 @@ function ReviewDocumentCreator() {
             disabled={isCreating}
             style={{ marginTop: '2px', flexShrink: 0 }}
           />
-          <div>
+          <div className="flex flex-col gap-2 flex-1">
             <div className="font-semibold text-sm">Skip paused documents</div>
-            <div className="rn-clr-content-secondary text-xs mt-1">
+            <div className="rn-clr-content-secondary text-xs">
               Exclude flashcard rems from documents with Deck Status = "Paused". Skipped high-priority items will trigger a warning.
             </div>
+            {filterPaused && (
+              <div className="flex items-center gap-2 text-xs mt-1">
+                <span className="rn-clr-content-secondary">Always keep items with priority</span>
+                <input
+                  type="number"
+                  min={1}
+                  max={100}
+                  value={pausedPriorityThreshold}
+                  onChange={(e) => setPausedPriorityThreshold(Math.max(1, Math.min(100, parseInt(e.target.value) || 1)))}
+                  disabled={isCreating}
+                  className="rn-clr-background rounded"
+                  style={{ width: '56px', padding: '2px 6px', border: '1px solid var(--rn-clr-border, #d1d5db)', fontSize: '12px' }}
+                />
+                <span className="rn-clr-content-secondary">or less (even if paused)</span>
+              </div>
+            )}
           </div>
         </label>
       </div>


### PR DESCRIPTION
## v0.2.229 - May 13th, 2026

### ✨ New: Skip Paused Documents in Priority Review Document

The Priority Review Document creator now includes a **"Skip paused documents"** option (default: on). When enabled, flashcard rems that live inside a document whose **Deck Status** is "Paused" are excluded from the generated review session, preventing a paused deck from silently consuming priority slots.

**Priority override threshold:** A number input (default **20**) lets you keep items at or above that priority level even when they are inside a paused document — ensuring critically important items are never silently dropped.

**Warning panel:** After creation, if any rems were skipped, the popup shows a warning panel listing each skipped item (name + absolute priority), sorted from most to least important. Items with priority < 20 are highlighted in red as potential high-priority oversight. The "How it works" info box is hidden when the warning panel is visible so the **Close** button is always accessible. The full list (with rem IDs) is also printed to the browser console for easy lookup.

**How it works under the hood:** The check is lazy — the ancestor walk that detects the Deck `Status` slot only runs for cards that would actually be selected, so performance scales with the number of items requested, not the size of your knowledge base.
-
