### PR TITLE
several improvements and bug fixes

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,7 +1,8 @@
 {
   "permissions": {
     "allow": [
-      "Bash(grep -n \"period={period}\\\\|period,\" /Users/hugomarins/incremental-everything/src/widgets/study_dashboard.tsx)"
+      "Bash(grep -n \"period={period}\\\\|period,\" /Users/hugomarins/incremental-everything/src/widgets/study_dashboard.tsx)",
+      "Read(//Users/hugomarins/RemNote-Statistics-Plugin/src/**)"
     ]
   }
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(grep -n \"period={period}\\\\|period,\" /Users/hugomarins/incremental-everything/src/widgets/study_dashboard.tsx)"
+    ]
+  }
+}

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ The plugin now features **Automatic Light Mode**.
 - If you want to turn a highlight into an incremental Rem, click on the highlight and click the puzzle piece icon.
 - 📄 **PDFs & Web**
   - **Visual Status**: Highlights turn **Green** when toggled as Incremental, and **Blue** when extracted.
+  - **Tag Badges**: To keep the editor uncluttered, the `Incremental` and `pdfextract` tag labels are replaced by compact emoji badges — **🔍** for `Incremental` and **✂️** for `pdfextract` — so you can still identify item types at a glance without losing horizontal space.
   - **PDF Control Panel**: Manage chapters, set page ranges, and view reading history for long documents.
   - **Multi-PDF Switcher** *(new)*: When an Inc Rem has multiple PDF sources, a dropdown appears in the Reader (next to the 📝 Document Notes icon), in the Editor Review Timer, in the Execute Repetition popup, in the PDF Control Panel, and in the Editor Toolbar — letting you switch the PDF in view and pin a chosen one as active for that Inc Rem. Resolution order is **explicit pin → `#preferthispdf` → first PDF**, applied uniformly across every surface.
   - **Position Tracking**: The plugin automatically saves your last read page when using the PDF Chapter workflow or creating extracts.

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -7,7 +7,7 @@
   "version": {
     "major": 0,
     "minor": 2,
-    "patch": 238
+    "patch": 239
   },
   "unlisted": false,
   "theme": [],

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -7,7 +7,7 @@
   "version": {
     "major": 0,
     "minor": 2,
-    "patch": 247
+    "patch": 248
   },
   "unlisted": false,
   "theme": [],

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -7,7 +7,7 @@
   "version": {
     "major": 0,
     "minor": 2,
-    "patch": 245
+    "patch": 246
   },
   "unlisted": false,
   "theme": [],

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -7,7 +7,7 @@
   "version": {
     "major": 0,
     "minor": 2,
-    "patch": 244
+    "patch": 245
   },
   "unlisted": false,
   "theme": [],

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -7,7 +7,7 @@
   "version": {
     "major": 0,
     "minor": 2,
-    "patch": 240
+    "patch": 242
   },
   "unlisted": false,
   "theme": [],

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -7,7 +7,7 @@
   "version": {
     "major": 0,
     "minor": 2,
-    "patch": 246
+    "patch": 247
   },
   "unlisted": false,
   "theme": [],

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -7,7 +7,7 @@
   "version": {
     "major": 0,
     "minor": 2,
-    "patch": 243
+    "patch": 244
   },
   "unlisted": false,
   "theme": [],

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -7,7 +7,7 @@
   "version": {
     "major": 0,
     "minor": 2,
-    "patch": 242
+    "patch": 243
   },
   "unlisted": false,
   "theme": [],

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -7,7 +7,7 @@
   "version": {
     "major": 0,
     "minor": 2,
-    "patch": 239
+    "patch": 240
   },
   "unlisted": false,
   "theme": [],

--- a/src/components/IncRemRow.tsx
+++ b/src/components/IncRemRow.tsx
@@ -4,6 +4,7 @@ import { TypeBadge } from './TypeBadge';
 import { PriorityBadge } from './PriorityBadge';
 import { TimeBadge } from './TimeBadge';
 import { InlinePriorityEditor } from './InlineEditors';
+import { RemText } from './RemText';
 import { formatDuration, timeSince } from '../lib/utils';
 
 export interface IncRemRowData {
@@ -60,8 +61,8 @@ export function IncRemRow({
           className="flex-1 min-w-0 text-sm"
           style={{ color: 'var(--rn-clr-content-primary)' }}
         >
-          <div className="truncate" title={incRem.breadcrumb ? `${incRem.breadcrumb} > ${incRem.remText}` : incRem.remText}>
-            {incRem.remText || 'Loading...'}
+          <div className="line-clamp-2" title={incRem.breadcrumb || undefined}>
+            <RemText remId={incRem.remId} />
           </div>
           {((incRem.historyCount !== undefined && incRem.historyCount > 0) || (incRem.totalTimeSpent !== undefined && incRem.totalTimeSpent > 0) || incRem.lastReviewDate || incRem.createdAt) ? (
             <div className="text-xs mt-0.5 flex items-center gap-2" style={{ color: 'var(--rn-clr-content-tertiary)' }}>

--- a/src/components/RemText.tsx
+++ b/src/components/RemText.tsx
@@ -1,6 +1,35 @@
 import React from 'react';
 import { usePlugin, useRunAsync } from '@remnote/plugin-sdk';
-import { resolveRemTextSegments } from '../lib/richTextRemRefs';
+import { resolveRemTextSegments, RemTextSegment } from '../lib/richTextRemRefs';
+
+/**
+ * Renders pre-resolved rem-text segments as plain spans:
+ *  - text segments      → plain text (references already wrapped in `[ ]`)
+ *  - pin segments       → a 📌 icon whose hover tooltip is the referenced text
+ *
+ * Synchronous and embed-free, so it is cheap even in long lists.
+ */
+export function RemTextSegments({
+  segments,
+  className,
+}: {
+  segments: RemTextSegment[];
+  className?: string;
+}) {
+  return (
+    <span className={className}>
+      {segments.map((seg, i) =>
+        seg.kind === 'pin' ? (
+          <span key={i} title={seg.text} style={{ cursor: 'help', opacity: 0.7 }}>
+            📌
+          </span>
+        ) : (
+          <React.Fragment key={i}>{seg.text}</React.Fragment>
+        )
+      )}
+    </span>
+  );
+}
 
 interface RemTextProps {
   /** Rem whose text to render. Provide this or `text`. */
@@ -11,11 +40,10 @@ interface RemTextProps {
 }
 
 /**
- * Lightweight renderer for a rem's text:
- *  - normal rem references → their text wrapped in `[ ]` markers
- *  - pin references         → a 📌 icon whose hover tooltip is the referenced text
- *
- * Renders plain spans only (no SDK embed), so it is cheap in long lists.
+ * Lightweight renderer for a rem's text. Resolves rem references asynchronously
+ * (normal references → `[ ]`-wrapped text, pins → tooltip icon) then renders
+ * plain spans. Use {@link RemTextSegments} directly when segments are already
+ * resolved upstream.
  */
 export function RemText({ remId, text, className }: RemTextProps) {
   const plugin = usePlugin();
@@ -37,17 +65,5 @@ export function RemText({ remId, text, className }: RemTextProps) {
     return <span className={className}>[Empty rem]</span>;
   }
 
-  return (
-    <span className={className}>
-      {segments.map((seg, i) =>
-        seg.kind === 'pin' ? (
-          <span key={i} title={seg.text} style={{ cursor: 'help', opacity: 0.7 }}>
-            📌
-          </span>
-        ) : (
-          <React.Fragment key={i}>{seg.text}</React.Fragment>
-        )
-      )}
-    </span>
-  );
+  return <RemTextSegments segments={segments} className={className} />;
 }

--- a/src/components/RemText.tsx
+++ b/src/components/RemText.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { usePlugin, useRunAsync } from '@remnote/plugin-sdk';
+import { resolveRemTextSegments } from '../lib/richTextRemRefs';
+
+interface RemTextProps {
+  /** Rem whose text to render. Provide this or `text`. */
+  remId?: string;
+  /** Raw rich text, when already loaded — avoids an extra rem lookup. */
+  text?: unknown;
+  className?: string;
+}
+
+/**
+ * Lightweight renderer for a rem's text:
+ *  - normal rem references → their text wrapped in `[ ]` markers
+ *  - pin references         → a 📌 icon whose hover tooltip is the referenced text
+ *
+ * Renders plain spans only (no SDK embed), so it is cheap in long lists.
+ */
+export function RemText({ remId, text, className }: RemTextProps) {
+  const plugin = usePlugin();
+
+  const segments = useRunAsync(async () => {
+    let rt: unknown = text;
+    if (rt === undefined && remId) {
+      const rem = await plugin.rem.findOne(remId);
+      rt = rem?.text ?? null;
+    }
+    if (rt == null) return null;
+    return resolveRemTextSegments(plugin, rt);
+  }, [remId, text]);
+
+  if (segments === undefined) {
+    return <span className={className}>Loading...</span>;
+  }
+  if (!segments || segments.length === 0) {
+    return <span className={className}>[Empty rem]</span>;
+  }
+
+  return (
+    <span className={className}>
+      {segments.map((seg, i) =>
+        seg.kind === 'pin' ? (
+          <span key={i} title={seg.text} style={{ cursor: 'help', opacity: 0.7 }}>
+            📌
+          </span>
+        ) : (
+          <React.Fragment key={i}>{seg.text}</React.Fragment>
+        )
+      )}
+    </span>
+  );
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -16,3 +16,4 @@ export type { EditingState } from './PdfRemItem';
 export { IncRemTable } from './IncRemTable';
 export type { IncRemWithDetails, DocumentInfo, IncRemListState } from './IncRemTable';
 export { WeightedShieldTooltip } from './WeightedShieldTooltip';
+export { RemText } from './RemText';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -16,4 +16,4 @@ export type { EditingState } from './PdfRemItem';
 export { IncRemTable } from './IncRemTable';
 export type { IncRemWithDetails, DocumentInfo, IncRemListState } from './IncRemTable';
 export { WeightedShieldTooltip } from './WeightedShieldTooltip';
-export { RemText } from './RemText';
+export { RemText, RemTextSegments } from './RemText';

--- a/src/lib/hierarchical_parent_selector/treeHelpers.ts
+++ b/src/lib/hierarchical_parent_selector/treeHelpers.ts
@@ -9,6 +9,7 @@ import {
   BuiltInPowerupCodes,
 } from '@remnote/plugin-sdk';
 import { ParentTreeNode, getLastDestinationKey } from './types';
+import { resolveRemTextSegments } from '../richTextRemRefs';
 import { powerupCode, prioritySlotCode, allIncrementalRemKey } from '../consts';
 import { IncrementalRem } from '../incremental_rem';
 import { safeRemTextToString, findPDFinRem, findHTMLinRem, getKnownHtmlRemsKey } from '../pdfUtils';
@@ -64,6 +65,7 @@ export async function createTreeNode(
   parentId: RemId | null = null
 ): Promise<ParentTreeNode> {
   const remText = await safeRemTextToString(plugin, rem.text);
+  const nameSegments = await resolveRemTextSegments(plugin, rem.text);
   const isIncremental = await rem.hasPowerup(powerupCode);
 
   // Check if has children (for expand indicator)
@@ -88,6 +90,7 @@ export async function createTreeNode(
   return {
     remId: rem._id,
     name: remText,
+    nameSegments,
     priority,
     percentile,
     isIncremental,

--- a/src/lib/hierarchical_parent_selector/types.ts
+++ b/src/lib/hierarchical_parent_selector/types.ts
@@ -1,4 +1,5 @@
 import { RemId, RichTextInterface } from '@remnote/plugin-sdk';
+import { RemTextSegment } from '../richTextRemRefs';
 
 /**
  * Represents a node in the hierarchical parent selector tree.
@@ -6,7 +7,8 @@ import { RemId, RichTextInterface } from '@remnote/plugin-sdk';
  */
 export interface ParentTreeNode {
   remId: RemId;
-  name: string;
+  name: string;                   // Plain-text name (used for sorting/filtering/tooltips)
+  nameSegments: RemTextSegment[];  // Display segments — pins render as an icon, not text
   priority: number | null;
   percentile: number | null;
   isIncremental: boolean;

--- a/src/lib/highlightActions.ts
+++ b/src/lib/highlightActions.ts
@@ -295,18 +295,29 @@ export const createRemUnderParent = async (
 
   await saveLastSelectedDestination(plugin, pdfRemId, contextRemId, parentId);
 
-  // Save reading position/bookmark for the queue item.
+  // Save reading position/bookmark for the active IncRem context.
   // pageIndex is null for HTML / PDF Text Reader highlights — we still record
   // the bookmark by highlight rem id so jumps work in those modes too.
+  //
+  // Prefer the explicit contextRemId (resolved by the caller from queue OR editor
+  // review timer). Fall back to pageRangeContext for legacy callers that don't pass it.
   if (makeIncremental) {
     const { pdfRemId: actualPdf, pageIndex } = await getPdfInfoFromHighlight(plugin, highlightRem);
     if (actualPdf) {
         try {
-            const queueCtx = await plugin.storage.getSession<any>('pageRangeContext');
-            if (queueCtx && queueCtx.pdfRemId === actualPdf && queueCtx.incrementalRemId) {
-                await addPageToHistory(plugin, queueCtx.incrementalRemId, actualPdf, pageIndex, undefined, highlightRem._id);
+            let bookmarkRemId: RemId | null = null;
+            if (contextRemId) {
+              bookmarkRemId = contextRemId;
+            } else {
+              const queueCtx = await plugin.storage.getSession<any>('pageRangeContext');
+              if (queueCtx && queueCtx.pdfRemId === actualPdf && queueCtx.incrementalRemId) {
+                bookmarkRemId = queueCtx.incrementalRemId;
+              }
+            }
+            if (bookmarkRemId) {
+                await addPageToHistory(plugin, bookmarkRemId, actualPdf, pageIndex, undefined, highlightRem._id);
                 if (pageIndex !== null) {
-                    await setIncrementalReadingPosition(plugin, queueCtx.incrementalRemId, actualPdf, pageIndex);
+                    await setIncrementalReadingPosition(plugin, bookmarkRemId, actualPdf, pageIndex);
                 }
             }
         } catch(e) {

--- a/src/lib/highlightActions.ts
+++ b/src/lib/highlightActions.ts
@@ -112,6 +112,7 @@ import {
   ParentTreeNode,
   ParentSelectorContext,
 } from './hierarchical_parent_selector/types';
+import { resolveRemTextSegments } from './richTextRemRefs';
 import {
   findAllRemsForPDFAsTree,
   findAllRemsForHTMLAsTree,
@@ -397,6 +398,7 @@ export const createRemFromHighlight = async (
     rootCandidates.push({
       remId: sourceDocument._id,
       name: sourceText,
+      nameSegments: await resolveRemTextSegments(plugin, sourceDocument.text || []),
       priority: null,
       percentile: null,
       isIncremental: false,

--- a/src/lib/highlightToolbarActions.ts
+++ b/src/lib/highlightToolbarActions.ts
@@ -80,26 +80,17 @@ export async function handleCreateExtract(plugin: ReactRNPlugin, remId: string) 
   const highlight = await plugin.rem.findOne(remId);
   if (!highlight) return;
 
-  const { pdfRemId: docId, pageIndex } = await getPdfInfoFromHighlight(plugin as any, highlight);
+  const { pdfRemId: docId } = await getPdfInfoFromHighlight(plugin as any, highlight);
   const contextRemId = await resolveContextRemId(plugin, docId, { checkEditorTimer: true });
 
+  // createRemFromHighlight opens the parent-selector popup and returns immediately.
+  // Bookmark + toast are handled inside createRemUnderParent once the user confirms
+  // a parent — doing them here would fire even when the user cancels.
   await createRemFromHighlight(plugin as any, highlight, {
     makeIncremental: true,
     contextRemId,
     showPriorityPopupIfNew: true,
   });
-
-  if (contextRemId && docId) {
-    try {
-      await addPageToHistory(plugin as any, contextRemId, docId, pageIndex, undefined, highlight._id);
-      if (pageIndex !== null) {
-        await setIncrementalReadingPosition(plugin as any, contextRemId, docId, pageIndex);
-      }
-      await plugin.app.toast('✅ Extract created & bookmark updated');
-    } catch (e) {
-      console.error('Failed to update bookmark position via Toolbar', e);
-    }
-  }
 }
 
 export async function handleToggleIncremental(

--- a/src/lib/history_utils.ts
+++ b/src/lib/history_utils.ts
@@ -8,14 +8,20 @@ export interface IncrementalHistoryData {
     kbId?: string;
     text?: string;
     _v?: number;
-    /** 'reviewed' = a review session; 'created' = the rem was first made Incremental */
-    eventType?: 'reviewed' | 'created';
+    /** 'reviewed' = a review session; 'created' = the rem was first made Incremental; 'dismissed' = dismissed outside a review */
+    eventType?: 'reviewed' | 'created' | 'dismissed';
+    /** Set on a 'reviewed' entry when the same action also dismissed the rem */
+    wasDismissed?: boolean;
 }
 
 const HISTORY_KEY = 'incrementalHistoryData';
 const MAX_HISTORY_ITEMS = 200;
 
-export async function addToIncrementalHistory(plugin: RNPlugin, remId: RemId) {
+export async function addToIncrementalHistory(
+    plugin: RNPlugin,
+    remId: RemId,
+    opts?: { dismissed?: boolean }
+) {
     if (!remId) return;
 
     const currentKb = await plugin.kb.getCurrentKnowledgeBaseData();
@@ -23,13 +29,12 @@ export async function addToIncrementalHistory(plugin: RNPlugin, remId: RemId) {
 
     const historyRaw = (await plugin.storage.getSynced<IncrementalHistoryData[]>(HISTORY_KEY)) || [];
 
-    // Remove existing entry for this remId if it exists to bump it to the top
+    // Remove existing non-creation entry for this remId so it bumps to the top
     const existingIndex = historyRaw.findIndex((x) => x.remId === remId && x.eventType !== 'created');
     if (existingIndex !== -1) {
         historyRaw.splice(existingIndex, 1);
     }
 
-    // Add new entry
     const newEntry: IncrementalHistoryData = {
         key: Math.random(),
         remId,
@@ -37,12 +42,48 @@ export async function addToIncrementalHistory(plugin: RNPlugin, remId: RemId) {
         kbId,
         _v: 1,
         eventType: 'reviewed',
+        ...(opts?.dismissed ? { wasDismissed: true } : {}),
         // Text will be backfilled by the widget to keep this function fast
     };
 
     historyRaw.unshift(newEntry);
 
-    // Limit size
+    if (historyRaw.length > MAX_HISTORY_ITEMS) {
+        historyRaw.length = MAX_HISTORY_ITEMS;
+    }
+
+    await plugin.storage.setSynced(HISTORY_KEY, historyRaw);
+}
+
+/**
+ * Logs a standalone dismissal (e.g. Ctrl+D in the editor) with no preceding
+ * review. The widget renders only the red "Dismissed" badge for these.
+ */
+export async function addDismissalToIncrementalHistory(plugin: RNPlugin, remId: RemId) {
+    if (!remId) return;
+
+    const currentKb = await plugin.kb.getCurrentKnowledgeBaseData();
+    const kbId = currentKb._id;
+
+    const historyRaw = (await plugin.storage.getSynced<IncrementalHistoryData[]>(HISTORY_KEY)) || [];
+
+    // Bump any prior non-creation entry for this rem to keep the timeline tidy
+    const existingIndex = historyRaw.findIndex((x) => x.remId === remId && x.eventType !== 'created');
+    if (existingIndex !== -1) {
+        historyRaw.splice(existingIndex, 1);
+    }
+
+    const newEntry: IncrementalHistoryData = {
+        key: Math.random(),
+        remId,
+        time: Date.now(),
+        kbId,
+        _v: 1,
+        eventType: 'dismissed',
+    };
+
+    historyRaw.unshift(newEntry);
+
     if (historyRaw.length > MAX_HISTORY_ITEMS) {
         historyRaw.length = MAX_HISTORY_ITEMS;
     }

--- a/src/lib/richTextRemRefs.ts
+++ b/src/lib/richTextRemRefs.ts
@@ -1,0 +1,72 @@
+import { RNPlugin, RichTextElementRemInterface } from '@remnote/plugin-sdk';
+
+export type RemTextSegment =
+  | { kind: 'text'; text: string }
+  | { kind: 'pin'; text: string };
+
+const isRemRef = (el: unknown): el is RichTextElementRemInterface =>
+  el != null && typeof el === 'object' && (el as any).i === 'q';
+
+/** Resolve a rem-reference element to the plain text of the rem it points at. */
+async function resolveRefText(plugin: RNPlugin, el: RichTextElementRemInterface): Promise<string> {
+  let text = '';
+  try {
+    text = (await plugin.richText.toString([el])).trim();
+  } catch {
+    /* fall through to direct lookup */
+  }
+  if (!text) {
+    try {
+      const refRem = await plugin.rem.findOne(el._id);
+      if (refRem?.text) text = (await plugin.richText.toString(refRem.text)).trim();
+    } catch {
+      /* ignore */
+    }
+  }
+  return text || 'Untitled';
+}
+
+/**
+ * Resolve a rem's rich text into lightweight display segments:
+ *  - Plain text and normal rem references (text wrapped in `[ ]`) become `text` segments.
+ *  - Pin references become `pin` segments carrying the referenced rem's text, so the
+ *    renderer can show a pin icon with that text as a hover tooltip.
+ *
+ * This deliberately produces plain strings — no SDK `<RichText>` embed — so it stays
+ * cheap enough to render thousands of rows. Formatting (bold, cloze, color, highlight)
+ * is intentionally dropped.
+ */
+export async function resolveRemTextSegments(
+  plugin: RNPlugin,
+  richText: unknown
+): Promise<RemTextSegment[]> {
+  if (richText == null) return [];
+  if (typeof richText === 'string') return [{ kind: 'text', text: richText }];
+  if (!Array.isArray(richText)) return [];
+
+  const segments: RemTextSegment[] = [];
+  const pushText = (t: string) => {
+    if (!t) return;
+    const last = segments[segments.length - 1];
+    if (last?.kind === 'text') last.text += t;
+    else segments.push({ kind: 'text', text: t });
+  };
+
+  for (const el of richText) {
+    if (typeof el === 'string') {
+      pushText(el);
+      continue;
+    }
+    if (isRemRef(el)) {
+      const text = await resolveRefText(plugin, el);
+      if (el.pin) segments.push({ kind: 'pin', text });
+      else pushText(`[${text}]`);
+      continue;
+    }
+    const anyEl = el as any;
+    if (anyEl?.text) pushText(anyEl.text);
+    else if (anyEl?.i === 'i') pushText('[Image]');
+    else if (anyEl?.url) pushText('[Link]');
+  }
+  return segments;
+}

--- a/src/lib/ui_helpers.ts
+++ b/src/lib/ui_helpers.ts
@@ -106,6 +106,19 @@ export async function registerPdfHighlightCSS(plugin: ReactRNPlugin) {
   await plugin.app.registerCSS('pdf-inc-highlight-styling', css);
 }
 
+export async function registerTagBadgeCSS(plugin: ReactRNPlugin) {
+  const css = `
+    [data-rem-tags~="incremental"] .hierarchy-editor__tag-bar__tag {
+      font-size: 0px;
+    }
+    [data-rem-tags~="incremental"] .hierarchy-editor__tag-bar__tag:before {
+      font-size: 12px;
+      content: '🔍';
+    }
+  `;
+  await plugin.app.registerCSS('tag-badge-styling', css);
+}
+
 export async function registerClozeExtractCSS(plugin: ReactRNPlugin) {
   const css = `
     /* Badge: violet ↑ pill before the bullet */

--- a/src/lib/ui_helpers.ts
+++ b/src/lib/ui_helpers.ts
@@ -84,14 +84,22 @@ export async function registerPluginHidingCSS(plugin: ReactRNPlugin) {
 export async function registerPdfHighlightCSS(plugin: ReactRNPlugin) {
   const css = `
     [data-rem-tags~="pdf-highlight"][data-rem-tags~="pdfextract"],
-    [data-rem-tags~="html-highlight"][data-rem-tags~="pdfextract"] { 
+    [data-rem-tags~="html-highlight"][data-rem-tags~="pdfextract"] {
       background-color: #75ccf8 !important;
       padding-bottom: 2.7px;
-    } 
+    }
     [data-rem-tags~="pdf-highlight"][data-rem-tags~="incremental"],
-    [data-rem-tags~="html-highlight"][data-rem-tags~="incremental"] { 
+    [data-rem-tags~="html-highlight"][data-rem-tags~="incremental"] {
       background-color: #75f8b2 !important;
       padding-bottom: 2.7px;
+    }
+
+    [data-rem-tags~="pdfextract"] .hierarchy-editor__tag-bar__tag {
+      font-size: 0px;
+    }
+    [data-rem-tags~="pdfextract"] .hierarchy-editor__tag-bar__tag:before {
+      font-size: 12px;
+      content: '✂️';
     }
   `;
 

--- a/src/register/commands.ts
+++ b/src/register/commands.ts
@@ -620,81 +620,96 @@ export async function registerCommands(plugin: ReactRNPlugin) {
         return result;
       };
 
-      // 1. Create child rem
-      const clozeRem = await plugin.rem.createRem();
-      if (!clozeRem) return;
+      // Suppress GlobalRemChanged during the batch of writes below.
+      // Without this, each write (createRem, setText, setParent, addTag, addPowerup,
+      // parent setText, setCardPriority × 3 properties) fires a GlobalRemChanged event.
+      // After the 1s debounce, each runs the expensive property drift path
+      // (autoAssignCardPriority → ancestor walk → cache flush), causing a ~60s UI freeze.
+      await plugin.storage.setSession('plugin_operation_active', true);
 
-      await clozeRem.setText(buildChildText());
-      await clozeRem.setParent(rem);
+      try {
+        // 1. Create child rem
+        const clozeRem = await plugin.rem.createRem();
+        if (!clozeRem) return;
 
-      let clozeExtractTag = await plugin.rem.findByName(['cloze-extract'], null);
-      if (!clozeExtractTag) {
-        clozeExtractTag = await plugin.rem.createRem();
-        if (clozeExtractTag) await clozeExtractTag.setText(['cloze-extract']);
-      }
-      if (clozeExtractTag) await clozeRem.addTag(clozeExtractTag._id);
+        await clozeRem.setText(buildChildText());
+        await clozeRem.setParent(rem);
 
-      // 2. Apply the Remove Parent powerup to the cloze rem so its parent is hidden
-      // from queue display only when this specific cloze is the current card.
-      // Tagging the parent with Remove from Queue (the previous behavior) would
-      // also hide it for sibling/descendant flashcards (e.g. descriptor children),
-      // breaking their context. Scoping the effect to the cloze itself avoids that.
-      await clozeRem.addPowerup(REMOVE_PARENT_POWERUP_CODE);
+        let clozeExtractTag = await plugin.rem.findByName(['cloze-extract'], null);
+        if (!clozeExtractTag) {
+          clozeExtractTag = await plugin.rem.createRem();
+          if (clozeExtractTag) await clozeExtractTag.setText(['cloze-extract']);
+        }
+        if (clozeExtractTag) await clozeRem.addTag(clozeExtractTag._id);
 
-      // 3. Mark selected text in parent with yellow highlight + red font.
-      // Uses the same section-relative positions (sect_r_start/sect_r_end).
-      const processParentSection = (richText: RichTextInterface, localStart: number, localEnd: number): RichTextInterface => {
-        const arr: any[] = [];
-        let currIdx = 0;
-        for (const item of richText) {
-          const isStr  = typeof item === 'string';
-          const node   = isStr ? { i: 'm' as const, text: item as string } : (item as any);
-          // Text-only positions: non-'m' nodes pass through unchanged.
-          const nodeLen = node.i === 'm' ? (node.text?.length || 0) : 0;
+        // 2. Apply the Remove Parent powerup to the cloze rem so its parent is hidden
+        // from queue display only when this specific cloze is the current card.
+        // Tagging the parent with Remove from Queue (the previous behavior) would
+        // also hide it for sibling/descendant flashcards (e.g. descriptor children),
+        // breaking their context. Scoping the effect to the cloze itself avoids that.
+        await clozeRem.addPowerup(REMOVE_PARENT_POWERUP_CODE);
 
-          if (nodeLen === 0) {
-            arr.push(item);
-          } else {
-            const nodeStart = currIdx;
-            const nodeEnd   = currIdx + nodeLen;
-            if (nodeEnd <= localStart || nodeStart >= localEnd) {
+        // 3. Mark selected text in parent with yellow highlight + red font.
+        // Uses the same section-relative positions (sect_r_start/sect_r_end).
+        const processParentSection = (richText: RichTextInterface, localStart: number, localEnd: number): RichTextInterface => {
+          const arr: any[] = [];
+          let currIdx = 0;
+          for (const item of richText) {
+            const isStr  = typeof item === 'string';
+            const node   = isStr ? { i: 'm' as const, text: item as string } : (item as any);
+            // Text-only positions: non-'m' nodes pass through unchanged.
+            const nodeLen = node.i === 'm' ? (node.text?.length || 0) : 0;
+
+            if (nodeLen === 0) {
               arr.push(item);
             } else {
-              const textStr  = node.text || '';
-              const relStart = Math.max(0, localStart - nodeStart);
-              const relEnd   = Math.min(nodeLen, localEnd - nodeStart);
-              if (relStart > 0) {
-                arr.push(isStr ? textStr.substring(0, relStart) : { ...node, text: textStr.substring(0, relStart) });
+              const nodeStart = currIdx;
+              const nodeEnd   = currIdx + nodeLen;
+              if (nodeEnd <= localStart || nodeStart >= localEnd) {
+                arr.push(item);
+              } else {
+                const textStr  = node.text || '';
+                const relStart = Math.max(0, localStart - nodeStart);
+                const relEnd   = Math.min(nodeLen, localEnd - nodeStart);
+                if (relStart > 0) {
+                  arr.push(isStr ? textStr.substring(0, relStart) : { ...node, text: textStr.substring(0, relStart) });
+                }
+                arr.push({ ...node, text: textStr.substring(relStart, relEnd), [RICH_TEXT_FORMATTING.HIGHLIGHT]: 3, [RICH_TEXT_FORMATTING.TEXT_COLOR]: 1 });
+                if (relEnd < nodeLen) {
+                  arr.push(isStr ? textStr.substring(relEnd) : { ...node, text: textStr.substring(relEnd) });
+                }
               }
-              arr.push({ ...node, text: textStr.substring(relStart, relEnd), [RICH_TEXT_FORMATTING.HIGHLIGHT]: 3, [RICH_TEXT_FORMATTING.TEXT_COLOR]: 1 });
-              if (relEnd < nodeLen) {
-                arr.push(isStr ? textStr.substring(relEnd) : { ...node, text: textStr.substring(relEnd) });
-              }
+              currIdx += nodeLen;
             }
-            currIdx += nodeLen;
           }
+          return arr;
+        };
+
+        if (isBack) {
+          await rem.setBackText(processParentSection(backText, sect_r_start, sect_r_end));
+        } else {
+          await rem.setText(processParentSection(frontText, sect_r_start, sect_r_end));
         }
-        return arr;
-      };
 
-      if (isBack) {
-        await rem.setBackText(processParentSection(backText, sect_r_start, sect_r_end));
-      } else {
-        await rem.setText(processParentSection(frontText, sect_r_start, sect_r_end));
+        // Apply the auto-priority computed at the top (before the new cloze existed,
+        // so the existing-cloze count was correct).
+        await setCardPriority(plugin, clozeRem, autoPriority.priority, 'manual');
+        await updateCardPriorityCache(plugin, clozeRem._id, true, {
+          remId: clozeRem._id,
+          priority: autoPriority.priority,
+          source: 'manual',
+          cardCount: 1,
+          dueCards: 1,
+        } as any);
+
+        return { clozeRem, parentRem: rem, autoPriority };
+      } finally {
+        // Clear the suppression flag after a delay longer than the GlobalRemChanged
+        // debounce (1000ms) so any pending events are also suppressed.
+        setTimeout(async () => {
+          await plugin.storage.setSession('plugin_operation_active', false);
+        }, 2000);
       }
-
-      // Apply the auto-priority computed at the top (before the new cloze existed,
-      // so the existing-cloze count was correct).
-      await setCardPriority(plugin, clozeRem, autoPriority.priority, 'manual');
-      await updateCardPriorityCache(plugin, clozeRem._id, true, {
-        remId: clozeRem._id,
-        priority: autoPriority.priority,
-        source: 'manual',
-        cardCount: 1,
-        dueCards: 1,
-      } as any);
-
-      return { clozeRem, parentRem: rem, autoPriority };
   };
 
   plugin.app.registerCommand({

--- a/src/register/commands.ts
+++ b/src/register/commands.ts
@@ -29,6 +29,7 @@ import { removeIncrementalRemCache } from '../lib/incremental_rem/cache';
 import { IncrementalRep } from '../lib/incremental_rem/types';
 import { safeRemTextToString, getCurrentPageKey, addPageToHistory, registerRemsAsPdfKnown, getActivePdfForIncRem, getAllPDFsInRem, getDescendantsToDepth, getRemCardContent } from '../lib/pdfUtils';
 import { transferToDismissed } from '../lib/dismissed';
+import { addToIncrementalHistory, addDismissalToIncrementalHistory } from '../lib/history_utils';
 import { handleCardPriorityInheritance } from '../lib/card_priority/card_priority_inheritance';
 import { CARD_PRIORITY_CODE } from '../lib/card_priority/types';
 import dayjs from 'dayjs';
@@ -1790,6 +1791,9 @@ export async function registerCommands(plugin: ReactRNPlugin) {
         // 4. Transfer history to dismissed powerup
         await transferToDismissed(plugin, rem, updatedHistory);
 
+        // 4b. Record the dismissal in the Incremental History widget
+        await addToIncrementalHistory(plugin, rem._id, { dismissed: true });
+
         // 5. Remove from session cache
         await removeIncrementalRemCache(plugin, rem._id);
 
@@ -1845,6 +1849,8 @@ export async function registerCommands(plugin: ReactRNPlugin) {
             // Transfer existing history to dismissed (no new rep entry needed)
             await transferToDismissed(plugin, r, incRemInfo.history || []);
           }
+          // Log a standalone dismissal in the Incremental History widget
+          await addDismissalToIncrementalHistory(plugin, r._id);
           // Remove from session cache
           await removeIncrementalRemCache(plugin, r._id);
           // Remove incremental powerup

--- a/src/register/commands.ts
+++ b/src/register/commands.ts
@@ -1624,6 +1624,33 @@ export async function registerCommands(plugin: ReactRNPlugin) {
     },
   });
 
+  // Open Study Dashboard Command
+  plugin.app.registerCommand({
+    id: 'open-study-dashboard',
+    name: 'Open Study Dashboard',
+    description:
+      'Open the Study Dashboard: filterable summary of Incremental/Dismissed/Flashcard activity, with hierarchy.',
+    quickCode: 'sdb',
+    action: async () => {
+      // Resolve a context rem (focused rem in editor, current card in queue).
+      let remId: string | undefined;
+      const url = await plugin.window.getURL();
+      const isQueue = url.includes('/flashcards');
+      if (isQueue) {
+        const card = await plugin.queue.getCurrentCard();
+        if (card?.remId) remId = card.remId;
+        if (!remId) {
+          const cur = await plugin.storage.getSession<string>(currentIncRemKey);
+          if (cur) remId = cur;
+        }
+      } else {
+        const focused = await plugin.focus.getFocusedRem();
+        if (focused?._id) remId = focused._id;
+      }
+      await plugin.widget.openPopup('study_dashboard', remId ? { remId } : undefined);
+    },
+  });
+
   // Open Sorting Criteria Widget Command
   plugin.app.registerCommand({
     id: 'open-sorting-criteria',

--- a/src/register/events.ts
+++ b/src/register/events.ts
@@ -821,13 +821,20 @@ export function registerGlobalRemChangedListener(plugin: ReactRNPlugin) {
 
       // Also capture nextRepDate for manual date reset detection
       // (only relevant when powerup is still present, so direct rem read is fine)
+      //
+      // IMPORTANT: normalize to start-of-day. The cached nextRepDate may be a raw
+      // epoch (Date.now() + interval * 86400000) with sub-day precision, while
+      // getIncrementalRemFromRem resolves the Daily Document reference via
+      // dayjs('YYYY-MM-DD') → midnight-aligned timestamp. Without normalizing,
+      // the same calendar day produces different millisecond values → false-positive
+      // "manual date reset" on every GlobalRemChanged (e.g. when creating a cloze).
       if (!currentIncRem && !capturedHistory) {
         // Skip nextRepDate capture — powerup is gone, this was a removal event
       } else {
         const incRemForDate = currentIncRem || (cachedIncRem as any);
         if (incRemForDate && incRemForDate.nextRepDate) {
           if (!pendingNextRepDateMap.has(data.remId)) {
-            pendingNextRepDateMap.set(data.remId, incRemForDate.nextRepDate);
+            pendingNextRepDateMap.set(data.remId, dayjs(incRemForDate.nextRepDate).startOf('day').valueOf());
           }
         }
       }
@@ -872,7 +879,7 @@ export function registerGlobalRemChangedListener(plugin: ReactRNPlugin) {
             // Get the CURRENT nextRepDate from the rem itself
             const currentIncRem = await getIncrementalRemFromRem(plugin, rem);
 
-            if (currentIncRem && currentIncRem.nextRepDate !== oldNextRepDate) {
+            if (currentIncRem && dayjs(currentIncRem.nextRepDate).startOf('day').valueOf() !== oldNextRepDate) {
               // Check if this change was made by the plugin using a session flag
               const pluginIsUpdating = await plugin.storage.getSession<boolean>('plugin_updating_srs_data');
 

--- a/src/register/tracker.ts
+++ b/src/register/tracker.ts
@@ -156,22 +156,31 @@ export function registerIncrementalRemTracker(plugin: ReactRNPlugin) {
   };
 
   plugin.track(async (rp) => {
-    const pendingRemId = await rp.storage.getSession<string>('pendingInheritanceCascade');
-    if (!pendingRemId) return;
+    const pending = await rp.storage.getSession<string | string[]>('pendingInheritanceCascade');
+    if (!pending || (Array.isArray(pending) && pending.length === 0)) return;
 
     // Clear immediately to prevent re-trigger on the next track() tick
     await plugin.storage.setSession('pendingInheritanceCascade', null);
 
+    const remIds = Array.isArray(pending) ? pending : [pending];
+
     if (cascadeRunning) {
-      // Cascade already in progress — add to the queue for a follow-up pass
-      pendingCascadeRemIds.add(pendingRemId);
-      console.log('[Tracker] Cascade queued (cascade running) for remId:', pendingRemId);
+      // Cascade already in progress — add all to the queue for a follow-up pass
+      for (const id of remIds) pendingCascadeRemIds.add(id);
+      console.log('[Tracker] Cascade queued (cascade running) for', remIds.length, 'remId(s)');
       return;
     }
 
-    // Run the cascade immediately — no debounce needed.
-    console.log('[Tracker] Cascade triggered for remId:', pendingRemId);
-    await runCascade(pendingRemId);
+    // Run the cascade for the first remId; queue the rest so the runCascade
+    // finally-block drains them in sequence.
+    const [first, ...rest] = remIds;
+    for (const id of rest) pendingCascadeRemIds.add(id);
+    console.log(
+      '[Tracker] Cascade triggered for remId:',
+      first,
+      rest.length > 0 ? `(+ ${rest.length} queued)` : ''
+    );
+    await runCascade(first);
   });
 
   // Pending priority save watcher

--- a/src/register/tracker.ts
+++ b/src/register/tracker.ts
@@ -39,7 +39,7 @@ export function registerIncrementalRemTracker(plugin: ReactRNPlugin) {
   });
 
   // Track queue state and current rem to detect when powerup is removed
-  let intervalId: NodeJS.Timeout | null = null;
+  let intervalId: ReturnType<typeof setInterval> | null = null;
   let lastCheckedRemId: string | null = null;
   let pollCount = 0;
   const MAX_POLLS_PER_REM = 60; // 60 polls * 500ms = 30 seconds max per item

--- a/src/register/widgets.ts
+++ b/src/register/widgets.ts
@@ -241,7 +241,7 @@ export async function registerWidgets(plugin: ReactRNPlugin) {
 
   plugin.app.registerWidget('aggregated_repetition_history', WidgetLocation.Popup, {
     dimensions: {
-      width: '450px',
+      width: '550px',
       height: 'auto',
     },
   });

--- a/src/register/widgets.ts
+++ b/src/register/widgets.ts
@@ -246,6 +246,13 @@ export async function registerWidgets(plugin: ReactRNPlugin) {
     },
   });
 
+  plugin.app.registerWidget('study_dashboard', WidgetLocation.Popup, {
+    dimensions: {
+      width: '900px',
+      height: 850,
+    },
+  });
+
   plugin.app.registerWidget('flashcard_repetition_history', WidgetLocation.Popup, {
     dimensions: {
       width: '1150px',

--- a/src/widgets/aggregated_repetition_history.tsx
+++ b/src/widgets/aggregated_repetition_history.tsx
@@ -4,7 +4,8 @@ import { IncrementalRep } from '../lib/incremental_rem/types';
 import { formatDuration } from '../lib/utils';
 import { getIncrementalRemFromRem } from '../lib/incremental_rem';
 import { getDismissedHistoryFromRem } from '../lib/dismissed';
-import { safeRemTextToString } from '../lib/pdfUtils'; // Reuse this safe string converter
+import { resolveRemTextSegments } from '../lib/richTextRemRefs';
+import { RemTextSegments } from '../components';
 
 // --- Types ---
 
@@ -204,10 +205,10 @@ const TreeNode = ({
     const [expanded, setExpanded] = useState(false);
     const node = data.nodes[nodeId];
 
-    const remName = useRunAsync(async () => {
-        if (!node) return 'Untitled';
-        return await safeRemTextToString(plugin, node.remText) || 'Untitled';
-    }, [node?.remText]) || 'Loading...';
+    const nameSegments = useRunAsync(async () => {
+        if (!node) return [];
+        return await resolveRemTextSegments(plugin, node.remText);
+    }, [node?.remText]);
 
     if (!node) return null;
 
@@ -253,7 +254,11 @@ const TreeNode = ({
                     <div style={{ flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
                         {node.isIncremental && <span style={{ color: 'var(--rn-clr-green, #22c55e)', marginRight: '4px' }}>●</span>}
                         {node.isDismissed && <span style={{ color: 'var(--rn-clr-orange, #f59e0b)', marginRight: '4px' }}>●</span>}
-                        {remName}
+                        {nameSegments === undefined
+                            ? 'Loading...'
+                            : nameSegments.length > 0
+                                ? <RemTextSegments segments={nameSegments} />
+                                : 'Untitled'}
                     </div>
 
                     <div style={{ fontSize: '11px', color: 'var(--rn-clr-content-tertiary)', marginLeft: '8px', minWidth: '40px', textAlign: 'right' }}>
@@ -446,7 +451,7 @@ function AggregatedRepetitionHistoryPopup() {
     }, []);
 
     const containerStyle: React.CSSProperties = {
-        width: '450px',
+        width: '550px',
         maxHeight: '850px',
         backgroundColor: 'var(--rn-clr-background-primary)',
         borderRadius: '12px',

--- a/src/widgets/aggregated_repetition_history.tsx
+++ b/src/widgets/aggregated_repetition_history.tsx
@@ -251,7 +251,13 @@ const TreeNode = ({
                         {hasChildren ? (expanded ? '▼' : '▶') : '•'}
                     </div>
 
-                    <div style={{ flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                    <div style={{
+                        flex: 1,
+                        display: '-webkit-box',
+                        WebkitLineClamp: 2,
+                        WebkitBoxOrient: 'vertical',
+                        overflow: 'hidden',
+                    }}>
                         {node.isIncremental && <span style={{ color: 'var(--rn-clr-green, #22c55e)', marginRight: '4px' }}>●</span>}
                         {node.isDismissed && <span style={{ color: 'var(--rn-clr-orange, #f59e0b)', marginRight: '4px' }}>●</span>}
                         {nameSegments === undefined

--- a/src/widgets/answer_buttons.tsx
+++ b/src/widgets/answer_buttons.tsx
@@ -805,7 +805,7 @@ export function AnswerButtons() {
                         animation: isKbShieldActive ? 'shieldTextGlow 2s ease-in-out infinite' : 'none',
                         color: isKbShieldActive ? 'var(--rn-clr-blue)' : 'inherit'
                       }}>
-                        KB: <strong>{shieldStatusAsync.kb.absolute}</strong> ({shieldStatusAsync.kb.percentile?.toFixed(1)}%)
+                        KB: <strong style={{ color: percentileToHslColor(shieldStatusAsync.kb.percentile ?? shieldStatusAsync.kb.absolute) }}>{shieldStatusAsync.kb.absolute}</strong> ({shieldStatusAsync.kb.percentile?.toFixed(1)}%)
                       </span>
                     ) : (
                       <span>KB: 100%</span>
@@ -815,7 +815,7 @@ export function AnswerButtons() {
                         animation: isDocShieldActive ? 'shieldTextGlow 2s ease-in-out infinite' : 'none',
                         color: isDocShieldActive ? 'var(--rn-clr-blue)' : 'inherit'
                       }}>
-                        Doc: <strong>{shieldStatusAsync.doc.absolute}</strong> ({shieldStatusAsync.doc.percentile?.toFixed(1)}%)
+                        Doc: <strong style={{ color: percentileToHslColor(shieldStatusAsync.doc.percentile ?? shieldStatusAsync.doc.absolute) }}>{shieldStatusAsync.doc.absolute}</strong> ({shieldStatusAsync.doc.percentile?.toFixed(1)}%)
                       </span>
                     ) : (
                       sessionCache?.dueIncRemsInScope && <span>Doc: 100%</span>

--- a/src/widgets/answer_buttons.tsx
+++ b/src/widgets/answer_buttons.tsx
@@ -38,6 +38,7 @@ import { WeightedShieldTooltip } from '../components';
 import { shouldUseLightMode } from '../lib/mobileUtils';
 import { getHtmlSourceUrl } from '../lib/incRemHelpers';
 import { transferToDismissed } from '../lib/dismissed';
+import { addToIncrementalHistory } from '../lib/history_utils';
 import { handleReviewInEditorRem } from '../lib/review_actions';
 
 import { handleCardPriorityInheritance } from '../lib/card_priority/card_priority_inheritance';
@@ -449,6 +450,9 @@ export function AnswerButtons() {
 
             // Save updated history to dismissed powerup BEFORE removing incremental
             await transferToDismissed(plugin, rem, updatedHistory);
+
+            // Reflect the dismissal in the Incremental History widget
+            await addToIncrementalHistory(plugin, rem._id, { dismissed: true });
 
             // Remove from session cache
             await removeIncrementalRemCache(plugin, rem._id);

--- a/src/widgets/batch_card_priority.tsx
+++ b/src/widgets/batch_card_priority.tsx
@@ -378,9 +378,17 @@ function BatchCardPriority() {
 
       setSuccessMessage(`✅ Applied cardPriority to ${appliedCount} rem(s)`);
 
-      // Delegate inheritance cascade to background tracker
-      if (anchorRemId) {
-        await plugin.storage.setSession('pendingInheritanceCascade', anchorRemId);
+      // Delegate inheritance cascade to background tracker.
+      // We cascade from each modified rem, not from the anchor: tagged/referencing
+      // rems are scattered across the KB and are NOT descendants of the anchor,
+      // so a cascade rooted at the anchor would never reach the subtrees whose
+      // inherited cardPriority just became stale.
+      const cascadeRemIds = selectedRems
+        .filter((r) => !(r.hasManualCardPriority && !overwriteExisting))
+        .map((r) => r.remId);
+
+      if (cascadeRemIds.length > 0) {
+        await plugin.storage.setSession('pendingInheritanceCascade', cascadeRemIds);
       } else {
         await plugin.storage.setSession('plugin_operation_active', false);
       }

--- a/src/widgets/card_priority_display.tsx
+++ b/src/widgets/card_priority_display.tsx
@@ -576,7 +576,7 @@ export function CardPriorityDisplay() {
                     fontWeight: isKbShieldActive ? 700 : 'inherit',
                     color: isKbShieldActive ? 'var(--rn-clr-blue)' : 'inherit'
                   }}>
-                    KB: <PriorityBadge priority={shieldStatus.kb.absolute} percentile={shieldStatus.kb.percentile} compact />
+                    KB: <strong style={{ color: percentileToHslColor(shieldStatus.kb.percentile ?? shieldStatus.kb.absolute) }}>{shieldStatus.kb.absolute}</strong>
                     {shieldStatus.kb.percentile !== undefined && ` (${shieldStatus.kb.percentile.toFixed(1)}%)`}
                   </span>
                 )}
@@ -586,7 +586,7 @@ export function CardPriorityDisplay() {
                     fontWeight: isDocShieldActive ? 700 : 'inherit',
                     color: isDocShieldActive ? 'var(--rn-clr-blue)' : 'inherit'
                   }}>
-                    Doc: <PriorityBadge priority={shieldStatus.doc.absolute} percentile={shieldStatus.doc.percentile} compact />
+                    Doc: <strong style={{ color: percentileToHslColor(shieldStatus.doc.percentile ?? shieldStatus.doc.absolute) }}>{shieldStatus.doc.absolute}</strong>
                     {shieldStatus.doc.percentile !== undefined && ` (${shieldStatus.doc.percentile.toFixed(1)}%)`}
                   </span>
                 )}

--- a/src/widgets/editor_review_timer.tsx
+++ b/src/widgets/editor_review_timer.tsx
@@ -491,8 +491,8 @@ function EditorReviewTimer() {
     // The widget will automatically refresh due to useTrackerPlugin dependency changes
   };
 
-  const handleDismissAndNext = async () => {
-    if (!timerData || timerData.queueList.length === 0) return;
+  const handleDismiss = async () => {
+    if (!timerData) return;
 
     const currentRem = await plugin.rem.findOne(timerData.remId);
     if (!currentRem) {
@@ -547,6 +547,25 @@ function EditorReviewTimer() {
     }
 
     await plugin.app.toast(`✓ Dismissed: ${timerData.remName}`);
+
+    const hasNext = !!(timerData.queueList && timerData.queueList.length > 0);
+
+    if (!hasNext) {
+      // No queueList → end the timer in place (mirrors handleEndReview's teardown
+      // without recording another repetition, since dismissal already finalized it).
+      await plugin.storage.setSession('editor-review-timer-rem-id', undefined);
+      await plugin.storage.setSession('editor-review-timer-start', undefined);
+      await plugin.storage.setSession('editor-review-timer-interval', undefined);
+      await plugin.storage.setSession('editor-review-timer-priority', undefined);
+      await plugin.storage.setSession('editor-review-timer-rem-name', undefined);
+      await plugin.storage.setSession('editor-review-timer-from-queue', undefined);
+      await plugin.storage.setSession('editor-review-timer-origin', undefined);
+      await plugin.storage.setSession('editor-review-timer-paused-at', undefined);
+      await plugin.storage.setSession('editor-review-timer-accumulated-ms', undefined);
+      await plugin.storage.setSession('editor-review-timer-queue-list', undefined);
+      await forceSaveSession(plugin);
+      return;
+    }
 
     // Advance to the next item in queue
     const nextRemId = timerData.queueList[0];
@@ -813,32 +832,33 @@ function EditorReviewTimer() {
           </button>
         )}
 
-        {/* "Dismiss" button — shown alongside "Next" when queue has items (inc-rem-list/main-view origin) */}
-        {timerData.queueList && timerData.queueList.length > 0 &&
-          (timerData.origin === 'inc-rem-list' || timerData.origin === 'inc-rem-main-view') && (
-            <button
-              onClick={handleDismissAndNext}
-              style={{
-                padding: '6px 14px',
-                fontSize: '13px',
-                backgroundColor: '#ef4444',
-                color: 'white',
-                border: 'none',
-                borderRadius: '4px',
-                cursor: 'pointer',
-                fontWeight: 600,
-              }}
-              onMouseEnter={(e) => {
-                e.currentTarget.style.backgroundColor = '#dc2626';
-              }}
-              onMouseLeave={(e) => {
-                e.currentTarget.style.backgroundColor = '#ef4444';
-              }}
-              title="Dismiss: Remove incremental status, add Dismissed powerup, and advance to next item"
-            >
-              ✓ Dismiss
-            </button>
-          )}
+        {/* "Dismiss" button — always available while a timer is active. When a
+            queueList is present it advances to the next item; otherwise it
+            simply ends the timer (Ctrl+Shift+J / Start Timer flows). */}
+        <button
+          onClick={handleDismiss}
+          style={{
+            padding: '6px 14px',
+            fontSize: '13px',
+            backgroundColor: '#ef4444',
+            color: 'white',
+            border: 'none',
+            borderRadius: '4px',
+            cursor: 'pointer',
+            fontWeight: 600,
+          }}
+          onMouseEnter={(e) => {
+            e.currentTarget.style.backgroundColor = '#dc2626';
+          }}
+          onMouseLeave={(e) => {
+            e.currentTarget.style.backgroundColor = '#ef4444';
+          }}
+          title={timerData.queueList && timerData.queueList.length > 0
+            ? 'Dismiss: Remove incremental status, add Dismissed powerup, and advance to next item'
+            : 'Dismiss: Remove incremental status, add Dismissed powerup, and end the timer'}
+        >
+          ✓ Dismiss
+        </button>
 
         {/* "Back to..." button — shown when origin is queue or inc-rem-list/main-view */}
         {(timerData.origin === 'queue' || timerData.origin === 'inc-rem-list' || timerData.origin === 'inc-rem-main-view') && (

--- a/src/widgets/editor_review_timer.tsx
+++ b/src/widgets/editor_review_timer.tsx
@@ -832,34 +832,6 @@ function EditorReviewTimer() {
           </button>
         )}
 
-        {/* "Dismiss" button — always available while a timer is active. When a
-            queueList is present it advances to the next item; otherwise it
-            simply ends the timer (Ctrl+Shift+J / Start Timer flows). */}
-        <button
-          onClick={handleDismiss}
-          style={{
-            padding: '6px 14px',
-            fontSize: '13px',
-            backgroundColor: '#ef4444',
-            color: 'white',
-            border: 'none',
-            borderRadius: '4px',
-            cursor: 'pointer',
-            fontWeight: 600,
-          }}
-          onMouseEnter={(e) => {
-            e.currentTarget.style.backgroundColor = '#dc2626';
-          }}
-          onMouseLeave={(e) => {
-            e.currentTarget.style.backgroundColor = '#ef4444';
-          }}
-          title={timerData.queueList && timerData.queueList.length > 0
-            ? 'Dismiss: Remove incremental status, add Dismissed powerup, and advance to next item'
-            : 'Dismiss: Remove incremental status, add Dismissed powerup, and end the timer'}
-        >
-          ✓ Dismiss
-        </button>
-
         {/* "Back to..." button — shown when origin is queue or inc-rem-list/main-view */}
         {(timerData.origin === 'queue' || timerData.origin === 'inc-rem-list' || timerData.origin === 'inc-rem-main-view') && (
           <button
@@ -935,6 +907,33 @@ function EditorReviewTimer() {
           }}
         >
           ↗ Go to Rem
+        </button>
+        {/* "Dismiss" button — always available while a timer is active. When a
+            queueList is present it advances to the next item; otherwise it
+            simply ends the timer (Ctrl+Shift+J / Start Timer flows). */}
+        <button
+          onClick={handleDismiss}
+          style={{
+            padding: '6px 14px',
+            fontSize: '13px',
+            backgroundColor: '#ef4444',
+            color: 'white',
+            border: 'none',
+            borderRadius: '4px',
+            cursor: 'pointer',
+            fontWeight: 600,
+          }}
+          onMouseEnter={(e) => {
+            e.currentTarget.style.backgroundColor = '#dc2626';
+          }}
+          onMouseLeave={(e) => {
+            e.currentTarget.style.backgroundColor = '#ef4444';
+          }}
+          title={timerData.queueList && timerData.queueList.length > 0
+            ? 'Dismiss: Remove incremental status, add Dismissed powerup, and advance to next item'
+            : 'Dismiss: Remove incremental status, add Dismissed powerup, and end the timer'}
+        >
+          ✓ Dismiss
         </button>
         <button
           onClick={handleCancel}

--- a/src/widgets/editor_review_timer.tsx
+++ b/src/widgets/editor_review_timer.tsx
@@ -539,6 +539,7 @@ function EditorReviewTimer() {
 
       // Transfer history to Dismissed powerup and remove Incremental powerup
       await transferToDismissed(plugin, currentRem, updatedHistory);
+      await addToIncrementalHistory(plugin, timerData.remId, { dismissed: true });
       await removeIncrementalRemCache(plugin, currentRem._id);
       await currentRem.removePowerup(powerupCode);
     } finally {

--- a/src/widgets/inc_rem_list.tsx
+++ b/src/widgets/inc_rem_list.tsx
@@ -25,6 +25,11 @@ export function IncRemList() {
   // Track in-flight priority changes so cache reloads don't overwrite them with stale data.
   const pendingPriorityChanges = useRef<Record<string, number>>({});
 
+  // Once the first load finishes, cache-driven refreshes run silently in the
+  // background instead of swapping the list for a "Loading..." placeholder.
+  const hasLoadedOnceRef = useRef(false);
+  const loadInFlightRef = useRef(false);
+
   // Track current filter/sort state so we can store it before launching review
   const currentListState = useRef<IncRemListState | null>(null);
 
@@ -93,8 +98,14 @@ export function IncRemList() {
   );
 
   const loadIncRemDetails = async (incRems: IncrementalRem[]) => {
-    if (loadingRems) return;
-    setLoadingRems(true);
+    if (loadInFlightRef.current) return;
+    loadInFlightRef.current = true;
+
+    // Only show the full "Loading..." placeholder on the first load. Cache-driven
+    // background refreshes keep the existing list mounted, so the scroll position
+    // (and any open rem-reference hover popup) is preserved.
+    const isInitialLoad = !hasLoadedOnceRef.current;
+    if (isInitialLoad) setLoadingRems(true);
 
     const sortedByPriority = [...incRems].sort((a, b) => a.priority - b.priority);
     const percentiles: Record<string, number> = {};
@@ -155,7 +166,9 @@ export function IncRemList() {
     }
 
     setIncRemsWithDetails(finalDetails);
-    setLoadingRems(false);
+    hasLoadedOnceRef.current = true;
+    loadInFlightRef.current = false;
+    if (isInitialLoad) setLoadingRems(false);
   };
 
   const handleClose = () => plugin.widget.closePopup();

--- a/src/widgets/inc_rem_main_view.tsx
+++ b/src/widgets/inc_rem_main_view.tsx
@@ -130,6 +130,11 @@ export function IncRemMainView() {
   // Track in-flight priority changes so cache reloads don't overwrite them with stale data.
   const pendingPriorityChanges = useRef<Record<string, number>>({});
 
+  // Once the first load finishes, cache-driven refreshes run silently in the
+  // background instead of swapping the list for a "Loading..." placeholder.
+  const hasLoadedOnceRef = useRef(false);
+  const loadInFlightRef = useRef(false);
+
   // Container ref used to locate the rendered <svg> for export.
   const chartContainerRef = useRef<HTMLDivElement>(null);
 
@@ -187,8 +192,14 @@ export function IncRemMainView() {
   }, []);
 
   const loadIncRemDetails = async (incRems: IncrementalRem[]) => {
-    if (loadingRems) return;
-    setLoadingRems(true);
+    if (loadInFlightRef.current) return;
+    loadInFlightRef.current = true;
+
+    // Only show the full "Loading..." placeholder on the first load. Cache-driven
+    // background refreshes keep the existing list mounted, so the scroll position
+    // (and any open rem-reference hover popup) is preserved.
+    const isInitialLoad = !hasLoadedOnceRef.current;
+    if (isInitialLoad) setLoadingRems(true);
 
     const sortedByPriority = [...incRems].sort((a, b) => a.priority - b.priority);
     const percentiles: Record<string, number> = {};
@@ -252,7 +263,9 @@ export function IncRemMainView() {
     }
 
     setIncRemsWithDetails(finalDetails);
-    setLoadingRems(false);
+    hasLoadedOnceRef.current = true;
+    loadInFlightRef.current = false;
+    if (isInitialLoad) setLoadingRems(false);
   };
 
   const handleRemClick = async (remId: string) => {

--- a/src/widgets/incremental_history.tsx
+++ b/src/widgets/incremental_history.tsx
@@ -221,8 +221,13 @@ function IncrementalHistory() {
 }
 
 /** Small pill badge to differentiate event types */
-function EventBadge({ eventType }: { eventType?: 'reviewed' | 'created' }) {
-    const isCreated = eventType === 'created';
+function EventBadge({ eventType }: { eventType?: 'reviewed' | 'created' | 'dismissed' }) {
+    const palette =
+        eventType === 'created'
+            ? { bg: 'rgba(16,185,129,0.15)', fg: '#10b981', label: 'Created' }
+            : eventType === 'dismissed'
+                ? { bg: 'rgba(239,68,68,0.15)', fg: '#ef4444', label: 'Dismissed' }
+                : { bg: 'rgba(99,102,241,0.12)', fg: '#818cf8', label: 'Reviewed' };
     return (
         <span
             style={{
@@ -233,13 +238,13 @@ function EventBadge({ eventType }: { eventType?: 'reviewed' | 'created' }) {
                 textTransform: 'uppercase',
                 padding: '1px 5px',
                 borderRadius: 3,
-                backgroundColor: isCreated ? 'rgba(16,185,129,0.15)' : 'rgba(99,102,241,0.12)',
-                color: isCreated ? '#10b981' : '#818cf8',
+                backgroundColor: palette.bg,
+                color: palette.fg,
                 flexShrink: 0,
                 alignSelf: 'center',
             }}
         >
-            {isCreated ? 'Created' : 'Reviewed'}
+            {palette.label}
         </span>
     );
 }
@@ -304,9 +309,12 @@ function HistoryItem({
     };
 
     const isCreated = data.eventType === 'created';
+    const isDismissedOnly = data.eventType === 'dismissed';
     const timeLabel = isCreated
         ? `Created ${timeSince(new Date(data.time))}`
-        : `Seen ${timeSince(new Date(data.time))}`;
+        : isDismissedOnly
+            ? `Dismissed ${timeSince(new Date(data.time))}`
+            : `Seen ${timeSince(new Date(data.time))}`;
 
     return (
         <div className="px-1 py-4 border-b border-gray-100" key={data.key}>
@@ -328,6 +336,9 @@ function HistoryItem({
                 <div className="flex-grow min-w-0">
                     <div className="flex items-center gap-1.5 mb-0.5">
                         <EventBadge eventType={data.eventType} />
+                        {data.eventType === 'reviewed' && data.wasDismissed && (
+                            <EventBadge eventType="dismissed" />
+                        )}
                         {incPriority !== null && (
                             <span
                                 onClick={(e) => {

--- a/src/widgets/index.tsx
+++ b/src/widgets/index.tsx
@@ -25,7 +25,7 @@ import { enableHideInQueueIntegrationId } from '../lib/consts';
 import { registerIncrementalRemTracker } from '../register/tracker';
 import { cleanupOrphanedReviewGraphs } from '../lib/priority_review_document/cleanup';
 import { registerJumpToRemHelper } from '../register/window';
-import { registerPluginHidingCSS, registerPdfHighlightCSS, registerClozeExtractCSS } from '../lib/ui_helpers';
+import { registerPluginHidingCSS, registerPdfHighlightCSS, registerClozeExtractCSS, registerTagBadgeCSS } from '../lib/ui_helpers';
 
 async function onActivate(plugin: ReactRNPlugin) {
   //Debug
@@ -74,6 +74,7 @@ async function onActivate(plugin: ReactRNPlugin) {
   await registerPdfHighlightCSS(plugin);
   await registerPluginHidingCSS(plugin);
   await registerClozeExtractCSS(plugin);
+  await registerTagBadgeCSS(plugin);
 
   await registerCommands(plugin);
 

--- a/src/widgets/parent_selector.tsx
+++ b/src/widgets/parent_selector.tsx
@@ -231,16 +231,22 @@ const TreeNodeRow = React.forwardRef<HTMLDivElement, TreeNodeRowProps>((
         gap: '8px',
         padding: `8px 16px 8px ${indentPadding}px`,
         cursor: 'pointer',
-        backgroundColor: isSelected
+        backgroundColor: isSelected && isSuggested
+          ? '#dbeafe'
+          : isSelected
           ? 'var(--rn-clr-background-tertiary)'
           : isSuggested
           ? 'var(--rn-clr-blue-light, #eff6ff)'
           : 'transparent',
-        borderLeft: isSelected
+        borderLeft: isSelected && isSuggested
+          ? '3px solid #1d4ed8'
+          : isSelected
           ? '3px solid #3b82f6'
           : isSuggested
           ? '3px solid var(--rn-clr-blue, #3b82f6)'
           : '3px solid transparent',
+        outline: isSelected && isSuggested ? '1px dashed #93c5fd' : 'none',
+        outlineOffset: '-2px',
         transition: 'background-color 0.1s ease',
       }}
     >
@@ -260,8 +266,8 @@ const TreeNodeRow = React.forwardRef<HTMLDivElement, TreeNodeRowProps>((
         </span>
       )}
 
-      {isSuggested && !isSelected && (
-        <span style={{ fontSize: '11px', color: 'var(--rn-clr-blue, #3b82f6)' }} title="Suggested: this rem's page range contains the highlighted page">
+      {isSuggested && (
+        <span style={{ fontSize: '11px', color: isSelected ? '#1d4ed8' : 'var(--rn-clr-blue, #3b82f6)' }} title="Suggested: this rem's page range contains the highlighted page">
           ★
         </span>
       )}
@@ -270,7 +276,7 @@ const TreeNodeRow = React.forwardRef<HTMLDivElement, TreeNodeRowProps>((
         style={{
           flex: 1,
           fontSize: '13px',
-          color: isSuggested && !isSelected ? 'var(--rn-clr-blue, #1e40af)' : 'var(--rn-clr-content-primary)',
+          color: isSuggested ? (isSelected ? '#1d4ed8' : 'var(--rn-clr-blue, #1e40af)') : 'var(--rn-clr-content-primary)',
           overflow: 'hidden',
           textOverflow: 'ellipsis',
           whiteSpace: 'nowrap',

--- a/src/widgets/parent_selector.tsx
+++ b/src/widgets/parent_selector.tsx
@@ -28,6 +28,7 @@ import {
 } from '../lib/hierarchical_parent_selector/treeHelpers';
 import { createRemUnderParent } from '../lib/highlightActions';
 import { getIncrementalPageRange } from '../lib/pdfUtils';
+import { RemTextSegments } from '../components';
 
 // ============================================================================
 // STYLES
@@ -277,7 +278,7 @@ const TreeNodeRow = React.forwardRef<HTMLDivElement, TreeNodeRowProps>((
         }}
         title={isSuggested ? `Suggested — its page range contains page ${node.name}` : node.name}
       >
-        {node.name.length > 50 ? `${node.name.slice(0, 50)}...` : node.name}
+        <RemTextSegments segments={node.nameSegments} />
       </span>
 
       <AddChildButton

--- a/src/widgets/parent_selector.tsx
+++ b/src/widgets/parent_selector.tsx
@@ -564,8 +564,28 @@ function ParentSelectorWidget() {
         } catch (error) {
           console.error('[ParentSelector:Widget] Error expanding to last destination:', error);
         }
+      } else if (contextData.contextRemId) {
+        // No prior memory but we know which IncRem the user is currently reviewing
+        // (from queue or editor review timer) — suggest that one.
+        try {
+          const { tree: expandedTree, foundIndex } = await expandToLastDestination(
+            plugin,
+            initialTree,
+            contextData.contextRemId,
+            incrementalRemsToUse
+          );
+
+          initialTree = expandedTree;
+          setSuggestedRemId(contextData.contextRemId);
+          if (foundIndex >= 0) {
+            setSelectedIndex(foundIndex);
+          }
+        } catch (error) {
+          console.error('[ParentSelector:Widget] Error expanding to contextRemId:', error);
+        }
       } else {
-        // No prior memory: suggest the tightest-range IncRem containing the highlight page
+        // No prior memory and no active IncRem context: suggest the tightest-range
+        // IncRem whose page range contains the highlight page.
         const pageIndex = (contextData as any).highlightPageIndex as number | null | undefined;
         if (pageIndex != null && contextData.pdfRemId) {
           try {

--- a/src/widgets/priority_editor.tsx
+++ b/src/widgets/priority_editor.tsx
@@ -77,26 +77,26 @@ export function PriorityEditor() {
     | { hostKind: 'html'; pdfOptions: []; activePdfId: null; htmlRemId: string; htmlRemName: string | null }
     | { hostKind: null; pdfOptions: []; activePdfId: null; htmlRemId: null; htmlRemName: null };
 
-  const hostInfo = useRunAsync(async (): Promise<HostInfo | null> => {
+  const hostInfo = useTrackerPlugin(async (rp): Promise<HostInfo | null> => {
     if (!remId) return null;
-    const rem = await plugin.rem.findOne(remId);
+    const rem = await rp.rem.findOne(remId);
     if (!rem) return null;
 
-    const pdfs = await getAllPDFsInRem(plugin as any, rem);
+    const pdfs = await getAllPDFsInRem(rp as any, rem);
 
     if (pdfs.length > 0) {
       const pdfOptions = await Promise.all(
         pdfs.map(async (p) => ({
           remId: p.rem._id,
-          name: await safeRemTextToString(plugin as any, p.rem.text),
+          name: await safeRemTextToString(rp as any, p.rem.text),
           isPreferred: p.isPreferred,
         }))
       );
-      const activePdf = await getActivePdfForIncRem(plugin as any, rem);
+      const activePdf = await getActivePdfForIncRem(rp as any, rem);
       // Also resolve the HTML rem — bookmarks saved in Text Reader mode are
       // stored under the HTML rem's history key even when a PDF is present.
-      const htmlRem = await findHTMLinRem(plugin as any, rem);
-      const htmlRemName = htmlRem?.text ? await safeRemTextToString(plugin as any, htmlRem.text) : null;
+      const htmlRem = await findHTMLinRem(rp as any, rem);
+      const htmlRemName = htmlRem?.text ? await safeRemTextToString(rp as any, htmlRem.text) : null;
       return {
         hostKind: 'pdf',
         pdfOptions,
@@ -106,11 +106,11 @@ export function PriorityEditor() {
       };
     }
 
-    const htmlRem = await findHTMLinRem(plugin as any, rem);
+    const htmlRem = await findHTMLinRem(rp as any, rem);
     if (!htmlRem) {
       return { hostKind: null, pdfOptions: [], activePdfId: null, htmlRemId: null, htmlRemName: null };
     }
-    const htmlRemName = htmlRem.text ? await safeRemTextToString(plugin as any, htmlRem.text) : null;
+    const htmlRemName = htmlRem.text ? await safeRemTextToString(rp as any, htmlRem.text) : null;
     return {
       hostKind: 'html',
       pdfOptions: [],
@@ -118,7 +118,7 @@ export function PriorityEditor() {
       htmlRemId: htmlRem._id,
       htmlRemName,
     };
-  }, [remId, pinRefreshCounter]);
+  }, [remId, pinRefreshCounter, refreshSignal]);
 
   const pdfOptions = hostInfo?.pdfOptions ?? [];
   const activePdfId = hostInfo?.activePdfId ?? null;

--- a/src/widgets/priority_editor.tsx
+++ b/src/widgets/priority_editor.tsx
@@ -8,7 +8,7 @@ import { useEffect, useMemo, useState, useCallback, useRef } from 'react';
 import { getIncrementalRemFromRem } from '../lib/incremental_rem';
 import { updateIncrementalRemCache } from '../lib/incremental_rem/cache';
 import { getCardPriority, setCardPriority, CardPriorityInfo } from '../lib/card_priority';
-import { allIncrementalRemKey, powerupCode, prioritySlotCode, allCardPriorityInfoKey, cardPriorityCacheRefreshKey, pageRangeWidgetId } from '../lib/consts';
+import { allIncrementalRemKey, powerupCode, prioritySlotCode, allCardPriorityInfoKey, pageRangeWidgetId } from '../lib/consts';
 import { IncrementalRem } from '../lib/incremental_rem';
 import { calculateRelativePercentile, formatDuration } from '../lib/utils';
 import { updateCardPriorityCache } from '../lib/card_priority/cache';
@@ -57,11 +57,13 @@ export function PriorityEditor() {
   const pdfEndRef = useRef<HTMLInputElement>(null);
   const pdfPageRef = useRef<HTMLInputElement>(null);
 
-  // Listen for cache refresh signal to force re-evaluation of all data
-  const refreshSignal = useTrackerPlugin(
-    (rp) => rp.storage.getSession(cardPriorityCacheRefreshKey),
-    []
-  );
+  // NOTE: We intentionally do NOT subscribe to the global cardPriorityCacheRefreshKey
+  // here. This widget is registered as RightSideOfEditor, meaning RemNote creates one
+  // instance per visible rem. Subscribing all instances to a global cache-flush signal
+  // causes N widgets × M cache-flushes worth of heavy async queries (getIncrementalRemFromRem,
+  // getCardPriority, getCards, etc.) to fire simultaneously, blocking the UI for 30+ seconds.
+  // The useTrackerPlugin hooks below already provide built-in reactivity for this rem's
+  // own powerup property changes — the global broadcast is not needed.
 
   // Bumped after the user pins a new active PDF, so the host-info refetch
   // picks up the new active-PDF resolution. Otherwise `useRunAsync` keyed on
@@ -118,7 +120,7 @@ export function PriorityEditor() {
       htmlRemId: htmlRem._id,
       htmlRemName,
     };
-  }, [remId, pinRefreshCounter, refreshSignal]);
+  }, [remId, pinRefreshCounter]);
 
   const pdfOptions = hostInfo?.pdfOptions ?? [];
   const activePdfId = hostInfo?.activePdfId ?? null;
@@ -203,7 +205,7 @@ export function PriorityEditor() {
         displayMode: displayMode || 'all',
       };
     },
-    [remId, refreshSignal]
+    [remId]
   );
 
   // Host data (range / history / stats). Reads only from the synced storage

--- a/src/widgets/study_dashboard.tsx
+++ b/src/widgets/study_dashboard.tsx
@@ -1,0 +1,1875 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+    BuiltInPowerupCodes,
+    Card,
+    PluginRem,
+    QueueInteractionScore,
+    renderWidget,
+    usePlugin,
+    useRunAsync,
+    WidgetLocation,
+} from '@remnote/plugin-sdk';
+import { IncrementalRep } from '../lib/incremental_rem/types';
+import {
+    dismissedHistorySlotCode,
+    dismissedPowerupCode,
+    powerupCode,
+    repHistorySlotCode,
+} from '../lib/consts';
+import { buildComprehensiveScope } from '../lib/scope_helpers';
+import { formatDuration, tryParseJson } from '../lib/utils';
+import { resolveRemTextSegments } from '../lib/richTextRemRefs';
+import { RemTextSegments } from '../components';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type ContextMode = 'global' | 'document';
+type ScopeMode = 'descendants' | 'comprehensive';
+type Period =
+    | 'today'
+    | 'yesterday'
+    | 'week'
+    | 'thisWeek'
+    | 'lastWeek'
+    | 'month'
+    | 'thisMonth'
+    | 'lastMonth'
+    | 'year'
+    | 'thisYear'
+    | 'lastYear'
+    | 'all'
+    | 'custom';
+
+interface CardData {
+    id: string;
+    remId: string;
+    history: any[]; // card.repetitionHistory
+}
+
+interface RemData {
+    id: string;
+    parentId: string | null;
+    remText: any;
+    isInc: boolean;
+    isDism: boolean;
+    incHistory: IncrementalRep[];
+    dismHistory: IncrementalRep[];
+    cards: CardData[]; // cards directly attached to this rem
+}
+
+interface PeriodStats {
+    incRemReps: number;
+    incRemTimeSec: number;
+    cardReps: number;
+    cardTimeMs: number;
+    cardForgot: number;
+    // Distinct-card counts (for "items with reps")
+    cardsWithRepsCount: number;
+}
+
+interface SummaryStats {
+    incTaggedCount: number;
+    incTaggedWithRepsCount: number;
+    incReps: number;
+    incTimeSec: number;
+
+    dismTaggedCount: number;
+    dismTaggedWithRepsCount: number;
+    dismReps: number;
+    dismTimeSec: number;
+
+    cardsCount: number;
+    cardsWithRepsCount: number;
+    cardReps: number;
+    cardTimeMs: number;
+    cardForgot: number;
+}
+
+interface TreeNode {
+    id: string; // rem id
+    childrenIds: string[];
+    // selfData null = structural-only ancestor
+    selfData: RemData | null;
+    // aggregate stats for self + descendants in the period
+    aggr: PeriodStats;
+    // counts for self + descendants
+    aggrIncTagged: number;
+    aggrDismTagged: number;
+    aggrIncTaggedWithReps: number;
+    aggrDismTaggedWithReps: number;
+    aggrCardsCount: number;
+    // text loaded lazily by component
+    remText?: any;
+}
+
+interface BuiltTree {
+    nodes: Record<string, TreeNode>;
+    rootIds: string[];
+}
+
+interface DashboardData {
+    // For document mode: the full tree (already built)
+    tree?: BuiltTree;
+    // For global mode: per-top-level pre-computed aggregates, subtrees built on expand
+    topLevels?: Array<{
+        topId: string;
+        aggr: PeriodStats;
+        aggrIncTagged: number;
+        aggrDismTagged: number;
+        aggrIncTaggedWithReps: number;
+        aggrDismTaggedWithReps: number;
+        aggrCardsCount: number;
+    }>;
+    summary: SummaryStats;
+}
+
+interface ProgressState {
+    running: boolean;
+    percent: number;
+    label: string;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const DEFAULT_RESPONSE_TIME_LIMIT_SEC = 180;
+const FLASHCARD_RESPONSE_TIME_LIMIT_SETTING = 'flashcard_response_time_limit';
+
+function isRealIncRep(et: IncrementalRep['eventType']): boolean {
+    return (
+        et === undefined ||
+        et === 'rep' ||
+        et === 'executeRepetition' ||
+        et === 'rescheduledInQueue'
+    );
+}
+
+function isRealCardScore(score: number | undefined): boolean {
+    if (score === undefined) return false;
+    return (
+        score === QueueInteractionScore.AGAIN ||
+        score === QueueInteractionScore.HARD ||
+        score === QueueInteractionScore.GOOD ||
+        score === QueueInteractionScore.EASY
+    );
+}
+
+function getStartOfDay(date: Date) {
+    const d = new Date(date);
+    d.setHours(0, 0, 0, 0);
+    return d.getTime();
+}
+function getStartOfWeek(date: Date) {
+    const d = new Date(date);
+    const day = d.getDay();
+    d.setDate(d.getDate() - day);
+    d.setHours(0, 0, 0, 0);
+    return d.getTime();
+}
+function getStartOfMonth(date: Date) {
+    const d = new Date(date);
+    d.setDate(1);
+    d.setHours(0, 0, 0, 0);
+    return d.getTime();
+}
+function getStartOfYear(date: Date) {
+    const d = new Date(date);
+    d.setMonth(0, 1);
+    d.setHours(0, 0, 0, 0);
+    return d.getTime();
+}
+
+function resolvePeriod(
+    p: Period,
+    customStart: string,
+    customEnd: string
+): { startMs: number; endMs: number } {
+    const now = new Date();
+    const sodToday = getStartOfDay(now);
+    const sodTomorrow = sodToday + 86400000;
+    const sodYesterday = sodToday - 86400000;
+    const sow = getStartOfWeek(now);
+    const sowLast = sow - 7 * 86400000;
+    const som = getStartOfMonth(now);
+    const lastMonth = new Date(now);
+    lastMonth.setMonth(lastMonth.getMonth() - 1);
+    const somLast = getStartOfMonth(lastMonth);
+    const soy = getStartOfYear(now);
+    const lastYear = new Date(now);
+    lastYear.setFullYear(lastYear.getFullYear() - 1);
+    const soyLast = getStartOfYear(lastYear);
+
+    switch (p) {
+        case 'today':
+            return { startMs: sodToday, endMs: sodTomorrow };
+        case 'yesterday':
+            return { startMs: sodYesterday, endMs: sodToday };
+        case 'week':
+            return { startMs: now.getTime() - 7 * 86400000, endMs: now.getTime() };
+        case 'thisWeek':
+            return { startMs: sow, endMs: now.getTime() };
+        case 'lastWeek':
+            return { startMs: sowLast, endMs: sow };
+        case 'month':
+            return { startMs: now.getTime() - 30 * 86400000, endMs: now.getTime() };
+        case 'thisMonth':
+            return { startMs: som, endMs: now.getTime() };
+        case 'lastMonth':
+            return { startMs: somLast, endMs: som };
+        case 'year':
+            return { startMs: now.getTime() - 365 * 86400000, endMs: now.getTime() };
+        case 'thisYear':
+            return { startMs: soy, endMs: now.getTime() };
+        case 'lastYear':
+            return { startMs: soyLast, endMs: soy };
+        case 'all':
+            return { startMs: 0, endMs: now.getTime() + 86400000 };
+        case 'custom': {
+            const s = new Date(customStart);
+            const e = new Date(customEnd);
+            const sMs = isNaN(s.getTime()) ? 0 : getStartOfDay(s);
+            const eMs = isNaN(e.getTime()) ? now.getTime() + 86400000 : getStartOfDay(e) + 86400000;
+            return { startMs: sMs, endMs: eMs };
+        }
+    }
+}
+
+function emptyStats(): PeriodStats {
+    return {
+        incRemReps: 0,
+        incRemTimeSec: 0,
+        cardReps: 0,
+        cardTimeMs: 0,
+        cardForgot: 0,
+        cardsWithRepsCount: 0,
+    };
+}
+
+function addStats(a: PeriodStats, b: PeriodStats): PeriodStats {
+    return {
+        incRemReps: a.incRemReps + b.incRemReps,
+        incRemTimeSec: a.incRemTimeSec + b.incRemTimeSec,
+        cardReps: a.cardReps + b.cardReps,
+        cardTimeMs: a.cardTimeMs + b.cardTimeMs,
+        cardForgot: a.cardForgot + b.cardForgot,
+        cardsWithRepsCount: a.cardsWithRepsCount + b.cardsWithRepsCount,
+    };
+}
+
+function statsFromRem(
+    rem: RemData,
+    startMs: number,
+    endMs: number,
+    cardCapMs: number
+): { self: PeriodStats; hasIncReps: boolean; hasDismReps: boolean } {
+    const s = emptyStats();
+    let hasIncReps = false;
+    let hasDismReps = false;
+    for (const rep of rem.incHistory) {
+        if (!rep || typeof rep.date !== 'number') continue;
+        if (rep.date < startMs || rep.date >= endMs) continue;
+        if (!isRealIncRep(rep.eventType)) continue;
+        s.incRemReps += 1;
+        s.incRemTimeSec += rep.reviewTimeSeconds || 0;
+        hasIncReps = true;
+    }
+    for (const rep of rem.dismHistory) {
+        if (!rep || typeof rep.date !== 'number') continue;
+        if (rep.date < startMs || rep.date >= endMs) continue;
+        if (!isRealIncRep(rep.eventType)) continue;
+        s.incRemReps += 1;
+        s.incRemTimeSec += rep.reviewTimeSeconds || 0;
+        hasDismReps = true;
+    }
+    for (const card of rem.cards) {
+        let cardHasReps = false;
+        for (const rep of card.history || []) {
+            if (!rep || typeof rep.date !== 'number') continue;
+            if (rep.date < startMs || rep.date >= endMs) continue;
+            if (!isRealCardScore(rep.score)) continue;
+            const t = Math.min(Math.max(0, rep.responseTime || 0), cardCapMs);
+            s.cardReps += 1;
+            s.cardTimeMs += t;
+            if (rep.score === QueueInteractionScore.AGAIN) s.cardForgot += 1;
+            cardHasReps = true;
+        }
+        if (cardHasReps) s.cardsWithRepsCount += 1;
+    }
+    return { self: s, hasIncReps, hasDismReps };
+}
+
+// Fast tag/history fetch (avoids the heavier getIncrementalRemFromRem)
+async function readIncHistoryRaw(rem: PluginRem): Promise<IncrementalRep[]> {
+    try {
+        const raw = await rem.getPowerupProperty(powerupCode, repHistorySlotCode);
+        const parsed = tryParseJson(raw);
+        return Array.isArray(parsed) ? parsed : [];
+    } catch {
+        return [];
+    }
+}
+async function readDismHistoryRaw(rem: PluginRem): Promise<IncrementalRep[]> {
+    try {
+        const raw = await rem.getPowerupProperty(dismissedPowerupCode, dismissedHistorySlotCode);
+        const parsed = tryParseJson(raw);
+        return Array.isArray(parsed) ? parsed : [];
+    } catch {
+        return [];
+    }
+}
+
+const CHUNK = 50;
+async function chunked<T, R>(
+    items: T[],
+    fn: (item: T) => Promise<R>,
+    onProgress?: (done: number, total: number) => void
+): Promise<R[]> {
+    const results: R[] = [];
+    for (let i = 0; i < items.length; i += CHUNK) {
+        const slice = items.slice(i, i + CHUNK);
+        const out = await Promise.all(slice.map(fn));
+        results.push(...out);
+        if (onProgress) onProgress(Math.min(i + CHUNK, items.length), items.length);
+    }
+    return results;
+}
+
+// ---------------------------------------------------------------------------
+// Loaders
+// ---------------------------------------------------------------------------
+
+async function loadRemData(
+    _plugin: ReturnType<typeof usePlugin>,
+    rem: PluginRem
+): Promise<RemData> {
+    const [isInc, isDism, cards] = await Promise.all([
+        rem.hasPowerup(powerupCode),
+        rem.hasPowerup(dismissedPowerupCode),
+        rem.getCards().catch(() => [] as Card[]),
+    ]);
+    const incHistory = isInc ? await readIncHistoryRaw(rem) : [];
+    const dismHistory = isDism ? await readDismHistoryRaw(rem) : [];
+    return {
+        id: rem._id,
+        parentId: rem.parent || null,
+        remText: rem.text,
+        isInc,
+        isDism,
+        incHistory,
+        dismHistory,
+        cards: (cards || []).map((c) => ({
+            id: c._id,
+            remId: c.remId,
+            history: (c as any).repetitionHistory || [],
+        })),
+    };
+}
+
+async function buildDocumentTree(
+    plugin: ReturnType<typeof usePlugin>,
+    rootRem: PluginRem,
+    scope: ScopeMode,
+    startMs: number,
+    endMs: number,
+    cardCapMs: number,
+    onProgress: (p: number, label: string) => void
+): Promise<{ tree: BuiltTree; summary: SummaryStats }> {
+    onProgress(0.05, 'Gathering rems…');
+
+    let inScopeIds: Set<string>;
+    let inScopeRems: PluginRem[];
+
+    if (scope === 'descendants') {
+        const descendants = await rootRem.getDescendants();
+        const all = [rootRem, ...descendants];
+        inScopeIds = new Set(all.map((r) => r._id));
+        inScopeRems = all;
+    } else {
+        const scopeIds = await buildComprehensiveScope(plugin, rootRem._id);
+        inScopeIds = new Set(scopeIds);
+        const fetched = await chunked(
+            Array.from(scopeIds),
+            async (id) => plugin.rem.findOne(id),
+            (done, total) =>
+                onProgress(0.05 + 0.15 * (done / Math.max(1, total)), `Loading rems (${done}/${total})`)
+        );
+        inScopeRems = fetched.filter((r): r is PluginRem => !!r);
+    }
+
+    onProgress(0.2, `Reading history for ${inScopeRems.length} rems…`);
+
+    const remDataList: RemData[] = await chunked(
+        inScopeRems,
+        (r) => loadRemData(plugin, r),
+        (done, total) =>
+            onProgress(0.2 + 0.6 * (done / Math.max(1, total)), `History (${done}/${total})`)
+    );
+    const remDataById: Record<string, RemData> = {};
+    for (const rd of remDataList) remDataById[rd.id] = rd;
+
+    onProgress(0.85, 'Building tree…');
+
+    // For comprehensive: include structural ancestors not in scope so each in-scope
+    // rem connects upward to a root. We walk parents and add them as ancestor stubs.
+    const ancestorIds = new Set<string>();
+    if (scope === 'comprehensive') {
+        for (const rd of remDataList) {
+            let p = rd.parentId;
+            while (p && !inScopeIds.has(p) && !ancestorIds.has(p)) {
+                ancestorIds.add(p);
+                const ancestor = await plugin.rem.findOne(p);
+                if (!ancestor) break;
+                p = ancestor.parent || null;
+            }
+        }
+    }
+
+    // Materialise ancestor stubs
+    const stubData: Record<string, { parentId: string | null; remText: any }> = {};
+    if (ancestorIds.size > 0) {
+        const ids = Array.from(ancestorIds);
+        await chunked(ids, async (id) => {
+            const r = await plugin.rem.findOne(id);
+            if (r) stubData[id] = { parentId: r.parent || null, remText: r.text };
+            return null;
+        });
+    }
+
+    // Build child map
+    const allNodeIds = new Set<string>([...Object.keys(remDataById), ...Object.keys(stubData)]);
+    const childMap: Record<string, string[]> = {};
+    const rootIds: string[] = [];
+
+    for (const id of allNodeIds) {
+        const parentId =
+            (remDataById[id]?.parentId ?? stubData[id]?.parentId) || null;
+        if (parentId && allNodeIds.has(parentId)) {
+            (childMap[parentId] ||= []).push(id);
+        } else {
+            rootIds.push(id);
+        }
+    }
+
+    // Compute per-node selfStats and totals, then aggregate bottom-up via DFS.
+    const nodes: Record<string, TreeNode> = {};
+
+    function compute(id: string): TreeNode {
+        if (nodes[id]) return nodes[id];
+        const data = remDataById[id] || null;
+        const childrenIds = childMap[id] || [];
+
+        const self = data ? statsFromRem(data, startMs, endMs, cardCapMs) : null;
+        let aggr = self ? self.self : emptyStats();
+        let aggrIncTagged = data && data.isInc ? 1 : 0;
+        let aggrDismTagged = data && data.isDism ? 1 : 0;
+        let aggrIncTaggedWithReps =
+            data && data.isInc && self && self.hasIncReps ? 1 : 0;
+        let aggrDismTaggedWithReps =
+            data && data.isDism && self && self.hasDismReps ? 1 : 0;
+        let aggrCardsCount = data ? data.cards.length : 0;
+
+        for (const c of childrenIds) {
+            const child = compute(c);
+            aggr = addStats(aggr, child.aggr);
+            aggrIncTagged += child.aggrIncTagged;
+            aggrDismTagged += child.aggrDismTagged;
+            aggrIncTaggedWithReps += child.aggrIncTaggedWithReps;
+            aggrDismTaggedWithReps += child.aggrDismTaggedWithReps;
+            aggrCardsCount += child.aggrCardsCount;
+        }
+
+        nodes[id] = {
+            id,
+            childrenIds,
+            selfData: data,
+            aggr,
+            aggrIncTagged,
+            aggrDismTagged,
+            aggrIncTaggedWithReps,
+            aggrDismTaggedWithReps,
+            aggrCardsCount,
+            remText: data?.remText ?? stubData[id]?.remText,
+        };
+        return nodes[id];
+    }
+
+    for (const rid of rootIds) compute(rid);
+
+    // Summary from root totals: sum aggrs across roots
+    const summary: SummaryStats = {
+        incTaggedCount: 0,
+        incTaggedWithRepsCount: 0,
+        incReps: 0,
+        incTimeSec: 0,
+        dismTaggedCount: 0,
+        dismTaggedWithRepsCount: 0,
+        dismReps: 0,
+        dismTimeSec: 0,
+        cardsCount: 0,
+        cardsWithRepsCount: 0,
+        cardReps: 0,
+        cardTimeMs: 0,
+        cardForgot: 0,
+    };
+
+    // Walk all rem-data (not ancestor stubs) to compute summary directly — cleaner than
+    // splitting inc vs dism after-the-fact from aggregated stats.
+    for (const rd of remDataList) {
+        const { self, hasIncReps, hasDismReps } = statsFromRem(rd, startMs, endMs, cardCapMs);
+        if (rd.isInc) {
+            summary.incTaggedCount += 1;
+            if (hasIncReps) summary.incTaggedWithRepsCount += 1;
+            // Inc/Dism reps shown separately in summary, so attribute only inc-history reps here.
+            let incReps = 0;
+            let incTime = 0;
+            for (const rep of rd.incHistory) {
+                if (!rep || typeof rep.date !== 'number') continue;
+                if (rep.date < startMs || rep.date >= endMs) continue;
+                if (!isRealIncRep(rep.eventType)) continue;
+                incReps += 1;
+                incTime += rep.reviewTimeSeconds || 0;
+            }
+            summary.incReps += incReps;
+            summary.incTimeSec += incTime;
+        }
+        if (rd.isDism) {
+            summary.dismTaggedCount += 1;
+            if (hasDismReps) summary.dismTaggedWithRepsCount += 1;
+            let dismReps = 0;
+            let dismTime = 0;
+            for (const rep of rd.dismHistory) {
+                if (!rep || typeof rep.date !== 'number') continue;
+                if (rep.date < startMs || rep.date >= endMs) continue;
+                if (!isRealIncRep(rep.eventType)) continue;
+                dismReps += 1;
+                dismTime += rep.reviewTimeSeconds || 0;
+            }
+            summary.dismReps += dismReps;
+            summary.dismTimeSec += dismTime;
+        }
+        for (const card of rd.cards) {
+            summary.cardsCount += 1;
+            let cardHasReps = false;
+            for (const rep of card.history || []) {
+                if (!rep || typeof rep.date !== 'number') continue;
+                if (rep.date < startMs || rep.date >= endMs) continue;
+                if (!isRealCardScore(rep.score)) continue;
+                const t = Math.min(Math.max(0, rep.responseTime || 0), cardCapMs);
+                summary.cardReps += 1;
+                summary.cardTimeMs += t;
+                if (rep.score === QueueInteractionScore.AGAIN) summary.cardForgot += 1;
+                cardHasReps = true;
+            }
+            if (cardHasReps) summary.cardsWithRepsCount += 1;
+        }
+        // Unused variable: self — kept above just to compute hasIncReps/hasDismReps.
+        void self;
+    }
+
+    onProgress(1, 'Done');
+
+    return { tree: { nodes, rootIds }, summary };
+}
+
+async function buildGlobalDashboard(
+    plugin: ReturnType<typeof usePlugin>,
+    startMs: number,
+    endMs: number,
+    cardCapMs: number,
+    onProgress: (p: number, label: string) => void
+): Promise<{
+    topLevels: DashboardData['topLevels'];
+    summary: SummaryStats;
+    // also keep a parent-chain cache so subtree expansion is faster
+    parentChainCache: Map<string, string[]>;
+    // map of remId -> RemData for any rem we've already loaded (incremental / dismissed / card-bearing)
+    remDataById: Map<string, RemData>;
+}> {
+    onProgress(0.02, 'Fetching tagged rems…');
+
+    const incPup = await plugin.powerup.getPowerupByCode(powerupCode);
+    const dismPup = await plugin.powerup.getPowerupByCode(dismissedPowerupCode);
+    const [incRems, dismRems, allCards] = await Promise.all([
+        (incPup?.taggedRem() as Promise<PluginRem[] | undefined>) || Promise.resolve([]),
+        (dismPup?.taggedRem() as Promise<PluginRem[] | undefined>) || Promise.resolve([]),
+        plugin.card.getAll(),
+    ]);
+    const incList = incRems || [];
+    const dismList = dismRems || [];
+
+    onProgress(
+        0.1,
+        `Inc: ${incList.length}, Dism: ${dismList.length}, Cards: ${allCards?.length || 0}`
+    );
+
+    // Index unique tagged rems
+    const taggedById = new Map<string, PluginRem>();
+    for (const r of incList) taggedById.set(r._id, r);
+    for (const r of dismList) taggedById.set(r._id, r);
+
+    // Read inc/dism histories
+    const taggedDataById = new Map<string, RemData>();
+    const taggedArr = Array.from(taggedById.values());
+    await chunked(
+        taggedArr,
+        async (r) => {
+            const data = await loadRemData(plugin, r);
+            // For globally tagged rems we don't need .cards from this path — overwrite later via allCards.
+            data.cards = [];
+            taggedDataById.set(r._id, data);
+            return null;
+        },
+        (done, total) =>
+            onProgress(0.1 + 0.4 * (done / Math.max(1, total)), `History (${done}/${total})`)
+    );
+
+    onProgress(0.55, 'Processing cards…');
+
+    // Group cards by remId. We use plugin.card.getAll() rather than per-rem fetches.
+    const cardsByRem = new Map<string, CardData[]>();
+    for (const c of allCards || []) {
+        const cd: CardData = {
+            id: c._id,
+            remId: c.remId,
+            history: (c as any).repetitionHistory || [],
+        };
+        let arr = cardsByRem.get(c.remId);
+        if (!arr) {
+            arr = [];
+            cardsByRem.set(c.remId, arr);
+        }
+        arr.push(cd);
+    }
+
+    // Build a unified rem-data map: tagged rems + rems that own cards.
+    const remDataById = new Map<string, RemData>(taggedDataById);
+    for (const [remId, cards] of cardsByRem) {
+        const existing = remDataById.get(remId);
+        if (existing) {
+            existing.cards = cards;
+        } else {
+            remDataById.set(remId, {
+                id: remId,
+                parentId: null, // resolved later when computing parent chain
+                remText: null,
+                isInc: false,
+                isDism: false,
+                incHistory: [],
+                dismHistory: [],
+                cards,
+            });
+        }
+    }
+
+    onProgress(0.65, 'Walking ancestor chains…');
+
+    // Parent-chain cache: remId -> [self, parent, grandparent, ..., topAncestor]
+    const parentChainCache = new Map<string, string[]>();
+    async function ancestorChain(id: string): Promise<string[]> {
+        const cached = parentChainCache.get(id);
+        if (cached) return cached;
+        const chain: string[] = [];
+        let cur: string | null = id;
+        while (cur) {
+            if (parentChainCache.has(cur)) {
+                chain.push(...parentChainCache.get(cur)!);
+                break;
+            }
+            chain.push(cur);
+            const r: PluginRem | undefined = await plugin.rem.findOne(cur);
+            if (!r) break;
+            cur = r.parent || null;
+        }
+        parentChainCache.set(id, chain);
+        return chain;
+    }
+
+    // For every rem with data in the period, attribute to its top ancestor.
+    const summary: SummaryStats = {
+        incTaggedCount: 0,
+        incTaggedWithRepsCount: 0,
+        incReps: 0,
+        incTimeSec: 0,
+        dismTaggedCount: 0,
+        dismTaggedWithRepsCount: 0,
+        dismReps: 0,
+        dismTimeSec: 0,
+        cardsCount: 0,
+        cardsWithRepsCount: 0,
+        cardReps: 0,
+        cardTimeMs: 0,
+        cardForgot: 0,
+    };
+
+    // Per-top-level aggregates
+    const topAggrs = new Map<
+        string,
+        {
+            aggr: PeriodStats;
+            aggrIncTagged: number;
+            aggrDismTagged: number;
+            aggrIncTaggedWithReps: number;
+            aggrDismTaggedWithReps: number;
+            aggrCardsCount: number;
+        }
+    >();
+    const ensureTop = (id: string) => {
+        let t = topAggrs.get(id);
+        if (!t) {
+            t = {
+                aggr: emptyStats(),
+                aggrIncTagged: 0,
+                aggrDismTagged: 0,
+                aggrIncTaggedWithReps: 0,
+                aggrDismTaggedWithReps: 0,
+                aggrCardsCount: 0,
+            };
+            topAggrs.set(id, t);
+        }
+        return t;
+    };
+
+    const remEntries = Array.from(remDataById.values());
+    let processed = 0;
+    for (const rd of remEntries) {
+        // Build ancestor chain for this rem (parent + above). Need parent info — look up if missing.
+        if (rd.parentId === null && !parentChainCache.has(rd.id)) {
+            const r = await plugin.rem.findOne(rd.id);
+            rd.parentId = r?.parent || null;
+            if (r) rd.remText = rd.remText ?? r.text;
+        }
+        const chain = await ancestorChain(rd.id);
+        const topId = chain[chain.length - 1] || rd.id;
+
+        const { self, hasIncReps, hasDismReps } = statsFromRem(rd, startMs, endMs, cardCapMs);
+        const top = ensureTop(topId);
+        top.aggr = addStats(top.aggr, self);
+        if (rd.isInc) {
+            top.aggrIncTagged += 1;
+            summary.incTaggedCount += 1;
+            if (hasIncReps) {
+                top.aggrIncTaggedWithReps += 1;
+                summary.incTaggedWithRepsCount += 1;
+            }
+            let incReps = 0;
+            let incTime = 0;
+            for (const rep of rd.incHistory) {
+                if (!rep || typeof rep.date !== 'number') continue;
+                if (rep.date < startMs || rep.date >= endMs) continue;
+                if (!isRealIncRep(rep.eventType)) continue;
+                incReps += 1;
+                incTime += rep.reviewTimeSeconds || 0;
+            }
+            summary.incReps += incReps;
+            summary.incTimeSec += incTime;
+        }
+        if (rd.isDism) {
+            top.aggrDismTagged += 1;
+            summary.dismTaggedCount += 1;
+            if (hasDismReps) {
+                top.aggrDismTaggedWithReps += 1;
+                summary.dismTaggedWithRepsCount += 1;
+            }
+            let dismReps = 0;
+            let dismTime = 0;
+            for (const rep of rd.dismHistory) {
+                if (!rep || typeof rep.date !== 'number') continue;
+                if (rep.date < startMs || rep.date >= endMs) continue;
+                if (!isRealIncRep(rep.eventType)) continue;
+                dismReps += 1;
+                dismTime += rep.reviewTimeSeconds || 0;
+            }
+            summary.dismReps += dismReps;
+            summary.dismTimeSec += dismTime;
+        }
+        top.aggrCardsCount += rd.cards.length;
+        summary.cardsCount += rd.cards.length;
+        for (const card of rd.cards) {
+            let cardHasReps = false;
+            for (const rep of card.history || []) {
+                if (!rep || typeof rep.date !== 'number') continue;
+                if (rep.date < startMs || rep.date >= endMs) continue;
+                if (!isRealCardScore(rep.score)) continue;
+                const t = Math.min(Math.max(0, rep.responseTime || 0), cardCapMs);
+                summary.cardReps += 1;
+                summary.cardTimeMs += t;
+                if (rep.score === QueueInteractionScore.AGAIN) summary.cardForgot += 1;
+                cardHasReps = true;
+            }
+            if (cardHasReps) summary.cardsWithRepsCount += 1;
+        }
+
+        processed += 1;
+        if (processed % 100 === 0) {
+            onProgress(0.65 + 0.3 * (processed / Math.max(1, remEntries.length)), `Aggregating (${processed}/${remEntries.length})`);
+        }
+    }
+
+    onProgress(0.97, 'Sorting…');
+
+    const topLevels = Array.from(topAggrs.entries())
+        .map(([topId, v]) => ({ topId, ...v }))
+        .filter(
+            (t) =>
+                t.aggrIncTagged > 0 ||
+                t.aggrDismTagged > 0 ||
+                t.aggrCardsCount > 0
+        )
+        .sort((a, b) => b.aggr.cardTimeMs + b.aggr.incRemTimeSec * 1000 - (a.aggr.cardTimeMs + a.aggr.incRemTimeSec * 1000));
+
+    onProgress(1, 'Done');
+    return { topLevels, summary, parentChainCache, remDataById };
+}
+
+// Build subtree for a given top-level rem on demand (Global mode).
+async function buildSubtreeForTop(
+    plugin: ReturnType<typeof usePlugin>,
+    topId: string,
+    startMs: number,
+    endMs: number,
+    cardCapMs: number,
+    remDataCache: Map<string, RemData>
+): Promise<BuiltTree> {
+    const topRem = await plugin.rem.findOne(topId);
+    if (!topRem) return { nodes: {}, rootIds: [] };
+
+    const descendants = await topRem.getDescendants();
+    const all = [topRem, ...descendants];
+
+    // For each rem, load data unless cached
+    const remDataList: RemData[] = await chunked(all, async (r) => {
+        const cached = remDataCache.get(r._id);
+        if (cached) {
+            // ensure parent/text are filled
+            if (!cached.remText) cached.remText = r.text;
+            if (cached.parentId === null) cached.parentId = r.parent || null;
+            return cached;
+        }
+        const data = await loadRemData(plugin, r);
+        remDataCache.set(r._id, data);
+        return data;
+    });
+    const remDataById: Record<string, RemData> = {};
+    for (const rd of remDataList) remDataById[rd.id] = rd;
+
+    const ids = Object.keys(remDataById);
+    const childMap: Record<string, string[]> = {};
+    const present = new Set(ids);
+    let rootId: string | null = null;
+    for (const id of ids) {
+        const p = remDataById[id].parentId;
+        if (p && present.has(p)) (childMap[p] ||= []).push(id);
+        else rootId = id; // top-level inside this subtree
+    }
+    if (!rootId) rootId = topId;
+
+    const nodes: Record<string, TreeNode> = {};
+    function compute(id: string): TreeNode {
+        if (nodes[id]) return nodes[id];
+        const data = remDataById[id];
+        const childrenIds = childMap[id] || [];
+
+        const self = data ? statsFromRem(data, startMs, endMs, cardCapMs) : null;
+        let aggr = self ? self.self : emptyStats();
+        let aggrIncTagged = data && data.isInc ? 1 : 0;
+        let aggrDismTagged = data && data.isDism ? 1 : 0;
+        let aggrIncTaggedWithReps =
+            data && data.isInc && self && self.hasIncReps ? 1 : 0;
+        let aggrDismTaggedWithReps =
+            data && data.isDism && self && self.hasDismReps ? 1 : 0;
+        let aggrCardsCount = data ? data.cards.length : 0;
+
+        for (const c of childrenIds) {
+            const child = compute(c);
+            aggr = addStats(aggr, child.aggr);
+            aggrIncTagged += child.aggrIncTagged;
+            aggrDismTagged += child.aggrDismTagged;
+            aggrIncTaggedWithReps += child.aggrIncTaggedWithReps;
+            aggrDismTaggedWithReps += child.aggrDismTaggedWithReps;
+            aggrCardsCount += child.aggrCardsCount;
+        }
+
+        nodes[id] = {
+            id,
+            childrenIds,
+            selfData: data || null,
+            aggr,
+            aggrIncTagged,
+            aggrDismTagged,
+            aggrIncTaggedWithReps,
+            aggrDismTaggedWithReps,
+            aggrCardsCount,
+            remText: data?.remText,
+        };
+        return nodes[id];
+    }
+    compute(rootId);
+
+    return { nodes, rootIds: [rootId] };
+}
+
+// ---------------------------------------------------------------------------
+// UI components
+// ---------------------------------------------------------------------------
+
+const periodPresets: { id: Period; label: string }[][] = [
+    [
+        { id: 'today', label: 'Today' },
+        { id: 'week', label: 'Week' },
+        { id: 'month', label: 'Month' },
+        { id: 'year', label: 'Year' },
+        { id: 'all', label: 'All' },
+    ],
+    [
+        { id: 'yesterday', label: 'Yesterday' },
+        { id: 'thisWeek', label: 'This Week' },
+        { id: 'thisMonth', label: 'This Month' },
+        { id: 'thisYear', label: 'This Year' },
+    ],
+    [
+        { id: 'lastWeek', label: 'Last Week' as any },
+        { id: 'lastMonth', label: 'Last Month' },
+        { id: 'lastYear', label: 'Last Year' },
+    ],
+];
+
+function PeriodPicker({
+    period,
+    onChange,
+    customStart,
+    customEnd,
+    onCustomChange,
+}: {
+    period: Period;
+    onChange: (p: Period) => void;
+    customStart: string;
+    customEnd: string;
+    onCustomChange: (s: string, e: string) => void;
+}) {
+    const btn = (id: Period, label: string) => {
+        const active = id === period;
+        return (
+            <button
+                key={id}
+                onClick={() => onChange(id)}
+                style={{
+                    padding: '6px 10px',
+                    borderRadius: 6,
+                    border: '1px solid var(--rn-clr-border-primary)',
+                    background: active ? 'var(--rn-clr-blue-500, #3b82f6)' : 'transparent',
+                    color: active ? '#fff' : 'var(--rn-clr-content-primary)',
+                    fontSize: 12,
+                    cursor: 'pointer',
+                    minWidth: 90,
+                }}
+            >
+                {label}
+            </button>
+        );
+    };
+    return (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+            {periodPresets.map((row, i) => (
+                <div key={i} style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
+                    {row.map((p) => btn(p.id, p.label))}
+                </div>
+            ))}
+            <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginTop: 6 }}>
+                <div style={{ display: 'flex', flexDirection: 'column' }}>
+                    <span style={{ fontSize: 10, color: 'var(--rn-clr-content-tertiary)' }}>Start</span>
+                    <input
+                        type="date"
+                        value={customStart}
+                        onChange={(e) => {
+                            onCustomChange(e.target.value, customEnd);
+                            onChange('custom');
+                        }}
+                        style={{ fontSize: 12, padding: '4px 6px' }}
+                    />
+                </div>
+                <div style={{ display: 'flex', flexDirection: 'column' }}>
+                    <span style={{ fontSize: 10, color: 'var(--rn-clr-content-tertiary)' }}>End</span>
+                    <input
+                        type="date"
+                        value={customEnd}
+                        onChange={(e) => {
+                            onCustomChange(customStart, e.target.value);
+                            onChange('custom');
+                        }}
+                        style={{ fontSize: 12, padding: '4px 6px' }}
+                    />
+                </div>
+                {period === 'custom' && (
+                    <button
+                        onClick={() => onChange('today')}
+                        style={{
+                            fontSize: 11,
+                            background: 'transparent',
+                            border: 'none',
+                            color: 'var(--rn-clr-blue-500, #3b82f6)',
+                            cursor: 'pointer',
+                        }}
+                    >
+                        Clear
+                    </button>
+                )}
+            </div>
+        </div>
+    );
+}
+
+function formatMs(ms: number): string {
+    return formatDuration(Math.round(ms / 1000)) || '0s';
+}
+
+function retentionColor(rate: number): string {
+    if (rate >= 90) return '#16a34a';
+    if (rate < 80) return '#ef4444';
+    return '#ca8a04';
+}
+
+function speedColor(cpm: number): string {
+    if (cpm <= 0) return 'var(--rn-clr-content-tertiary)';
+    let hue: number;
+    if (cpm < 1.5) hue = 0;
+    else if (cpm >= 4) hue = 120;
+    else hue = Math.floor(((cpm - 1.5) / (4 - 1.5)) * 120);
+    return `hsl(${hue}, 90%, 35%)`;
+}
+
+function SummaryCard({ summary }: { summary: SummaryStats }) {
+    const totalIncDism = summary.incTaggedCount + summary.dismTaggedCount;
+    const incPct = totalIncDism > 0 ? Math.round((summary.incTaggedCount / totalIncDism) * 100) : 0;
+    const dismPct =
+        totalIncDism > 0 ? Math.round((summary.dismTaggedCount / totalIncDism) * 100) : 0;
+
+    const cpm =
+        summary.cardTimeMs > 0 ? summary.cardReps / (summary.cardTimeMs / 60000) : 0;
+    const remembered = Math.max(0, summary.cardReps - summary.cardForgot);
+    const retention = summary.cardReps > 0 ? (remembered / summary.cardReps) * 100 : 0;
+
+    const headerStyle: React.CSSProperties = {
+        display: 'grid',
+        gridTemplateColumns: '1.7fr 0.9fr 0.9fr 0.7fr 0.9fr 0.9fr 0.9fr',
+        fontSize: 10,
+        fontWeight: 600,
+        color: 'var(--rn-clr-content-tertiary)',
+        textTransform: 'uppercase',
+        letterSpacing: '0.5px',
+        padding: '6px 8px',
+    };
+    const rowStyle: React.CSSProperties = {
+        display: 'grid',
+        gridTemplateColumns: '1.7fr 0.9fr 0.9fr 0.7fr 0.9fr 0.9fr 0.9fr',
+        padding: '6px 8px',
+        borderTop: '1px solid var(--rn-clr-border-secondary)',
+        fontSize: 12,
+        alignItems: 'center',
+    };
+
+    return (
+        <div
+            style={{
+                border: '1px solid var(--rn-clr-border-primary)',
+                borderRadius: 8,
+                background: 'var(--rn-clr-background-primary)',
+            }}
+        >
+            <div style={headerStyle}>
+                <div>Type</div>
+                <div style={{ textAlign: 'right' }}>Items</div>
+                <div style={{ textAlign: 'right' }}>w/ Reps</div>
+                <div style={{ textAlign: 'right' }}>Reps</div>
+                <div style={{ textAlign: 'right' }}>Time</div>
+                <div style={{ textAlign: 'right' }}>Ret.</div>
+                <div style={{ textAlign: 'right' }}>Speed</div>
+            </div>
+            <div style={rowStyle}>
+                <div style={{ color: '#22c55e', fontWeight: 500 }}>
+                    Incremental{totalIncDism > 0 ? ` (${incPct}%)` : ''}
+                </div>
+                <div style={{ textAlign: 'right' }}>{summary.incTaggedCount}</div>
+                <div style={{ textAlign: 'right' }}>{summary.incTaggedWithRepsCount}</div>
+                <div style={{ textAlign: 'right' }}>{summary.incReps || '-'}</div>
+                <div style={{ textAlign: 'right' }}>
+                    {summary.incTimeSec ? formatDuration(summary.incTimeSec) : '-'}
+                </div>
+                <div style={{ textAlign: 'right', color: 'var(--rn-clr-content-tertiary)' }}>-</div>
+                <div style={{ textAlign: 'right', color: 'var(--rn-clr-content-tertiary)' }}>-</div>
+            </div>
+            <div style={rowStyle}>
+                <div style={{ color: '#f59e0b', fontWeight: 500 }}>
+                    Dismissed{totalIncDism > 0 ? ` (${dismPct}%)` : ''}
+                </div>
+                <div style={{ textAlign: 'right' }}>{summary.dismTaggedCount}</div>
+                <div style={{ textAlign: 'right' }}>{summary.dismTaggedWithRepsCount}</div>
+                <div style={{ textAlign: 'right' }}>{summary.dismReps || '-'}</div>
+                <div style={{ textAlign: 'right' }}>
+                    {summary.dismTimeSec ? formatDuration(summary.dismTimeSec) : '-'}
+                </div>
+                <div style={{ textAlign: 'right', color: 'var(--rn-clr-content-tertiary)' }}>-</div>
+                <div style={{ textAlign: 'right', color: 'var(--rn-clr-content-tertiary)' }}>-</div>
+            </div>
+            <div style={rowStyle}>
+                <div style={{ color: '#3b82f6', fontWeight: 500 }}>Flashcards</div>
+                <div style={{ textAlign: 'right' }}>{summary.cardsCount}</div>
+                <div style={{ textAlign: 'right' }}>{summary.cardsWithRepsCount}</div>
+                <div style={{ textAlign: 'right' }}>{summary.cardReps || '-'}</div>
+                <div style={{ textAlign: 'right' }}>
+                    {summary.cardTimeMs ? formatMs(summary.cardTimeMs) : '-'}
+                </div>
+                <div style={{ textAlign: 'right' }}>
+                    {summary.cardReps > 0 ? (
+                        <span style={{ color: retentionColor(retention), fontWeight: 600 }}>
+                            {retention.toFixed(0)}%
+                        </span>
+                    ) : (
+                        <span style={{ color: 'var(--rn-clr-content-tertiary)' }}>-</span>
+                    )}
+                </div>
+                <div style={{ textAlign: 'right' }}>
+                    {summary.cardReps > 0 ? (
+                        <span style={{ color: speedColor(cpm), fontWeight: 600 }}>
+                            {cpm.toFixed(1)}
+                            <span style={{ fontSize: 10, marginLeft: 2, color: 'var(--rn-clr-content-tertiary)' }}>cpm</span>
+                        </span>
+                    ) : (
+                        <span style={{ color: 'var(--rn-clr-content-tertiary)' }}>-</span>
+                    )}
+                </div>
+            </div>
+        </div>
+    );
+}
+
+const HierarchyHeader = () => (
+    <div
+        style={{
+            display: 'grid',
+            gridTemplateColumns: '2.4fr 0.9fr 1fr 1fr 0.7fr 0.7fr 24px',
+            fontSize: 10,
+            fontWeight: 600,
+            color: 'var(--rn-clr-content-tertiary)',
+            textTransform: 'uppercase',
+            letterSpacing: '0.5px',
+            padding: '6px 8px',
+            borderBottom: '1px solid var(--rn-clr-border-secondary)',
+        }}
+    >
+        <div>Rem</div>
+        <div style={{ textAlign: 'right' }}>Total Time</div>
+        <div style={{ textAlign: 'right' }}>Cards</div>
+        <div style={{ textAlign: 'right' }}>Inc. Rems</div>
+        <div style={{ textAlign: 'right' }}>Ret.</div>
+        <div style={{ textAlign: 'right' }}>Speed</div>
+        <div />
+    </div>
+);
+
+function HierarchyRow({
+    node,
+    depth,
+    expanded,
+    hasChildren,
+    onToggle,
+}: {
+    node: TreeNode;
+    depth: number;
+    expanded: boolean;
+    hasChildren: boolean;
+    onToggle: () => void;
+}) {
+    const plugin = usePlugin();
+    const nameSegments = useRunAsync(async () => {
+        if (!node.remText) return [];
+        return await resolveRemTextSegments(plugin, node.remText);
+    }, [node.remText]);
+
+    const a = node.aggr;
+    const totalTimeMs = a.cardTimeMs + a.incRemTimeSec * 1000;
+    const cpm = a.cardTimeMs > 0 ? a.cardReps / (a.cardTimeMs / 60000) : 0;
+    const remembered = Math.max(0, a.cardReps - a.cardForgot);
+    const retention = a.cardReps > 0 ? (remembered / a.cardReps) * 100 : 0;
+    const isStructural = !node.selfData;
+
+    return (
+        <div
+            style={{
+                display: 'grid',
+                gridTemplateColumns: '2.4fr 0.9fr 1fr 1fr 0.7fr 0.7fr 24px',
+                padding: '4px 8px',
+                paddingLeft: 8 + depth * 14,
+                fontSize: 12,
+                borderBottom: '1px solid var(--rn-clr-border-secondary)',
+                cursor: hasChildren ? 'pointer' : 'default',
+                alignItems: 'center',
+                opacity: isStructural ? 0.8 : 1,
+            }}
+            onClick={(e) => {
+                if (hasChildren) {
+                    e.stopPropagation();
+                    onToggle();
+                }
+            }}
+        >
+            <div
+                style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    overflow: 'hidden',
+                    minWidth: 0,
+                }}
+            >
+                <div
+                    style={{
+                        width: 14,
+                        marginRight: 4,
+                        opacity: 0.5,
+                        textAlign: 'center',
+                    }}
+                >
+                    {hasChildren ? (expanded ? '▼' : '▶') : '•'}
+                </div>
+                {node.selfData?.isInc && (
+                    <span style={{ color: '#22c55e', marginRight: 4 }}>●</span>
+                )}
+                {node.selfData?.isDism && (
+                    <span style={{ color: '#f59e0b', marginRight: 4 }}>●</span>
+                )}
+                <div
+                    style={{
+                        flex: 1,
+                        overflow: 'hidden',
+                        textOverflow: 'ellipsis',
+                        whiteSpace: 'nowrap',
+                        fontStyle: isStructural ? 'italic' : 'normal',
+                        color: isStructural ? 'var(--rn-clr-content-tertiary)' : undefined,
+                    }}
+                >
+                    {nameSegments === undefined ? (
+                        'Loading…'
+                    ) : nameSegments.length > 0 ? (
+                        <RemTextSegments segments={nameSegments} />
+                    ) : (
+                        'Untitled'
+                    )}
+                </div>
+            </div>
+            <div style={{ textAlign: 'right', fontFamily: 'monospace' }}>
+                {totalTimeMs > 0 ? formatMs(totalTimeMs) : '-'}
+            </div>
+            <div style={{ textAlign: 'right' }}>
+                {a.cardReps > 0 ? (
+                    <>
+                        <span style={{ fontWeight: 600 }}>{a.cardReps}</span>{' '}
+                        <span style={{ fontSize: 10, color: 'var(--rn-clr-content-tertiary)' }}>
+                            ({formatMs(a.cardTimeMs)})
+                        </span>
+                    </>
+                ) : (
+                    '-'
+                )}
+            </div>
+            <div style={{ textAlign: 'right' }}>
+                {a.incRemReps > 0 ? (
+                    <>
+                        <span style={{ fontWeight: 600 }}>{a.incRemReps}</span>{' '}
+                        <span style={{ fontSize: 10, color: 'var(--rn-clr-content-tertiary)' }}>
+                            ({formatDuration(a.incRemTimeSec) || '0s'})
+                        </span>
+                    </>
+                ) : (
+                    '-'
+                )}
+            </div>
+            <div style={{ textAlign: 'right' }}>
+                {a.cardReps > 0 ? (
+                    <span style={{ color: retentionColor(retention), fontWeight: 600 }}>
+                        {retention.toFixed(0)}%
+                    </span>
+                ) : (
+                    '-'
+                )}
+            </div>
+            <div style={{ textAlign: 'right' }}>
+                {a.cardReps > 0 ? (
+                    <span style={{ color: speedColor(cpm), fontWeight: 600 }}>
+                        {cpm.toFixed(1)}
+                    </span>
+                ) : (
+                    '-'
+                )}
+            </div>
+            <button
+                onClick={async (e) => {
+                    e.stopPropagation();
+                    const rem = await plugin.rem.findOne(node.id);
+                    if (!rem) return;
+                    const isPdfHighlight = await rem.hasPowerup(BuiltInPowerupCodes.PDFHighlight);
+                    const isPdfExtract = await rem.hasPowerup(BuiltInPowerupCodes.UploadedFile);
+                    if (isPdfHighlight || isPdfExtract) {
+                        await rem.openRemAsPage();
+                    } else {
+                        await plugin.window.openRem(rem);
+                    }
+                    await plugin.widget.closePopup();
+                }}
+                style={{
+                    background: 'transparent',
+                    border: 'none',
+                    cursor: 'pointer',
+                    opacity: 0.5,
+                    fontSize: 12,
+                }}
+                title="Open Rem"
+            >
+                ↗
+            </button>
+        </div>
+    );
+}
+
+function HierarchyTree({ tree }: { tree: BuiltTree }) {
+    const [expanded, setExpanded] = useState<Record<string, boolean>>({});
+    const toggle = (id: string) =>
+        setExpanded((prev) => ({ ...prev, [id]: !prev[id] }));
+
+    function renderNode(id: string, depth: number): React.ReactNode[] {
+        const node = tree.nodes[id];
+        if (!node) return [];
+        const hasChildren = node.childrenIds.length > 0;
+        const isOpen = !!expanded[id];
+        const rows: React.ReactNode[] = [
+            <HierarchyRow
+                key={id}
+                node={node}
+                depth={depth}
+                expanded={isOpen}
+                hasChildren={hasChildren}
+                onToggle={() => toggle(id)}
+            />,
+        ];
+        if (isOpen) {
+            for (const c of node.childrenIds) {
+                rows.push(...renderNode(c, depth + 1));
+            }
+        }
+        return rows;
+    }
+
+    return (
+        <div>
+            <HierarchyHeader />
+            {tree.rootIds.map((rid) => renderNode(rid, 0))}
+        </div>
+    );
+}
+
+// Global top-level row with lazy subtree.
+function GlobalTopLevelRow({
+    topId,
+    pre,
+    startMs,
+    endMs,
+    cardCapMs,
+    remDataCache,
+}: {
+    topId: string;
+    pre: NonNullable<DashboardData['topLevels']>[number];
+    startMs: number;
+    endMs: number;
+    cardCapMs: number;
+    remDataCache: Map<string, RemData>;
+}) {
+    const plugin = usePlugin();
+    const [expanded, setExpanded] = useState(false);
+    const [subtree, setSubtree] = useState<BuiltTree | null>(null);
+    const [loading, setLoading] = useState(false);
+    const [text, setText] = useState<any>(null);
+
+    useEffect(() => {
+        let cancelled = false;
+        (async () => {
+            const rem = await plugin.rem.findOne(topId);
+            if (!cancelled && rem) setText(rem.text);
+        })();
+        return () => {
+            cancelled = true;
+        };
+    }, [topId, plugin]);
+
+    // Synthetic node for the top-level row's display
+    const pseudoNode: TreeNode = {
+        id: topId,
+        childrenIds: [], // we don't render children here; the subtree handles it
+        selfData: null,
+        aggr: pre.aggr,
+        aggrIncTagged: pre.aggrIncTagged,
+        aggrDismTagged: pre.aggrDismTagged,
+        aggrIncTaggedWithReps: pre.aggrIncTaggedWithReps,
+        aggrDismTaggedWithReps: pre.aggrDismTaggedWithReps,
+        aggrCardsCount: pre.aggrCardsCount,
+        remText: text,
+    };
+
+    const onToggle = async () => {
+        if (expanded) {
+            setExpanded(false);
+            return;
+        }
+        setExpanded(true);
+        if (subtree) return;
+        setLoading(true);
+        try {
+            const t = await buildSubtreeForTop(plugin, topId, startMs, endMs, cardCapMs, remDataCache);
+            setSubtree(t);
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    return (
+        <div>
+            <HierarchyRow
+                node={pseudoNode}
+                depth={0}
+                expanded={expanded}
+                hasChildren={true}
+                onToggle={onToggle}
+            />
+            {expanded && (
+                <div>
+                    {loading && (
+                        <div
+                            style={{
+                                fontSize: 11,
+                                color: 'var(--rn-clr-content-tertiary)',
+                                padding: '6px 8px',
+                                paddingLeft: 30,
+                            }}
+                        >
+                            Loading subtree…
+                        </div>
+                    )}
+                    {subtree && (
+                        <div style={{ paddingLeft: 0 }}>
+                            <SubtreeRenderer tree={subtree} startDepth={1} hideRoot={true} />
+                        </div>
+                    )}
+                </div>
+            )}
+        </div>
+    );
+}
+
+function SubtreeRenderer({
+    tree,
+    startDepth = 0,
+    hideRoot = false,
+}: {
+    tree: BuiltTree;
+    startDepth?: number;
+    hideRoot?: boolean;
+}) {
+    const [expanded, setExpanded] = useState<Record<string, boolean>>({});
+    const toggle = (id: string) =>
+        setExpanded((prev) => ({ ...prev, [id]: !prev[id] }));
+
+    function renderNode(id: string, depth: number): React.ReactNode[] {
+        const node = tree.nodes[id];
+        if (!node) return [];
+        const hasChildren = node.childrenIds.length > 0;
+        const isOpen = !!expanded[id];
+        const rows: React.ReactNode[] = [];
+        const isRoot = depth === startDepth;
+        if (!(isRoot && hideRoot)) {
+            rows.push(
+                <HierarchyRow
+                    key={id}
+                    node={node}
+                    depth={depth}
+                    expanded={isOpen || (isRoot && hideRoot)}
+                    hasChildren={hasChildren}
+                    onToggle={() => toggle(id)}
+                />
+            );
+        }
+        const showChildren = isOpen || (isRoot && hideRoot);
+        if (showChildren) {
+            for (const c of node.childrenIds) {
+                rows.push(...renderNode(c, depth + 1));
+            }
+        }
+        return rows;
+    }
+
+    return <div>{tree.rootIds.map((rid) => renderNode(rid, startDepth))}</div>;
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+function StudyDashboardPopup() {
+    const plugin = usePlugin();
+
+    const ctx = useRunAsync(async () => {
+        try {
+            return await plugin.widget.getWidgetContext<WidgetLocation.Popup>();
+        } catch {
+            return null;
+        }
+    }, []);
+    const ctxRemId: string | undefined = (ctx as any)?.contextData?.remId;
+
+    const [contextMode, setContextMode] = useState<ContextMode>(
+        ctxRemId ? 'document' : 'global'
+    );
+    const [scope, setScope] = useState<ScopeMode>('comprehensive');
+    const [period, setPeriod] = useState<Period>('today');
+    const [customStart, setCustomStart] = useState('');
+    const [customEnd, setCustomEnd] = useState('');
+
+    useEffect(() => {
+        // Update default context once ctx loads
+        if (ctxRemId && contextMode !== 'document') {
+            setContextMode('document');
+        }
+    }, [ctxRemId]);
+
+    const { startMs, endMs } = useMemo(
+        () => resolvePeriod(period, customStart, customEnd),
+        [period, customStart, customEnd]
+    );
+
+    const cardCapMs = useRunAsync(async () => {
+        const v = await plugin.settings.getSetting<number>(FLASHCARD_RESPONSE_TIME_LIMIT_SETTING);
+        return ((v ?? DEFAULT_RESPONSE_TIME_LIMIT_SEC) as number) * 1000;
+    }, []);
+
+    const [progress, setProgress] = useState<ProgressState>({
+        running: false,
+        percent: 0,
+        label: '',
+    });
+    const [docTree, setDocTree] = useState<BuiltTree | null>(null);
+    const [globalTops, setGlobalTops] = useState<DashboardData['topLevels']>(undefined);
+    const [globalRemDataCache, setGlobalRemDataCache] = useState<Map<string, RemData>>(
+        new Map()
+    );
+    const [summary, setSummary] = useState<SummaryStats | null>(null);
+    const runIdRef = useRef(0);
+
+    const run = useCallback(async () => {
+        if (cardCapMs == null) return;
+        const runId = ++runIdRef.current;
+        setProgress({ running: true, percent: 0, label: 'Starting…' });
+        setDocTree(null);
+        setGlobalTops(undefined);
+        setSummary(null);
+
+        try {
+            if (contextMode === 'document' && ctxRemId) {
+                const rootRem = await plugin.rem.findOne(ctxRemId);
+                if (!rootRem) {
+                    if (runId !== runIdRef.current) return;
+                    setProgress({ running: false, percent: 0, label: '' });
+                    return;
+                }
+                const { tree, summary: s } = await buildDocumentTree(
+                    plugin,
+                    rootRem,
+                    scope,
+                    startMs,
+                    endMs,
+                    cardCapMs,
+                    (p, label) => {
+                        if (runId !== runIdRef.current) return;
+                        setProgress({ running: true, percent: p, label });
+                    }
+                );
+                if (runId !== runIdRef.current) return;
+                setDocTree(tree);
+                setSummary(s);
+            } else {
+                const r = await buildGlobalDashboard(plugin, startMs, endMs, cardCapMs, (p, label) => {
+                    if (runId !== runIdRef.current) return;
+                    setProgress({ running: true, percent: p, label });
+                });
+                if (runId !== runIdRef.current) return;
+                setGlobalTops(r.topLevels);
+                setGlobalRemDataCache(r.remDataById);
+                setSummary(r.summary);
+            }
+        } catch (err) {
+            console.error('[study_dashboard] compute failed', err);
+        } finally {
+            if (runId === runIdRef.current) {
+                setProgress({ running: false, percent: 1, label: '' });
+            }
+        }
+    }, [plugin, contextMode, ctxRemId, scope, startMs, endMs, cardCapMs]);
+
+    useEffect(() => {
+        if (cardCapMs == null) return;
+        run();
+    }, [run, cardCapMs]);
+
+    const containerStyle: React.CSSProperties = {
+        width: '900px',
+        height: '850px',
+        backgroundColor: 'var(--rn-clr-background-primary)',
+        borderRadius: 12,
+        overflow: 'hidden',
+        display: 'flex',
+        flexDirection: 'column',
+    };
+
+    return (
+        <div style={containerStyle}>
+            {/* Header */}
+            <div
+                style={{
+                    padding: '12px 16px',
+                    borderBottom: '1px solid var(--rn-clr-border-primary)',
+                    background: 'var(--rn-clr-background-secondary)',
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'space-between',
+                }}
+            >
+                <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                    <span style={{ fontSize: 16 }}>📊</span>
+                    <span style={{ fontWeight: 600, fontSize: 14 }}>Study Dashboard</span>
+                </div>
+                <button
+                    onClick={() => plugin.widget.closePopup()}
+                    style={{
+                        background: 'none',
+                        border: 'none',
+                        fontSize: 18,
+                        cursor: 'pointer',
+                        opacity: 0.6,
+                    }}
+                    title="Close"
+                >
+                    ✕
+                </button>
+            </div>
+
+            {/* Filters */}
+            <div
+                style={{
+                    padding: '12px 16px',
+                    borderBottom: '1px solid var(--rn-clr-border-primary)',
+                    background: 'var(--rn-clr-background-secondary)',
+                    display: 'flex',
+                    gap: 24,
+                    flexWrap: 'wrap',
+                }}
+            >
+                <div>
+                    <div
+                        style={{
+                            fontSize: 10,
+                            fontWeight: 600,
+                            color: 'var(--rn-clr-content-tertiary)',
+                            textTransform: 'uppercase',
+                            marginBottom: 6,
+                        }}
+                    >
+                        Context
+                    </div>
+                    <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+                        <label
+                            style={{ display: 'flex', alignItems: 'center', gap: 4, fontSize: 12, cursor: 'pointer' }}
+                        >
+                            <input
+                                type="radio"
+                                checked={contextMode === 'global'}
+                                onChange={() => setContextMode('global')}
+                            />
+                            Global
+                        </label>
+                        <label
+                            style={{
+                                display: 'flex',
+                                alignItems: 'center',
+                                gap: 4,
+                                fontSize: 12,
+                                cursor: ctxRemId ? 'pointer' : 'not-allowed',
+                                opacity: ctxRemId ? 1 : 0.5,
+                            }}
+                        >
+                            <input
+                                type="radio"
+                                disabled={!ctxRemId}
+                                checked={contextMode === 'document'}
+                                onChange={() => setContextMode('document')}
+                            />
+                            Document
+                        </label>
+                    </div>
+                    {contextMode === 'document' && (
+                        <div style={{ marginTop: 8 }}>
+                            <div
+                                style={{
+                                    fontSize: 10,
+                                    fontWeight: 600,
+                                    color: 'var(--rn-clr-content-tertiary)',
+                                    textTransform: 'uppercase',
+                                    marginBottom: 4,
+                                }}
+                            >
+                                Scope
+                            </div>
+                            <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+                                <label style={{ fontSize: 12, cursor: 'pointer' }}>
+                                    <input
+                                        type="radio"
+                                        checked={scope === 'descendants'}
+                                        onChange={() => setScope('descendants')}
+                                    />{' '}
+                                    Descendants Only
+                                </label>
+                                <label style={{ fontSize: 12, cursor: 'pointer' }}>
+                                    <input
+                                        type="radio"
+                                        checked={scope === 'comprehensive'}
+                                        onChange={() => setScope('comprehensive')}
+                                    />{' '}
+                                    Comprehensive
+                                </label>
+                            </div>
+                        </div>
+                    )}
+                </div>
+                <div style={{ flex: 1 }}>
+                    <div
+                        style={{
+                            fontSize: 10,
+                            fontWeight: 600,
+                            color: 'var(--rn-clr-content-tertiary)',
+                            textTransform: 'uppercase',
+                            marginBottom: 6,
+                        }}
+                    >
+                        Period
+                    </div>
+                    <PeriodPicker
+                        period={period}
+                        onChange={setPeriod}
+                        customStart={customStart}
+                        customEnd={customEnd}
+                        onCustomChange={(s, e) => {
+                            setCustomStart(s);
+                            setCustomEnd(e);
+                        }}
+                    />
+                </div>
+            </div>
+
+            {/* Progress / Summary / Hierarchy */}
+            <div style={{ flex: 1, overflowY: 'auto' }}>
+                {progress.running && (
+                    <div style={{ padding: '12px 16px' }}>
+                        <div
+                            style={{
+                                height: 6,
+                                background: 'var(--rn-clr-background-secondary)',
+                                borderRadius: 3,
+                                overflow: 'hidden',
+                            }}
+                        >
+                            <div
+                                style={{
+                                    width: `${Math.round(progress.percent * 100)}%`,
+                                    height: '100%',
+                                    background: '#3b82f6',
+                                    transition: 'width 0.2s ease',
+                                }}
+                            />
+                        </div>
+                        <div
+                            style={{
+                                fontSize: 11,
+                                color: 'var(--rn-clr-content-tertiary)',
+                                marginTop: 4,
+                            }}
+                        >
+                            {progress.label}
+                        </div>
+                    </div>
+                )}
+
+                {summary && (
+                    <div style={{ padding: '12px 16px' }}>
+                        <div
+                            style={{
+                                fontSize: 11,
+                                fontWeight: 600,
+                                color: 'var(--rn-clr-content-tertiary)',
+                                textTransform: 'uppercase',
+                                marginBottom: 6,
+                            }}
+                        >
+                            Summary
+                        </div>
+                        <SummaryCard summary={summary} />
+                    </div>
+                )}
+
+                {/* Hierarchy */}
+                <div style={{ padding: '0 16px 16px' }}>
+                    <div
+                        style={{
+                            fontSize: 11,
+                            fontWeight: 600,
+                            color: 'var(--rn-clr-content-tertiary)',
+                            textTransform: 'uppercase',
+                            marginBottom: 6,
+                        }}
+                    >
+                        Hierarchy
+                    </div>
+                    {!progress.running && contextMode === 'document' && docTree && (
+                        <HierarchyTree tree={docTree} />
+                    )}
+                    {!progress.running && contextMode === 'global' && globalTops && (
+                        <div>
+                            <HierarchyHeader />
+                            {globalTops.length === 0 && (
+                                <div
+                                    style={{
+                                        padding: 16,
+                                        textAlign: 'center',
+                                        color: 'var(--rn-clr-content-tertiary)',
+                                        fontSize: 12,
+                                    }}
+                                >
+                                    No activity in the selected period.
+                                </div>
+                            )}
+                            {globalTops.map((t) => (
+                                <GlobalTopLevelRow
+                                    key={t.topId}
+                                    topId={t.topId}
+                                    pre={t}
+                                    startMs={startMs}
+                                    endMs={endMs}
+                                    cardCapMs={cardCapMs || DEFAULT_RESPONSE_TIME_LIMIT_SEC * 1000}
+                                    remDataCache={globalRemDataCache}
+                                />
+                            ))}
+                        </div>
+                    )}
+                </div>
+            </div>
+        </div>
+    );
+}
+
+renderWidget(StudyDashboardPopup);

--- a/src/widgets/study_dashboard.tsx
+++ b/src/widgets/study_dashboard.tsx
@@ -491,7 +491,7 @@ async function buildDocumentTree(
     function compute(id: string): TreeNode {
         if (nodes[id]) return nodes[id];
         const data = remDataById[id] || null;
-        const childrenIds = childMap[id] || [];
+        const rawChildrenIds = childMap[id] || [];
 
         const self = data ? statsFromRem(data, startMs, endMs, cardCapMs) : null;
         let aggr = self ? self.self : emptyStats();
@@ -503,7 +503,9 @@ async function buildDocumentTree(
             data && data.isDism && self && self.hasDismReps ? 1 : 0;
         let aggrCardsCount = data ? data.cards.length : 0;
 
-        for (const c of childrenIds) {
+        // Keep only children whose subtree has reps in the selected period.
+        const childrenIds: string[] = [];
+        for (const c of rawChildrenIds) {
             const child = compute(c);
             aggr = addStats(aggr, child.aggr);
             aggrIncTagged += child.aggrIncTagged;
@@ -511,6 +513,9 @@ async function buildDocumentTree(
             aggrIncTaggedWithReps += child.aggrIncTaggedWithReps;
             aggrDismTaggedWithReps += child.aggrDismTaggedWithReps;
             aggrCardsCount += child.aggrCardsCount;
+            if (child.aggr.incRemReps > 0 || child.aggr.cardReps > 0) {
+                childrenIds.push(c);
+            }
         }
 
         nodes[id] = {
@@ -529,6 +534,14 @@ async function buildDocumentTree(
     }
 
     for (const rid of rootIds) compute(rid);
+
+    // Drop roots whose entire subtree has no reps in the selected period.
+    const filteredRootIds = rootIds.filter((id) => {
+        const n = nodes[id];
+        return n && (n.aggr.incRemReps > 0 || n.aggr.cardReps > 0);
+    });
+    rootIds.length = 0;
+    rootIds.push(...filteredRootIds);
 
     // Summary from root totals: sum aggrs across roots
     const summary: SummaryStats = {
@@ -844,12 +857,7 @@ async function buildGlobalDashboard(
 
     const topLevels = Array.from(topAggrs.entries())
         .map(([topId, v]) => ({ topId, ...v }))
-        .filter(
-            (t) =>
-                t.aggrIncTagged > 0 ||
-                t.aggrDismTagged > 0 ||
-                t.aggrCardsCount > 0
-        )
+        .filter((t) => t.aggr.incRemReps > 0 || t.aggr.cardReps > 0)
         .sort((a, b) => b.aggr.cardTimeMs + b.aggr.incRemTimeSec * 1000 - (a.aggr.cardTimeMs + a.aggr.incRemTimeSec * 1000));
 
     onProgress(1, 'Done');
@@ -902,7 +910,7 @@ async function buildSubtreeForTop(
     function compute(id: string): TreeNode {
         if (nodes[id]) return nodes[id];
         const data = remDataById[id];
-        const childrenIds = childMap[id] || [];
+        const rawChildrenIds = childMap[id] || [];
 
         const self = data ? statsFromRem(data, startMs, endMs, cardCapMs) : null;
         let aggr = self ? self.self : emptyStats();
@@ -914,7 +922,8 @@ async function buildSubtreeForTop(
             data && data.isDism && self && self.hasDismReps ? 1 : 0;
         let aggrCardsCount = data ? data.cards.length : 0;
 
-        for (const c of childrenIds) {
+        const childrenIds: string[] = [];
+        for (const c of rawChildrenIds) {
             const child = compute(c);
             aggr = addStats(aggr, child.aggr);
             aggrIncTagged += child.aggrIncTagged;
@@ -922,6 +931,9 @@ async function buildSubtreeForTop(
             aggrIncTaggedWithReps += child.aggrIncTaggedWithReps;
             aggrDismTaggedWithReps += child.aggrDismTaggedWithReps;
             aggrCardsCount += child.aggrCardsCount;
+            if (child.aggr.incRemReps > 0 || child.aggr.cardReps > 0) {
+                childrenIds.push(c);
+            }
         }
 
         nodes[id] = {

--- a/src/widgets/study_dashboard.tsx
+++ b/src/widgets/study_dashboard.tsx
@@ -632,6 +632,8 @@ async function buildGlobalDashboard(
     parentChainCache: Map<string, string[]>;
     // map of remId -> RemData for any rem we've already loaded (incremental / dismissed / card-bearing)
     remDataById: Map<string, RemData>;
+    // Pre-built subtrees keyed by top-level rem id — expansion is instant.
+    subtreesByTop: Map<string, BuiltTree>;
 }> {
     onProgress(0.02, 'Fetching tagged rems…');
 
@@ -713,6 +715,9 @@ async function buildGlobalDashboard(
 
     // Parent-chain cache: remId -> [self, parent, grandparent, ..., topAncestor]
     const parentChainCache = new Map<string, string[]>();
+    // Stash text for every rem we touch while walking chains; this avoids a
+    // second pass to fetch text for structural ancestor nodes when building subtrees.
+    const remTextCache = new Map<string, any>();
     async function ancestorChain(id: string): Promise<string[]> {
         const cached = parentChainCache.get(id);
         if (cached) return cached;
@@ -726,6 +731,7 @@ async function buildGlobalDashboard(
             chain.push(cur);
             const r: PluginRem | undefined = await plugin.rem.findOne(cur);
             if (!r) break;
+            if (!remTextCache.has(cur)) remTextCache.set(cur, r.text);
             cur = r.parent || null;
         }
         parentChainCache.set(id, chain);
@@ -853,7 +859,98 @@ async function buildGlobalDashboard(
         }
     }
 
-    onProgress(0.97, 'Sorting…');
+    onProgress(0.95, 'Building subtrees…');
+
+    // Pre-build a subtree per top-level using already-gathered data. No new RPC calls.
+    // For each rem-with-data, its parent chain (already cached) gives us its position in
+    // the hierarchy. We walk those chains in-memory to assemble parent→children links
+    // and aggregate stats bottom-up. Structural ancestors (chain entries not in
+    // remDataById) become tree-backbone nodes carrying only their text.
+    const topToChildMap = new Map<string, Map<string, Set<string>>>();
+    const topToNodeIds = new Map<string, Set<string>>();
+
+    for (const rd of remDataById.values()) {
+        const chain = parentChainCache.get(rd.id) || [rd.id];
+        if (chain.length === 0) continue;
+        const topId = chain[chain.length - 1];
+
+        let nodeIds = topToNodeIds.get(topId);
+        if (!nodeIds) {
+            nodeIds = new Set();
+            topToNodeIds.set(topId, nodeIds);
+        }
+        let childMap = topToChildMap.get(topId);
+        if (!childMap) {
+            childMap = new Map();
+            topToChildMap.set(topId, childMap);
+        }
+        for (let i = 0; i < chain.length; i++) {
+            const id = chain[i];
+            nodeIds.add(id);
+            if (i < chain.length - 1) {
+                const parentId = chain[i + 1];
+                let cset = childMap.get(parentId);
+                if (!cset) {
+                    cset = new Set();
+                    childMap.set(parentId, cset);
+                }
+                cset.add(id);
+            }
+        }
+    }
+
+    const subtreesByTop = new Map<string, BuiltTree>();
+    for (const [topId] of topToNodeIds) {
+        const childMap = topToChildMap.get(topId) || new Map<string, Set<string>>();
+        const nodes: Record<string, TreeNode> = {};
+
+        const compute = (id: string): TreeNode => {
+            if (nodes[id]) return nodes[id];
+            const data = remDataById.get(id) || null;
+            const rawChildrenIds = Array.from(childMap.get(id) || []);
+
+            const self = data ? statsFromRem(data, startMs, endMs, cardCapMs) : null;
+            let aggr = self ? self.self : emptyStats();
+            let aggrIncTagged = data && data.isInc ? 1 : 0;
+            let aggrDismTagged = data && data.isDism ? 1 : 0;
+            let aggrIncTaggedWithReps = data && data.isInc && self && self.hasIncReps ? 1 : 0;
+            let aggrDismTaggedWithReps = data && data.isDism && self && self.hasDismReps ? 1 : 0;
+            let aggrCardsCount = data ? data.cards.length : 0;
+
+            const childrenIds: string[] = [];
+            for (const c of rawChildrenIds) {
+                const child = compute(c);
+                aggr = addStats(aggr, child.aggr);
+                aggrIncTagged += child.aggrIncTagged;
+                aggrDismTagged += child.aggrDismTagged;
+                aggrIncTaggedWithReps += child.aggrIncTaggedWithReps;
+                aggrDismTaggedWithReps += child.aggrDismTaggedWithReps;
+                aggrCardsCount += child.aggrCardsCount;
+                if (child.aggr.incRemReps > 0 || child.aggr.cardReps > 0) {
+                    childrenIds.push(c);
+                }
+            }
+
+            nodes[id] = {
+                id,
+                childrenIds,
+                selfData: data,
+                aggr,
+                aggrIncTagged,
+                aggrDismTagged,
+                aggrIncTaggedWithReps,
+                aggrDismTaggedWithReps,
+                aggrCardsCount,
+                remText: data?.remText ?? remTextCache.get(id),
+            };
+            return nodes[id];
+        };
+        compute(topId);
+
+        subtreesByTop.set(topId, { nodes, rootIds: [topId] });
+    }
+
+    onProgress(0.99, 'Sorting…');
 
     const topLevels = Array.from(topAggrs.entries())
         .map(([topId, v]) => ({ topId, ...v }))
@@ -861,98 +958,7 @@ async function buildGlobalDashboard(
         .sort((a, b) => b.aggr.cardTimeMs + b.aggr.incRemTimeSec * 1000 - (a.aggr.cardTimeMs + a.aggr.incRemTimeSec * 1000));
 
     onProgress(1, 'Done');
-    return { topLevels, summary, parentChainCache, remDataById };
-}
-
-// Build subtree for a given top-level rem on demand (Global mode).
-async function buildSubtreeForTop(
-    plugin: ReturnType<typeof usePlugin>,
-    topId: string,
-    startMs: number,
-    endMs: number,
-    cardCapMs: number,
-    remDataCache: Map<string, RemData>
-): Promise<BuiltTree> {
-    const topRem = await plugin.rem.findOne(topId);
-    if (!topRem) return { nodes: {}, rootIds: [] };
-
-    const descendants = await topRem.getDescendants();
-    const all = [topRem, ...descendants];
-
-    // For each rem, load data unless cached
-    const remDataList: RemData[] = await chunked(all, async (r) => {
-        const cached = remDataCache.get(r._id);
-        if (cached) {
-            // ensure parent/text are filled
-            if (!cached.remText) cached.remText = r.text;
-            if (cached.parentId === null) cached.parentId = r.parent || null;
-            return cached;
-        }
-        const data = await loadRemData(plugin, r);
-        remDataCache.set(r._id, data);
-        return data;
-    });
-    const remDataById: Record<string, RemData> = {};
-    for (const rd of remDataList) remDataById[rd.id] = rd;
-
-    const ids = Object.keys(remDataById);
-    const childMap: Record<string, string[]> = {};
-    const present = new Set(ids);
-    let rootId: string | null = null;
-    for (const id of ids) {
-        const p = remDataById[id].parentId;
-        if (p && present.has(p)) (childMap[p] ||= []).push(id);
-        else rootId = id; // top-level inside this subtree
-    }
-    if (!rootId) rootId = topId;
-
-    const nodes: Record<string, TreeNode> = {};
-    function compute(id: string): TreeNode {
-        if (nodes[id]) return nodes[id];
-        const data = remDataById[id];
-        const rawChildrenIds = childMap[id] || [];
-
-        const self = data ? statsFromRem(data, startMs, endMs, cardCapMs) : null;
-        let aggr = self ? self.self : emptyStats();
-        let aggrIncTagged = data && data.isInc ? 1 : 0;
-        let aggrDismTagged = data && data.isDism ? 1 : 0;
-        let aggrIncTaggedWithReps =
-            data && data.isInc && self && self.hasIncReps ? 1 : 0;
-        let aggrDismTaggedWithReps =
-            data && data.isDism && self && self.hasDismReps ? 1 : 0;
-        let aggrCardsCount = data ? data.cards.length : 0;
-
-        const childrenIds: string[] = [];
-        for (const c of rawChildrenIds) {
-            const child = compute(c);
-            aggr = addStats(aggr, child.aggr);
-            aggrIncTagged += child.aggrIncTagged;
-            aggrDismTagged += child.aggrDismTagged;
-            aggrIncTaggedWithReps += child.aggrIncTaggedWithReps;
-            aggrDismTaggedWithReps += child.aggrDismTaggedWithReps;
-            aggrCardsCount += child.aggrCardsCount;
-            if (child.aggr.incRemReps > 0 || child.aggr.cardReps > 0) {
-                childrenIds.push(c);
-            }
-        }
-
-        nodes[id] = {
-            id,
-            childrenIds,
-            selfData: data || null,
-            aggr,
-            aggrIncTagged,
-            aggrDismTagged,
-            aggrIncTaggedWithReps,
-            aggrDismTaggedWithReps,
-            aggrCardsCount,
-            remText: data?.remText,
-        };
-        return nodes[id];
-    }
-    compute(rootId);
-
-    return { nodes, rootIds: [rootId] };
+    return { topLevels, summary, parentChainCache, remDataById, subtreesByTop };
 }
 
 // ---------------------------------------------------------------------------
@@ -1405,43 +1411,24 @@ function HierarchyTree({ tree }: { tree: BuiltTree }) {
     );
 }
 
-// Global top-level row with lazy subtree.
+// Global top-level row, rendering a pre-built subtree synchronously.
 function GlobalTopLevelRow({
     topId,
     pre,
-    startMs,
-    endMs,
-    cardCapMs,
-    remDataCache,
+    subtree,
 }: {
     topId: string;
     pre: NonNullable<DashboardData['topLevels']>[number];
-    startMs: number;
-    endMs: number;
-    cardCapMs: number;
-    remDataCache: Map<string, RemData>;
+    subtree: BuiltTree | null;
 }) {
-    const plugin = usePlugin();
     const [expanded, setExpanded] = useState(false);
-    const [subtree, setSubtree] = useState<BuiltTree | null>(null);
-    const [loading, setLoading] = useState(false);
-    const [text, setText] = useState<any>(null);
 
-    useEffect(() => {
-        let cancelled = false;
-        (async () => {
-            const rem = await plugin.rem.findOne(topId);
-            if (!cancelled && rem) setText(rem.text);
-        })();
-        return () => {
-            cancelled = true;
-        };
-    }, [topId, plugin]);
-
-    // Synthetic node for the top-level row's display
-    const pseudoNode: TreeNode = {
+    // Use the pre-built tree's root node when available — its remText was populated
+    // from remTextCache during the build pass — otherwise fall back to a pseudo node.
+    const rootNode = subtree?.nodes[topId];
+    const displayNode: TreeNode = rootNode ?? {
         id: topId,
-        childrenIds: [], // we don't render children here; the subtree handles it
+        childrenIds: [],
         selfData: null,
         aggr: pre.aggr,
         aggrIncTagged: pre.aggrIncTagged,
@@ -1449,54 +1436,21 @@ function GlobalTopLevelRow({
         aggrIncTaggedWithReps: pre.aggrIncTaggedWithReps,
         aggrDismTaggedWithReps: pre.aggrDismTaggedWithReps,
         aggrCardsCount: pre.aggrCardsCount,
-        remText: text,
+        remText: null,
     };
-
-    const onToggle = async () => {
-        if (expanded) {
-            setExpanded(false);
-            return;
-        }
-        setExpanded(true);
-        if (subtree) return;
-        setLoading(true);
-        try {
-            const t = await buildSubtreeForTop(plugin, topId, startMs, endMs, cardCapMs, remDataCache);
-            setSubtree(t);
-        } finally {
-            setLoading(false);
-        }
-    };
+    const hasChildren = (rootNode?.childrenIds.length ?? 0) > 0;
 
     return (
         <div>
             <HierarchyRow
-                node={pseudoNode}
+                node={displayNode}
                 depth={0}
                 expanded={expanded}
-                hasChildren={true}
-                onToggle={onToggle}
+                hasChildren={hasChildren}
+                onToggle={() => setExpanded((v) => !v)}
             />
-            {expanded && (
-                <div>
-                    {loading && (
-                        <div
-                            style={{
-                                fontSize: 11,
-                                color: 'var(--rn-clr-content-tertiary)',
-                                padding: '6px 8px',
-                                paddingLeft: 30,
-                            }}
-                        >
-                            Loading subtree…
-                        </div>
-                    )}
-                    {subtree && (
-                        <div style={{ paddingLeft: 0 }}>
-                            <SubtreeRenderer tree={subtree} startDepth={1} hideRoot={true} />
-                        </div>
-                    )}
-                </div>
+            {expanded && subtree && (
+                <SubtreeRenderer tree={subtree} startDepth={0} hideRoot={true} />
             )}
         </div>
     );
@@ -1618,7 +1572,7 @@ function StudyDashboardPopup() {
     });
     const [docTree, setDocTree] = useState<BuiltTree | null>(null);
     const [globalTops, setGlobalTops] = useState<DashboardData['topLevels']>(undefined);
-    const [globalRemDataCache, setGlobalRemDataCache] = useState<Map<string, RemData>>(
+    const [globalSubtreesByTop, setGlobalSubtreesByTop] = useState<Map<string, BuiltTree>>(
         new Map()
     );
     const [summary, setSummary] = useState<SummaryStats | null>(null);
@@ -1662,7 +1616,7 @@ function StudyDashboardPopup() {
                 });
                 if (runId !== runIdRef.current) return;
                 setGlobalTops(r.topLevels);
-                setGlobalRemDataCache(r.remDataById);
+                setGlobalSubtreesByTop(r.subtreesByTop);
                 setSummary(r.summary);
             }
         } catch (err) {
@@ -1980,10 +1934,7 @@ function StudyDashboardPopup() {
                                     key={t.topId}
                                     topId={t.topId}
                                     pre={t}
-                                    startMs={startMs}
-                                    endMs={endMs}
-                                    cardCapMs={cardCapMs || DEFAULT_RESPONSE_TIME_LIMIT_SEC * 1000}
-                                    remDataCache={globalRemDataCache}
+                                    subtree={globalSubtreesByTop.get(t.topId) || null}
                                 />
                             ))}
                         </div>

--- a/src/widgets/study_dashboard.tsx
+++ b/src/widgets/study_dashboard.tsx
@@ -718,24 +718,36 @@ async function buildGlobalDashboard(
     // Stash text for every rem we touch while walking chains; this avoids a
     // second pass to fetch text for structural ancestor nodes when building subtrees.
     const remTextCache = new Map<string, any>();
+    // In-flight chain promises so concurrent callers share work for shared ancestors.
+    // Without this, parallel sibling rems would each re-walk the same parent path,
+    // multiplying RPC traffic and pushing the WebSocket into timeout territory.
+    const inFlightChains = new Map<string, Promise<string[]>>();
+    const buildChain = async (id: string): Promise<string[]> => {
+        const r: PluginRem | undefined = await plugin.rem.findOne(id);
+        if (!r) {
+            const chain = [id];
+            parentChainCache.set(id, chain);
+            return chain;
+        }
+        if (!remTextCache.has(id)) remTextCache.set(id, r.text);
+        const parentId = r.parent || null;
+        const parentChain = parentId ? await ancestorChain(parentId) : [];
+        const chain = [id, ...parentChain];
+        parentChainCache.set(id, chain);
+        return chain;
+    };
     async function ancestorChain(id: string): Promise<string[]> {
         const cached = parentChainCache.get(id);
         if (cached) return cached;
-        const chain: string[] = [];
-        let cur: string | null = id;
-        while (cur) {
-            if (parentChainCache.has(cur)) {
-                chain.push(...parentChainCache.get(cur)!);
-                break;
-            }
-            chain.push(cur);
-            const r: PluginRem | undefined = await plugin.rem.findOne(cur);
-            if (!r) break;
-            if (!remTextCache.has(cur)) remTextCache.set(cur, r.text);
-            cur = r.parent || null;
+        const pending = inFlightChains.get(id);
+        if (pending) return pending;
+        const p = buildChain(id);
+        inFlightChains.set(id, p);
+        try {
+            return await p;
+        } finally {
+            inFlightChains.delete(id);
         }
-        parentChainCache.set(id, chain);
-        return chain;
     }
 
     // For every rem with data in the period, attribute to its top ancestor.
@@ -784,79 +796,92 @@ async function buildGlobalDashboard(
     };
 
     const remEntries = Array.from(remDataById.values());
+    const AGG_CHUNK = 50;
     let processed = 0;
-    for (const rd of remEntries) {
-        // Build ancestor chain for this rem (parent + above). Need parent info — look up if missing.
-        if (rd.parentId === null && !parentChainCache.has(rd.id)) {
-            const r = await plugin.rem.findOne(rd.id);
-            rd.parentId = r?.parent || null;
-            if (r) rd.remText = rd.remText ?? r.text;
-        }
-        const chain = await ancestorChain(rd.id);
-        const topId = chain[chain.length - 1] || rd.id;
+    for (let i = 0; i < remEntries.length; i += AGG_CHUNK) {
+        const chunk = remEntries.slice(i, i + AGG_CHUNK);
+        // Resolve ancestor chains in parallel; the shared inFlightChains cache
+        // makes sibling rems reuse each other's parent lookups instead of
+        // duplicating RPC traffic, which is what was overwhelming the WebSocket.
+        const resolved = await Promise.all(
+            chunk.map(async (rd) => {
+                if (rd.parentId === null && !parentChainCache.has(rd.id)) {
+                    const r = await plugin.rem.findOne(rd.id);
+                    rd.parentId = r?.parent || null;
+                    if (r) rd.remText = rd.remText ?? r.text;
+                }
+                const chain = await ancestorChain(rd.id);
+                return { rd, chain };
+            })
+        );
 
-        const { self, hasIncReps, hasDismReps } = statsFromRem(rd, startMs, endMs, cardCapMs);
-        const top = ensureTop(topId);
-        top.aggr = addStats(top.aggr, self);
-        if (rd.isInc) {
-            top.aggrIncTagged += 1;
-            summary.incTaggedCount += 1;
-            if (hasIncReps) {
-                top.aggrIncTaggedWithReps += 1;
-                summary.incTaggedWithRepsCount += 1;
+        // Accumulator updates are in-memory; do them sequentially to avoid races on shared maps.
+        for (const { rd, chain } of resolved) {
+            const topId = chain[chain.length - 1] || rd.id;
+            const { self, hasIncReps, hasDismReps } = statsFromRem(rd, startMs, endMs, cardCapMs);
+            const top = ensureTop(topId);
+            top.aggr = addStats(top.aggr, self);
+            if (rd.isInc) {
+                top.aggrIncTagged += 1;
+                summary.incTaggedCount += 1;
+                if (hasIncReps) {
+                    top.aggrIncTaggedWithReps += 1;
+                    summary.incTaggedWithRepsCount += 1;
+                }
+                let incReps = 0;
+                let incTime = 0;
+                for (const rep of rd.incHistory) {
+                    if (!rep || typeof rep.date !== 'number') continue;
+                    if (rep.date < startMs || rep.date >= endMs) continue;
+                    if (!isRealIncRep(rep.eventType)) continue;
+                    incReps += 1;
+                    incTime += rep.reviewTimeSeconds || 0;
+                }
+                summary.incReps += incReps;
+                summary.incTimeSec += incTime;
             }
-            let incReps = 0;
-            let incTime = 0;
-            for (const rep of rd.incHistory) {
-                if (!rep || typeof rep.date !== 'number') continue;
-                if (rep.date < startMs || rep.date >= endMs) continue;
-                if (!isRealIncRep(rep.eventType)) continue;
-                incReps += 1;
-                incTime += rep.reviewTimeSeconds || 0;
+            if (rd.isDism) {
+                top.aggrDismTagged += 1;
+                summary.dismTaggedCount += 1;
+                if (hasDismReps) {
+                    top.aggrDismTaggedWithReps += 1;
+                    summary.dismTaggedWithRepsCount += 1;
+                }
+                let dismReps = 0;
+                let dismTime = 0;
+                for (const rep of rd.dismHistory) {
+                    if (!rep || typeof rep.date !== 'number') continue;
+                    if (rep.date < startMs || rep.date >= endMs) continue;
+                    if (!isRealIncRep(rep.eventType)) continue;
+                    dismReps += 1;
+                    dismTime += rep.reviewTimeSeconds || 0;
+                }
+                summary.dismReps += dismReps;
+                summary.dismTimeSec += dismTime;
             }
-            summary.incReps += incReps;
-            summary.incTimeSec += incTime;
-        }
-        if (rd.isDism) {
-            top.aggrDismTagged += 1;
-            summary.dismTaggedCount += 1;
-            if (hasDismReps) {
-                top.aggrDismTaggedWithReps += 1;
-                summary.dismTaggedWithRepsCount += 1;
+            top.aggrCardsCount += rd.cards.length;
+            summary.cardsCount += rd.cards.length;
+            for (const card of rd.cards) {
+                let cardHasReps = false;
+                for (const rep of card.history || []) {
+                    if (!rep || typeof rep.date !== 'number') continue;
+                    if (rep.date < startMs || rep.date >= endMs) continue;
+                    if (!isRealCardScore(rep.score)) continue;
+                    const t = Math.min(Math.max(0, rep.responseTime || 0), cardCapMs);
+                    summary.cardReps += 1;
+                    summary.cardTimeMs += t;
+                    if (rep.score === QueueInteractionScore.AGAIN) summary.cardForgot += 1;
+                    cardHasReps = true;
+                }
+                if (cardHasReps) summary.cardsWithRepsCount += 1;
             }
-            let dismReps = 0;
-            let dismTime = 0;
-            for (const rep of rd.dismHistory) {
-                if (!rep || typeof rep.date !== 'number') continue;
-                if (rep.date < startMs || rep.date >= endMs) continue;
-                if (!isRealIncRep(rep.eventType)) continue;
-                dismReps += 1;
-                dismTime += rep.reviewTimeSeconds || 0;
-            }
-            summary.dismReps += dismReps;
-            summary.dismTimeSec += dismTime;
-        }
-        top.aggrCardsCount += rd.cards.length;
-        summary.cardsCount += rd.cards.length;
-        for (const card of rd.cards) {
-            let cardHasReps = false;
-            for (const rep of card.history || []) {
-                if (!rep || typeof rep.date !== 'number') continue;
-                if (rep.date < startMs || rep.date >= endMs) continue;
-                if (!isRealCardScore(rep.score)) continue;
-                const t = Math.min(Math.max(0, rep.responseTime || 0), cardCapMs);
-                summary.cardReps += 1;
-                summary.cardTimeMs += t;
-                if (rep.score === QueueInteractionScore.AGAIN) summary.cardForgot += 1;
-                cardHasReps = true;
-            }
-            if (cardHasReps) summary.cardsWithRepsCount += 1;
         }
 
-        processed += 1;
-        if (processed % 100 === 0) {
-            onProgress(0.65 + 0.3 * (processed / Math.max(1, remEntries.length)), `Aggregating (${processed}/${remEntries.length})`);
-        }
+        processed += chunk.length;
+        onProgress(
+            0.65 + 0.3 * (processed / Math.max(1, remEntries.length)),
+            `Aggregating (${processed}/${remEntries.length})`
+        );
     }
 
     onProgress(0.95, 'Building subtrees…');

--- a/src/widgets/study_dashboard.tsx
+++ b/src/widgets/study_dashboard.tsx
@@ -1582,6 +1582,30 @@ function StudyDashboardPopup() {
         [period, customStart, customEnd]
     );
 
+    // Reflect the resolved range in the Start/End date inputs when a preset is picked.
+    // For 'all', leave the inputs blank (no meaningful start). 'custom' leaves them as typed.
+    useEffect(() => {
+        if (period === 'custom') return;
+        if (period === 'all') {
+            if (customStart !== '') setCustomStart('');
+            if (customEnd !== '') setCustomEnd('');
+            return;
+        }
+        const toIsoDate = (ms: number) => {
+            const d = new Date(ms);
+            const y = d.getFullYear();
+            const m = String(d.getMonth() + 1).padStart(2, '0');
+            const day = String(d.getDate()).padStart(2, '0');
+            return `${y}-${m}-${day}`;
+        };
+        const newStart = toIsoDate(startMs);
+        // endMs is exclusive (start of the day after the last included day);
+        // subtract 1ms so the input shows the inclusive last day.
+        const newEnd = toIsoDate(endMs - 1);
+        if (newStart !== customStart) setCustomStart(newStart);
+        if (newEnd !== customEnd) setCustomEnd(newEnd);
+    }, [period, startMs, endMs]);
+
     const cardCapMs = useRunAsync(async () => {
         const v = await plugin.settings.getSetting<number>(FLASHCARD_RESPONSE_TIME_LIMIT_SETTING);
         return ((v ?? DEFAULT_RESPONSE_TIME_LIMIT_SEC) as number) * 1000;

--- a/src/widgets/study_dashboard.tsx
+++ b/src/widgets/study_dashboard.tsx
@@ -20,6 +20,38 @@ import { buildComprehensiveScope } from '../lib/scope_helpers';
 import { formatDuration, tryParseJson } from '../lib/utils';
 import { resolveRemTextSegments } from '../lib/richTextRemRefs';
 import { RemTextSegments } from '../components';
+import '../style.css';
+import '../App.css';
+
+// ---------------------------------------------------------------------------
+// Style helpers (mirroring the statistics plugin's chartHelpers)
+// ---------------------------------------------------------------------------
+const ACCENT_COLOR = '#3362f0';
+function getBoxStyle(): React.CSSProperties {
+    return {
+        backgroundColor: 'var(--rn-clr-background-secondary)',
+        borderColor: 'var(--rn-clr-border-primary)',
+        color: 'var(--rn-clr-content-primary)',
+    };
+}
+function getInputStyle(): React.CSSProperties {
+    return {
+        backgroundColor: 'var(--rn-clr-background-primary)',
+        borderColor: 'var(--rn-clr-border-primary)',
+        color: 'var(--rn-clr-content-primary)',
+    };
+}
+function getButtonStyle(isSelected: boolean): React.CSSProperties {
+    return {
+        backgroundColor: isSelected ? ACCENT_COLOR : 'var(--rn-clr-background-primary)',
+        color: isSelected ? '#fff' : 'var(--rn-clr-content-secondary)',
+        border: isSelected ? 'none' : '1px solid var(--rn-clr-border-primary)',
+        boxShadow: isSelected ? '0 2px 8px rgba(0,0,0,0.15)' : '0 1px 2px 0 rgba(0,0,0,0.05)',
+        fontWeight: isSelected ? 600 : 400,
+        transform: isSelected ? 'scale(1.02)' : 'scale(1)',
+        transition: 'all 0.2s ease-in-out',
+    };
+}
 
 // ---------------------------------------------------------------------------
 // Types
@@ -915,27 +947,6 @@ async function buildSubtreeForTop(
 // UI components
 // ---------------------------------------------------------------------------
 
-const periodPresets: { id: Period; label: string }[][] = [
-    [
-        { id: 'today', label: 'Today' },
-        { id: 'week', label: 'Week' },
-        { id: 'month', label: 'Month' },
-        { id: 'year', label: 'Year' },
-        { id: 'all', label: 'All' },
-    ],
-    [
-        { id: 'yesterday', label: 'Yesterday' },
-        { id: 'thisWeek', label: 'This Week' },
-        { id: 'thisMonth', label: 'This Month' },
-        { id: 'thisYear', label: 'This Year' },
-    ],
-    [
-        { id: 'lastWeek', label: 'Last Week' as any },
-        { id: 'lastMonth', label: 'Last Month' },
-        { id: 'lastYear', label: 'Last Year' },
-    ],
-];
-
 function PeriodPicker({
     period,
     onChange,
@@ -949,37 +960,54 @@ function PeriodPicker({
     customEnd: string;
     onCustomChange: (s: string, e: string) => void;
 }) {
-    const btn = (id: Period, label: string) => {
-        const active = id === period;
-        return (
-            <button
-                key={id}
-                onClick={() => onChange(id)}
-                style={{
-                    padding: '6px 10px',
-                    borderRadius: 6,
-                    border: '1px solid var(--rn-clr-border-primary)',
-                    background: active ? 'var(--rn-clr-blue-500, #3b82f6)' : 'transparent',
-                    color: active ? '#fff' : 'var(--rn-clr-content-primary)',
-                    fontSize: 12,
-                    cursor: 'pointer',
-                    minWidth: 90,
-                }}
-            >
-                {label}
-            </button>
-        );
-    };
+    const inputStyle = getInputStyle();
+    const renderPresetBtn = (label: string, id: Period) => (
+        <button
+            onClick={() => onChange(id)}
+            className="w-full h-full rounded px-2 py-1 text-xs transition-all hover:opacity-90 flex items-center justify-center"
+            style={getButtonStyle(id === period)}
+        >
+            {label}
+        </button>
+    );
+
     return (
-        <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
-            {periodPresets.map((row, i) => (
-                <div key={i} style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
-                    {row.map((p) => btn(p.id, p.label))}
+        <div>
+            {/* 5x3 grid matching the statistics plugin */}
+            <div className="grid gap-1 md:gap-1.5 grid-cols-3 sm:grid-cols-5">
+                <div style={{ gridColumn: '1', gridRow: '1 / 3' }}>
+                    {renderPresetBtn('Today', 'today')}
                 </div>
-            ))}
-            <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginTop: 6 }}>
-                <div style={{ display: 'flex', flexDirection: 'column' }}>
-                    <span style={{ fontSize: 10, color: 'var(--rn-clr-content-tertiary)' }}>Start</span>
+                <div style={{ gridColumn: '1', gridRow: '3' }}>
+                    {renderPresetBtn('Yesterday', 'yesterday')}
+                </div>
+
+                <div style={{ gridColumn: '2', gridRow: '1' }}>{renderPresetBtn('Week', 'week')}</div>
+                <div style={{ gridColumn: '2', gridRow: '2' }}>{renderPresetBtn('This Week', 'thisWeek')}</div>
+                <div style={{ gridColumn: '2', gridRow: '3' }}>{renderPresetBtn('Last Week', 'lastWeek')}</div>
+
+                <div style={{ gridColumn: '3', gridRow: '1' }}>{renderPresetBtn('Month', 'month')}</div>
+                <div style={{ gridColumn: '3', gridRow: '2' }}>{renderPresetBtn('This Month', 'thisMonth')}</div>
+                <div style={{ gridColumn: '3', gridRow: '3' }}>{renderPresetBtn('Last Month', 'lastMonth')}</div>
+
+                <div style={{ gridColumn: '4', gridRow: '1' }}>{renderPresetBtn('Year', 'year')}</div>
+                <div style={{ gridColumn: '4', gridRow: '2' }}>{renderPresetBtn('This Year', 'thisYear')}</div>
+                <div style={{ gridColumn: '4', gridRow: '3' }}>{renderPresetBtn('Last Year', 'lastYear')}</div>
+
+                <div style={{ gridColumn: '5', gridRow: '1 / 4' }}>
+                    <button
+                        onClick={() => onChange('all')}
+                        className="w-full h-full rounded px-2 py-1 text-xs transition-all hover:opacity-90 flex items-center justify-center font-bold"
+                        style={getButtonStyle(period === 'all')}
+                    >
+                        All
+                    </button>
+                </div>
+            </div>
+
+            <div className="flex flex-wrap gap-2 md:gap-4 items-end mt-3">
+                <div className="flex flex-col flex-1 min-w-[120px]">
+                    <span className="text-xs opacity-70 mb-1">Start Date</span>
                     <input
                         type="date"
                         value={customStart}
@@ -987,11 +1015,12 @@ function PeriodPicker({
                             onCustomChange(e.target.value, customEnd);
                             onChange('custom');
                         }}
-                        style={{ fontSize: 12, padding: '4px 6px' }}
+                        className="border rounded px-2 py-1 text-sm w-full"
+                        style={inputStyle}
                     />
                 </div>
-                <div style={{ display: 'flex', flexDirection: 'column' }}>
-                    <span style={{ fontSize: 10, color: 'var(--rn-clr-content-tertiary)' }}>End</span>
+                <div className="flex flex-col flex-1 min-w-[120px]">
+                    <span className="text-xs opacity-70 mb-1">End Date</span>
                     <input
                         type="date"
                         value={customEnd}
@@ -999,21 +1028,17 @@ function PeriodPicker({
                             onCustomChange(customStart, e.target.value);
                             onChange('custom');
                         }}
-                        style={{ fontSize: 12, padding: '4px 6px' }}
+                        className="border rounded px-2 py-1 text-sm w-full"
+                        style={inputStyle}
                     />
                 </div>
                 {period === 'custom' && (
                     <button
                         onClick={() => onChange('today')}
-                        style={{
-                            fontSize: 11,
-                            background: 'transparent',
-                            border: 'none',
-                            color: 'var(--rn-clr-blue-500, #3b82f6)',
-                            cursor: 'pointer',
-                        }}
+                        className="text-xs hover:underline mb-2 ml-auto"
+                        style={{ color: ACCENT_COLOR }}
                     >
-                        Clear
+                        Clear Filter
                     </button>
                 )}
             </div>
@@ -1629,151 +1654,212 @@ function StudyDashboardPopup() {
     };
 
     return (
-        <div style={containerStyle}>
+        <div style={containerStyle} className="statisticsBody">
             {/* Header */}
             <div
-                style={{
-                    padding: '12px 16px',
-                    borderBottom: '1px solid var(--rn-clr-border-primary)',
-                    background: 'var(--rn-clr-background-secondary)',
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'space-between',
-                }}
+                style={{ flex: '0 0 auto', padding: '1rem', borderBottom: '1px solid var(--rn-clr-border-primary)' }}
+                className="md:px-6"
             >
-                <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-                    <span style={{ fontSize: 16 }}>📊</span>
-                    <span style={{ fontWeight: 600, fontSize: 14 }}>Study Dashboard</span>
-                </div>
-                <button
-                    onClick={() => plugin.widget.closePopup()}
-                    style={{
-                        background: 'none',
-                        border: 'none',
-                        fontSize: 18,
-                        cursor: 'pointer',
-                        opacity: 0.6,
-                    }}
-                    title="Close"
-                >
-                    ✕
-                </button>
-            </div>
-
-            {/* Filters */}
-            <div
-                style={{
-                    padding: '12px 16px',
-                    borderBottom: '1px solid var(--rn-clr-border-primary)',
-                    background: 'var(--rn-clr-background-secondary)',
-                    display: 'flex',
-                    gap: 24,
-                    flexWrap: 'wrap',
-                }}
-            >
-                <div>
-                    <div
-                        style={{
-                            fontSize: 10,
-                            fontWeight: 600,
-                            color: 'var(--rn-clr-content-tertiary)',
-                            textTransform: 'uppercase',
-                            marginBottom: 6,
-                        }}
-                    >
-                        Context
-                    </div>
-                    <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
-                        <label
-                            style={{ display: 'flex', alignItems: 'center', gap: 4, fontSize: 12, cursor: 'pointer' }}
+                <div className="flex items-center justify-between gap-2 md:gap-3">
+                    <div className="flex items-center gap-2 md:gap-3">
+                        <svg
+                            xmlns="http://www.w3.org/2000/svg"
+                            className="w-6 h-6 md:w-7 md:h-7"
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            stroke="currentColor"
+                            strokeWidth="2"
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            style={{ color: ACCENT_COLOR }}
                         >
-                            <input
-                                type="radio"
-                                checked={contextMode === 'global'}
-                                onChange={() => setContextMode('global')}
-                            />
-                            Global
-                        </label>
-                        <label
-                            style={{
-                                display: 'flex',
-                                alignItems: 'center',
-                                gap: 4,
-                                fontSize: 12,
-                                cursor: ctxRemId ? 'pointer' : 'not-allowed',
-                                opacity: ctxRemId ? 1 : 0.5,
-                            }}
-                        >
-                            <input
-                                type="radio"
-                                disabled={!ctxRemId}
-                                checked={contextMode === 'document'}
-                                onChange={() => setContextMode('document')}
-                            />
-                            Document
-                        </label>
-                    </div>
-                    {contextMode === 'document' && (
-                        <div style={{ marginTop: 8 }}>
+                            <line x1="18" y1="20" x2="18" y2="10"></line>
+                            <line x1="12" y1="20" x2="12" y2="4"></line>
+                            <line x1="6" y1="20" x2="6" y2="14"></line>
+                        </svg>
+                        <div>
                             <div
-                                style={{
-                                    fontSize: 10,
-                                    fontWeight: 600,
-                                    color: 'var(--rn-clr-content-tertiary)',
-                                    textTransform: 'uppercase',
-                                    marginBottom: 4,
-                                }}
+                                className="font-bold text-lg md:text-2xl"
+                                style={{ color: 'var(--rn-clr-content-primary)' }}
                             >
-                                Scope
+                                Study Dashboard
                             </div>
-                            <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
-                                <label style={{ fontSize: 12, cursor: 'pointer' }}>
-                                    <input
-                                        type="radio"
-                                        checked={scope === 'descendants'}
-                                        onChange={() => setScope('descendants')}
-                                    />{' '}
-                                    Descendants Only
-                                </label>
-                                <label style={{ fontSize: 12, cursor: 'pointer' }}>
-                                    <input
-                                        type="radio"
-                                        checked={scope === 'comprehensive'}
-                                        onChange={() => setScope('comprehensive')}
-                                    />{' '}
-                                    Comprehensive
-                                </label>
+                            <div className="text-xs md:text-sm opacity-60 hidden sm:block">
+                                Filterable summary of Incremental, Dismissed, and Flashcard activity
                             </div>
                         </div>
-                    )}
-                </div>
-                <div style={{ flex: 1 }}>
-                    <div
-                        style={{
-                            fontSize: 10,
-                            fontWeight: 600,
-                            color: 'var(--rn-clr-content-tertiary)',
-                            textTransform: 'uppercase',
-                            marginBottom: 6,
-                        }}
-                    >
-                        Period
                     </div>
-                    <PeriodPicker
-                        period={period}
-                        onChange={setPeriod}
-                        customStart={customStart}
-                        customEnd={customEnd}
-                        onCustomChange={(s, e) => {
-                            setCustomStart(s);
-                            setCustomEnd(e);
+                    <button
+                        onClick={() => plugin.widget.closePopup()}
+                        className="flex items-center justify-center p-2 rounded-lg transition-all hover:opacity-80"
+                        style={{
+                            backgroundColor: 'var(--rn-clr-background-secondary)',
+                            border: '1px solid var(--rn-clr-border-primary)',
+                            cursor: 'pointer',
                         }}
-                    />
+                        title="Close"
+                    >
+                        <svg
+                            xmlns="http://www.w3.org/2000/svg"
+                            width="20"
+                            height="20"
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            stroke="currentColor"
+                            strokeWidth="2"
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                        >
+                            <line x1="18" y1="6" x2="6" y2="18"></line>
+                            <line x1="6" y1="6" x2="18" y2="18"></line>
+                        </svg>
+                    </button>
                 </div>
             </div>
 
-            {/* Progress / Summary / Hierarchy */}
-            <div style={{ flex: 1, overflowY: 'auto' }}>
+            {/* Scrollable body */}
+            <div className="custom-scroll" style={{ flex: '1 1 0', overflowY: 'auto', overflowX: 'hidden', padding: '1rem' }}>
+                {/* --- Controls section --- */}
+                <div
+                    className="mb-6 p-4 md:p-6 border rounded-lg shadow-sm fade-in"
+                    style={{ ...getBoxStyle(), borderRadius: '12px' }}
+                >
+                    <div className="flex flex-col md:flex-row gap-6">
+                        {/* Context column */}
+                        <div
+                            className="flex-1 md:border-r md:pr-6 flex flex-col pb-4 md:pb-0 border-b md:border-b-0"
+                            style={{ borderColor: 'var(--rn-clr-border-primary)' }}
+                        >
+                            <div className="flex items-center gap-2 mb-2 md:mb-3">
+                                <svg
+                                    xmlns="http://www.w3.org/2000/svg"
+                                    className="w-4 h-4"
+                                    viewBox="0 0 24 24"
+                                    fill="none"
+                                    stroke="currentColor"
+                                    strokeWidth="2"
+                                    strokeLinecap="round"
+                                    strokeLinejoin="round"
+                                    style={{ opacity: 0.7 }}
+                                >
+                                    <path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"></path>
+                                </svg>
+                                <h4 className="font-bold text-xs md:text-sm uppercase tracking-wide opacity-70">
+                                    Context
+                                </h4>
+                            </div>
+                            <div className="flex flex-col gap-1.5 md:gap-2">
+                                <label className="flex items-center space-x-2 cursor-pointer text-sm md:text-base">
+                                    <input
+                                        type="radio"
+                                        checked={contextMode === 'global'}
+                                        onChange={() => setContextMode('global')}
+                                        className="form-radio w-4 h-4"
+                                        style={{ accentColor: ACCENT_COLOR }}
+                                    />
+                                    <span>Global</span>
+                                </label>
+                                <label
+                                    className="flex items-center space-x-2 cursor-pointer text-sm md:text-base"
+                                    style={{ opacity: ctxRemId ? 1 : 0.5, cursor: ctxRemId ? 'pointer' : 'not-allowed' }}
+                                >
+                                    <input
+                                        type="radio"
+                                        disabled={!ctxRemId}
+                                        checked={contextMode === 'document'}
+                                        onChange={() => setContextMode('document')}
+                                        className="form-radio w-4 h-4"
+                                        style={{ accentColor: ACCENT_COLOR }}
+                                    />
+                                    <span>Document</span>
+                                </label>
+                            </div>
+
+                            {contextMode === 'document' && (
+                                <div className="mt-2 pl-6 flex flex-col gap-1">
+                                    <div className="text-xs opacity-50 uppercase tracking-wide mb-1">Scope</div>
+                                    <label className="flex items-center space-x-2 cursor-pointer text-xs">
+                                        <input
+                                            type="radio"
+                                            checked={scope === 'descendants'}
+                                            onChange={() => setScope('descendants')}
+                                            className="form-radio h-3 w-3"
+                                            style={{ accentColor: ACCENT_COLOR }}
+                                        />
+                                        <span>Descendants Only</span>
+                                    </label>
+                                    <label className="flex items-center space-x-2 cursor-pointer text-xs">
+                                        <input
+                                            type="radio"
+                                            checked={scope === 'comprehensive'}
+                                            onChange={() => setScope('comprehensive')}
+                                            className="form-radio h-3 w-3"
+                                            style={{ accentColor: ACCENT_COLOR }}
+                                        />
+                                        <span>Comprehensive</span>
+                                        <span
+                                            className="opacity-50 hover:opacity-100 cursor-help transition-opacity"
+                                            title="Descendants, Rems that reference or are tagged with this rem and its descendants, Sources, Portals and Table Views"
+                                        >
+                                            <svg
+                                                xmlns="http://www.w3.org/2000/svg"
+                                                width="14"
+                                                height="14"
+                                                viewBox="0 0 24 24"
+                                                fill="none"
+                                                stroke="currentColor"
+                                                strokeWidth="2"
+                                                strokeLinecap="round"
+                                                strokeLinejoin="round"
+                                            >
+                                                <circle cx="12" cy="12" r="10"></circle>
+                                                <line x1="12" y1="16" x2="12" y2="12"></line>
+                                                <line x1="12" y1="8" x2="12.01" y2="8"></line>
+                                            </svg>
+                                        </span>
+                                    </label>
+                                </div>
+                            )}
+                        </div>
+
+                        {/* Period column */}
+                        <div className="flex-[3] flex flex-col gap-2 md:gap-3">
+                            <div className="flex items-center gap-2 mb-2 md:mb-3">
+                                <svg
+                                    xmlns="http://www.w3.org/2000/svg"
+                                    className="w-4 h-4"
+                                    viewBox="0 0 24 24"
+                                    fill="none"
+                                    stroke="currentColor"
+                                    strokeWidth="2"
+                                    strokeLinecap="round"
+                                    strokeLinejoin="round"
+                                    style={{ opacity: 0.7 }}
+                                >
+                                    <rect x="3" y="4" width="18" height="18" rx="2" ry="2"></rect>
+                                    <line x1="16" y1="2" x2="16" y2="6"></line>
+                                    <line x1="8" y1="2" x2="8" y2="6"></line>
+                                    <line x1="3" y1="10" x2="21" y2="10"></line>
+                                </svg>
+                                <h4 className="font-bold text-xs md:text-sm uppercase tracking-wide opacity-70">
+                                    Period
+                                </h4>
+                            </div>
+                            <PeriodPicker
+                                period={period}
+                                onChange={setPeriod}
+                                customStart={customStart}
+                                customEnd={customEnd}
+                                onCustomChange={(s, e) => {
+                                    setCustomStart(s);
+                                    setCustomEnd(e);
+                                }}
+                            />
+                        </div>
+                    </div>
+                </div>
+
+                {/* Progress / Summary / Hierarchy */}
                 {progress.running && (
                     <div style={{ padding: '12px 16px' }}>
                         <div

--- a/src/widgets/study_dashboard.tsx
+++ b/src/widgets/study_dashboard.tsx
@@ -566,22 +566,24 @@ async function loadDocumentData(
 
     onProgress(0.87, 'Resolving ancestors…');
 
-    // For comprehensive: walk parents to add structural ancestors not in scope.
+    // Walk every in-scope node's parent chain — both data-bearing rems AND structural
+    // stubs — and add any unseen ancestors as new structural stubs. Doing this for both
+    // scope modes (not just comprehensive) protects against fragmented trees when a
+    // rem's `.parent` points outside whatever the scope-builder gathered.
     const ancestorIds = new Set<string>();
     const inScopeSet = new Set<string>([...Object.keys(remDataById), ...Object.keys(stubData)]);
-    if (scope === 'comprehensive') {
-        for (const rd of remDataList) {
-            let p = rd.parentId;
-            while (p && !inScopeSet.has(p) && !ancestorIds.has(p)) {
-                ancestorIds.add(p);
-                let ancestor = pluginRemById.get(p);
-                if (!ancestor) {
-                    ancestor = (await plugin.rem.findOne(p)) || undefined;
-                    if (ancestor) pluginRemById.set(p, ancestor);
-                }
-                if (!ancestor) break;
-                p = ancestor.parent || null;
+    const startingIds: string[] = [...Object.keys(remDataById), ...Object.keys(stubData)];
+    for (const id of startingIds) {
+        let p = (remDataById[id]?.parentId ?? stubData[id]?.parentId) || null;
+        while (p && !inScopeSet.has(p) && !ancestorIds.has(p)) {
+            ancestorIds.add(p);
+            let ancestor = pluginRemById.get(p);
+            if (!ancestor) {
+                ancestor = (await plugin.rem.findOne(p)) || undefined;
+                if (ancestor) pluginRemById.set(p, ancestor);
             }
+            if (!ancestor) break;
+            p = ancestor.parent || null;
         }
     }
     for (const id of ancestorIds) {
@@ -674,11 +676,34 @@ function aggregateDocumentData(
 
     for (const rid of rawRootIds) compute(rid);
 
-    // Drop roots whose entire subtree has no reps in the selected period.
-    const filteredRootIds = rawRootIds.filter((id) => {
-        const n = nodes[id];
-        return n && (n.aggr.incRemReps > 0 || n.aggr.cardReps > 0);
-    });
+    // Drop roots whose entire subtree has no reps in the selected period, then
+    // sort by total time descending (same convention as Global mode).
+    const filteredRootIds = rawRootIds
+        .filter((id) => {
+            const n = nodes[id];
+            return n && (n.aggr.incRemReps > 0 || n.aggr.cardReps > 0);
+        })
+        .sort((a, b) => {
+            const na = nodes[a].aggr;
+            const nb = nodes[b].aggr;
+            const tA = na.cardTimeMs + na.incRemTimeSec * 1000;
+            const tB = nb.cardTimeMs + nb.incRemTimeSec * 1000;
+            return tB - tA;
+        });
+
+    // Also sort each node's filtered children by total time descending.
+    for (const id of Object.keys(nodes)) {
+        const node = nodes[id];
+        if (node.childrenIds.length > 1) {
+            node.childrenIds.sort((a, b) => {
+                const na = nodes[a].aggr;
+                const nb = nodes[b].aggr;
+                const tA = na.cardTimeMs + na.incRemTimeSec * 1000;
+                const tB = nb.cardTimeMs + nb.incRemTimeSec * 1000;
+                return tB - tA;
+            });
+        }
+    }
 
     // Summary — walk remDataList directly.
     const summary: SummaryStats = {
@@ -1148,6 +1173,20 @@ function aggregateGlobalData(
             return nodes[id];
         };
         compute(topId);
+
+        // Sort each node's children by total time descending.
+        for (const nid of Object.keys(nodes)) {
+            const n = nodes[nid];
+            if (n.childrenIds.length > 1) {
+                n.childrenIds.sort((a, b) => {
+                    const na = nodes[a].aggr;
+                    const nb = nodes[b].aggr;
+                    const tA = na.cardTimeMs + na.incRemTimeSec * 1000;
+                    const tB = nb.cardTimeMs + nb.incRemTimeSec * 1000;
+                    return tB - tA;
+                });
+            }
+        }
 
         subtreesByTop.set(topId, { nodes, rootIds: [topId] });
     }

--- a/src/widgets/study_dashboard.tsx
+++ b/src/widgets/study_dashboard.tsx
@@ -20,7 +20,7 @@ import { CARD_PRIORITY_CODE } from '../lib/card_priority/types';
 import { buildComprehensiveScope } from '../lib/scope_helpers';
 import { formatDuration, tryParseJson } from '../lib/utils';
 import { resolveRemTextSegments } from '../lib/richTextRemRefs';
-import { RemTextSegments } from '../components';
+import { RemText, RemTextSegments } from '../components';
 import '../style.css';
 import '../App.css';
 
@@ -1786,20 +1786,14 @@ function StudyDashboardPopup() {
     }, []);
     const ctxRemId: string | undefined = (ctx as any)?.contextData?.remId;
 
-    const [contextMode, setContextMode] = useState<ContextMode>(
-        ctxRemId ? 'document' : 'global'
-    );
+    // Default to Global: it's the most common entry point and avoids surprising
+    // the user by silently scoping to whatever rem they happened to have focused.
+    // The user can switch to Document at any time (still allowed only when ctxRemId is present).
+    const [contextMode, setContextMode] = useState<ContextMode>('global');
     const [scope, setScope] = useState<ScopeMode>('comprehensive');
-    const [period, setPeriod] = useState<Period>('today');
+    const [period, setPeriod] = useState<Period>('thisYear');
     const [customStart, setCustomStart] = useState('');
     const [customEnd, setCustomEnd] = useState('');
-
-    useEffect(() => {
-        // Update default context once ctx loads
-        if (ctxRemId && contextMode !== 'document') {
-            setContextMode('document');
-        }
-    }, [ctxRemId]);
 
     const { startMs, endMs } = useMemo(
         () => resolvePeriod(period, customStart, customEnd),
@@ -2017,10 +2011,7 @@ function StudyDashboardPopup() {
                 >
                     <div className="flex flex-col md:flex-row gap-6">
                         {/* Context column */}
-                        <div
-                            className="flex-1 md:border-r md:pr-6 flex flex-col pb-4 md:pb-0 border-b md:border-b-0"
-                            style={{ borderColor: 'var(--rn-clr-border-primary)' }}
-                        >
+                        <div className="flex-1 md:pr-6 flex flex-col pb-4 md:pb-0">
                             <div className="flex items-center gap-2 mb-2 md:mb-3">
                                 <svg
                                     xmlns="http://www.w3.org/2000/svg"
@@ -2062,7 +2053,13 @@ function StudyDashboardPopup() {
                                         className="form-radio w-4 h-4"
                                         style={{ accentColor: ACCENT_COLOR }}
                                     />
-                                    <span>Document</span>
+                                    <span
+                                        className="truncate"
+                                        style={{ maxWidth: '28ch', display: 'inline-block', verticalAlign: 'bottom' }}
+                                        title={ctxRemId ? undefined : 'No rem context — open the dashboard from an editor or queue card to enable Document mode.'}
+                                    >
+                                        {ctxRemId ? <RemText remId={ctxRemId} /> : 'Document'}
+                                    </span>
                                 </label>
                             </div>
 

--- a/src/widgets/study_dashboard.tsx
+++ b/src/widgets/study_dashboard.tsx
@@ -1508,6 +1508,12 @@ function HierarchyRow({
     const retention = a.cardReps > 0 ? (remembered / a.cardReps) * 100 : 0;
     const isStructural = !node.selfData;
 
+    // Subtle per-level shading so the eye can follow the hierarchy. Uses a neutral
+    // grey with alpha so it works in both light and dark themes. Caps at depth 6 to
+    // avoid the background getting too dark for very deep nesting.
+    const shadeAlpha = depth === 0 ? 0 : Math.min(0.04 + (depth - 1) * 0.025, 0.16);
+    const rowBg = shadeAlpha > 0 ? `rgba(127, 127, 127, ${shadeAlpha})` : 'transparent';
+
     return (
         <div
             style={{
@@ -1520,6 +1526,7 @@ function HierarchyRow({
                 cursor: hasChildren ? 'pointer' : 'default',
                 alignItems: 'center',
                 opacity: isStructural ? 0.8 : 1,
+                background: rowBg,
             }}
             onClick={(e) => {
                 if (hasChildren) {

--- a/src/widgets/study_dashboard.tsx
+++ b/src/widgets/study_dashboard.tsx
@@ -16,6 +16,7 @@ import {
     powerupCode,
     repHistorySlotCode,
 } from '../lib/consts';
+import { CARD_PRIORITY_CODE } from '../lib/card_priority/types';
 import { buildComprehensiveScope } from '../lib/scope_helpers';
 import { formatDuration, tryParseJson } from '../lib/utils';
 import { resolveRemTextSegments } from '../lib/richTextRemRefs';
@@ -619,40 +620,59 @@ async function buildDocumentTree(
     return { tree: { nodes, rootIds }, summary };
 }
 
-async function buildGlobalDashboard(
-    plugin: ReturnType<typeof usePlugin>,
-    startMs: number,
-    endMs: number,
-    cardCapMs: number,
-    onProgress: (p: number, label: string) => void
-): Promise<{
-    topLevels: DashboardData['topLevels'];
-    summary: SummaryStats;
-    // also keep a parent-chain cache so subtree expansion is faster
-    parentChainCache: Map<string, string[]>;
-    // map of remId -> RemData for any rem we've already loaded (incremental / dismissed / card-bearing)
+// Period-independent loaded data — fetched once per (re)load and reused across
+// period changes. Caches survive between aggregations so subsequent aggregations
+// hit zero RPCs.
+interface LoadedGlobalData {
     remDataById: Map<string, RemData>;
-    // Pre-built subtrees keyed by top-level rem id — expansion is instant.
-    subtreesByTop: Map<string, BuiltTree>;
-}> {
+    parentChainCache: Map<string, string[]>;
+    remTextCache: Map<string, any>;
+    // Pre-populated parent map sourced from taggedRem PluginRems (free `.parent` access).
+    // Covers Incremental + Dismissed + cardPriority rems — typically ~all rems-with-data
+    // in a healthy KB, so chain walks need almost no `findOne` RPCs.
+    parentByRemId: Map<string, string | null>;
+}
+
+async function loadGlobalData(
+    plugin: ReturnType<typeof usePlugin>,
+    onProgress: (p: number, label: string) => void
+): Promise<LoadedGlobalData> {
     onProgress(0.02, 'Fetching tagged rems…');
 
-    const incPup = await plugin.powerup.getPowerupByCode(powerupCode);
-    const dismPup = await plugin.powerup.getPowerupByCode(dismissedPowerupCode);
-    const [incRems, dismRems, allCards] = await Promise.all([
+    const [incPup, dismPup, cpPup] = await Promise.all([
+        plugin.powerup.getPowerupByCode(powerupCode),
+        plugin.powerup.getPowerupByCode(dismissedPowerupCode),
+        plugin.powerup.getPowerupByCode(CARD_PRIORITY_CODE),
+    ]);
+    const [incRems, dismRems, cpRems, allCards] = await Promise.all([
         (incPup?.taggedRem() as Promise<PluginRem[] | undefined>) || Promise.resolve([]),
         (dismPup?.taggedRem() as Promise<PluginRem[] | undefined>) || Promise.resolve([]),
+        (cpPup?.taggedRem() as Promise<PluginRem[] | undefined>) || Promise.resolve([]),
         plugin.card.getAll(),
     ]);
     const incList = incRems || [];
     const dismList = dismRems || [];
+    const cpList = cpRems || [];
 
     onProgress(
-        0.1,
-        `Inc: ${incList.length}, Dism: ${dismList.length}, Cards: ${allCards?.length || 0}`
+        0.08,
+        `Inc: ${incList.length}, Dism: ${dismList.length}, CardPri: ${cpList.length}, Cards: ${allCards?.length || 0}`
     );
 
-    // Index unique tagged rems
+    // Pre-populate parent and text caches from every taggedRem PluginRem we have.
+    // For ~all rems-with-data in a healthy KB this eliminates the need to call
+    // `findOne` during chain walking — chains become essentially in-memory.
+    const parentByRemId = new Map<string, string | null>();
+    const remTextCache = new Map<string, any>();
+    const seedParent = (r: PluginRem) => {
+        if (!parentByRemId.has(r._id)) parentByRemId.set(r._id, r.parent || null);
+        if (!remTextCache.has(r._id)) remTextCache.set(r._id, r.text);
+    };
+    for (const r of cpList) seedParent(r);
+    for (const r of incList) seedParent(r);
+    for (const r of dismList) seedParent(r);
+
+    // Index unique inc/dism tagged rems — we need to read their histories.
     const taggedById = new Map<string, PluginRem>();
     for (const r of incList) taggedById.set(r._id, r);
     for (const r of dismList) taggedById.set(r._id, r);
@@ -670,10 +690,10 @@ async function buildGlobalDashboard(
             return null;
         },
         (done, total) =>
-            onProgress(0.1 + 0.4 * (done / Math.max(1, total)), `History (${done}/${total})`)
+            onProgress(0.08 + 0.55 * (done / Math.max(1, total)), `History (${done}/${total})`)
     );
 
-    onProgress(0.55, 'Processing cards…');
+    onProgress(0.65, 'Processing cards…');
 
     // Group cards by remId. We use plugin.card.getAll() rather than per-rem fetches.
     const cardsByRem = new Map<string, CardData[]>();
@@ -698,10 +718,12 @@ async function buildGlobalDashboard(
         if (existing) {
             existing.cards = cards;
         } else {
+            // Card-only rem. Pull parent/text from the cardPriority-seeded map if
+            // present; otherwise leave null and ancestorChain will findOne lazily.
             remDataById.set(remId, {
                 id: remId,
-                parentId: null, // resolved later when computing parent chain
-                remText: null,
+                parentId: parentByRemId.has(remId) ? parentByRemId.get(remId) || null : null,
+                remText: remTextCache.get(remId) ?? null,
                 isInc: false,
                 isDism: false,
                 incHistory: [],
@@ -711,26 +733,28 @@ async function buildGlobalDashboard(
         }
     }
 
-    onProgress(0.65, 'Walking ancestor chains…');
+    onProgress(0.7, 'Walking ancestor chains…');
 
     // Parent-chain cache: remId -> [self, parent, grandparent, ..., topAncestor]
     const parentChainCache = new Map<string, string[]>();
-    // Stash text for every rem we touch while walking chains; this avoids a
-    // second pass to fetch text for structural ancestor nodes when building subtrees.
-    const remTextCache = new Map<string, any>();
     // In-flight chain promises so concurrent callers share work for shared ancestors.
-    // Without this, parallel sibling rems would each re-walk the same parent path,
-    // multiplying RPC traffic and pushing the WebSocket into timeout territory.
     const inFlightChains = new Map<string, Promise<string[]>>();
     const buildChain = async (id: string): Promise<string[]> => {
-        const r: PluginRem | undefined = await plugin.rem.findOne(id);
-        if (!r) {
-            const chain = [id];
-            parentChainCache.set(id, chain);
-            return chain;
+        let parentId: string | null;
+        if (parentByRemId.has(id)) {
+            // We already know the parent (from a taggedRem PluginRem) — no RPC needed.
+            parentId = parentByRemId.get(id) || null;
+        } else {
+            const r: PluginRem | undefined = await plugin.rem.findOne(id);
+            if (!r) {
+                const chain = [id];
+                parentChainCache.set(id, chain);
+                return chain;
+            }
+            parentId = r.parent || null;
+            parentByRemId.set(id, parentId);
+            if (!remTextCache.has(id)) remTextCache.set(id, r.text);
         }
-        if (!remTextCache.has(id)) remTextCache.set(id, r.text);
-        const parentId = r.parent || null;
         const parentChain = parentId ? await ancestorChain(parentId) : [];
         const chain = [id, ...parentChain];
         parentChainCache.set(id, chain);
@@ -749,6 +773,52 @@ async function buildGlobalDashboard(
             inFlightChains.delete(id);
         }
     }
+
+    // Walk chains for every rem-with-data. With parentByRemId mostly populated this is
+    // dominated by in-memory work; only un-tagged ancestors (rare) trigger findOne.
+    const remEntries = Array.from(remDataById.values());
+    const WALK_CHUNK = 50;
+    let walked = 0;
+    for (let i = 0; i < remEntries.length; i += WALK_CHUNK) {
+        const chunk = remEntries.slice(i, i + WALK_CHUNK);
+        await Promise.all(
+            chunk.map(async (rd) => {
+                await ancestorChain(rd.id);
+                // Fill in parentId / remText if we now have them and didn't before.
+                if (rd.parentId === null && parentByRemId.has(rd.id)) {
+                    rd.parentId = parentByRemId.get(rd.id) || null;
+                }
+                if (!rd.remText && remTextCache.has(rd.id)) {
+                    rd.remText = remTextCache.get(rd.id);
+                }
+            })
+        );
+        walked += chunk.length;
+        onProgress(
+            0.7 + 0.28 * (walked / Math.max(1, remEntries.length)),
+            `Resolving (${walked}/${remEntries.length})`
+        );
+    }
+
+    onProgress(1, 'Loaded');
+    return { remDataById, parentChainCache, remTextCache, parentByRemId };
+}
+
+// Aggregate already-loaded data for a specific period. Pure in-memory work —
+// no RPC calls. Safe to call repeatedly on period changes.
+function aggregateGlobalData(
+    data: LoadedGlobalData,
+    startMs: number,
+    endMs: number,
+    cardCapMs: number,
+    onProgress: (p: number, label: string) => void
+): {
+    topLevels: DashboardData['topLevels'];
+    summary: SummaryStats;
+    subtreesByTop: Map<string, BuiltTree>;
+} {
+    const { remDataById, parentChainCache, remTextCache } = data;
+    onProgress(0.05, 'Aggregating…');
 
     // For every rem with data in the period, attribute to its top ancestor.
     const summary: SummaryStats = {
@@ -795,96 +865,73 @@ async function buildGlobalDashboard(
         return t;
     };
 
+    // Walk remDataById in-memory — all chains were resolved during loadGlobalData,
+    // so this is pure CPU work (no awaits).
     const remEntries = Array.from(remDataById.values());
-    const AGG_CHUNK = 50;
-    let processed = 0;
-    for (let i = 0; i < remEntries.length; i += AGG_CHUNK) {
-        const chunk = remEntries.slice(i, i + AGG_CHUNK);
-        // Resolve ancestor chains in parallel; the shared inFlightChains cache
-        // makes sibling rems reuse each other's parent lookups instead of
-        // duplicating RPC traffic, which is what was overwhelming the WebSocket.
-        const resolved = await Promise.all(
-            chunk.map(async (rd) => {
-                if (rd.parentId === null && !parentChainCache.has(rd.id)) {
-                    const r = await plugin.rem.findOne(rd.id);
-                    rd.parentId = r?.parent || null;
-                    if (r) rd.remText = rd.remText ?? r.text;
-                }
-                const chain = await ancestorChain(rd.id);
-                return { rd, chain };
-            })
-        );
-
-        // Accumulator updates are in-memory; do them sequentially to avoid races on shared maps.
-        for (const { rd, chain } of resolved) {
-            const topId = chain[chain.length - 1] || rd.id;
-            const { self, hasIncReps, hasDismReps } = statsFromRem(rd, startMs, endMs, cardCapMs);
-            const top = ensureTop(topId);
-            top.aggr = addStats(top.aggr, self);
-            if (rd.isInc) {
-                top.aggrIncTagged += 1;
-                summary.incTaggedCount += 1;
-                if (hasIncReps) {
-                    top.aggrIncTaggedWithReps += 1;
-                    summary.incTaggedWithRepsCount += 1;
-                }
-                let incReps = 0;
-                let incTime = 0;
-                for (const rep of rd.incHistory) {
-                    if (!rep || typeof rep.date !== 'number') continue;
-                    if (rep.date < startMs || rep.date >= endMs) continue;
-                    if (!isRealIncRep(rep.eventType)) continue;
-                    incReps += 1;
-                    incTime += rep.reviewTimeSeconds || 0;
-                }
-                summary.incReps += incReps;
-                summary.incTimeSec += incTime;
+    for (let i = 0; i < remEntries.length; i++) {
+        const rd = remEntries[i];
+        const chain = parentChainCache.get(rd.id) || [rd.id];
+        const topId = chain[chain.length - 1] || rd.id;
+        const { self, hasIncReps, hasDismReps } = statsFromRem(rd, startMs, endMs, cardCapMs);
+        const top = ensureTop(topId);
+        top.aggr = addStats(top.aggr, self);
+        if (rd.isInc) {
+            top.aggrIncTagged += 1;
+            summary.incTaggedCount += 1;
+            if (hasIncReps) {
+                top.aggrIncTaggedWithReps += 1;
+                summary.incTaggedWithRepsCount += 1;
             }
-            if (rd.isDism) {
-                top.aggrDismTagged += 1;
-                summary.dismTaggedCount += 1;
-                if (hasDismReps) {
-                    top.aggrDismTaggedWithReps += 1;
-                    summary.dismTaggedWithRepsCount += 1;
-                }
-                let dismReps = 0;
-                let dismTime = 0;
-                for (const rep of rd.dismHistory) {
-                    if (!rep || typeof rep.date !== 'number') continue;
-                    if (rep.date < startMs || rep.date >= endMs) continue;
-                    if (!isRealIncRep(rep.eventType)) continue;
-                    dismReps += 1;
-                    dismTime += rep.reviewTimeSeconds || 0;
-                }
-                summary.dismReps += dismReps;
-                summary.dismTimeSec += dismTime;
+            let incReps = 0;
+            let incTime = 0;
+            for (const rep of rd.incHistory) {
+                if (!rep || typeof rep.date !== 'number') continue;
+                if (rep.date < startMs || rep.date >= endMs) continue;
+                if (!isRealIncRep(rep.eventType)) continue;
+                incReps += 1;
+                incTime += rep.reviewTimeSeconds || 0;
             }
-            top.aggrCardsCount += rd.cards.length;
-            summary.cardsCount += rd.cards.length;
-            for (const card of rd.cards) {
-                let cardHasReps = false;
-                for (const rep of card.history || []) {
-                    if (!rep || typeof rep.date !== 'number') continue;
-                    if (rep.date < startMs || rep.date >= endMs) continue;
-                    if (!isRealCardScore(rep.score)) continue;
-                    const t = Math.min(Math.max(0, rep.responseTime || 0), cardCapMs);
-                    summary.cardReps += 1;
-                    summary.cardTimeMs += t;
-                    if (rep.score === QueueInteractionScore.AGAIN) summary.cardForgot += 1;
-                    cardHasReps = true;
-                }
-                if (cardHasReps) summary.cardsWithRepsCount += 1;
-            }
+            summary.incReps += incReps;
+            summary.incTimeSec += incTime;
         }
-
-        processed += chunk.length;
-        onProgress(
-            0.65 + 0.3 * (processed / Math.max(1, remEntries.length)),
-            `Aggregating (${processed}/${remEntries.length})`
-        );
+        if (rd.isDism) {
+            top.aggrDismTagged += 1;
+            summary.dismTaggedCount += 1;
+            if (hasDismReps) {
+                top.aggrDismTaggedWithReps += 1;
+                summary.dismTaggedWithRepsCount += 1;
+            }
+            let dismReps = 0;
+            let dismTime = 0;
+            for (const rep of rd.dismHistory) {
+                if (!rep || typeof rep.date !== 'number') continue;
+                if (rep.date < startMs || rep.date >= endMs) continue;
+                if (!isRealIncRep(rep.eventType)) continue;
+                dismReps += 1;
+                dismTime += rep.reviewTimeSeconds || 0;
+            }
+            summary.dismReps += dismReps;
+            summary.dismTimeSec += dismTime;
+        }
+        top.aggrCardsCount += rd.cards.length;
+        summary.cardsCount += rd.cards.length;
+        for (const card of rd.cards) {
+            let cardHasReps = false;
+            for (const rep of card.history || []) {
+                if (!rep || typeof rep.date !== 'number') continue;
+                if (rep.date < startMs || rep.date >= endMs) continue;
+                if (!isRealCardScore(rep.score)) continue;
+                const t = Math.min(Math.max(0, rep.responseTime || 0), cardCapMs);
+                summary.cardReps += 1;
+                summary.cardTimeMs += t;
+                if (rep.score === QueueInteractionScore.AGAIN) summary.cardForgot += 1;
+                cardHasReps = true;
+            }
+            if (cardHasReps) summary.cardsWithRepsCount += 1;
+        }
     }
 
-    onProgress(0.95, 'Building subtrees…');
+    onProgress(0.7, 'Building subtrees…');
 
     // Pre-build a subtree per top-level using already-gathered data. No new RPC calls.
     // For each rem-with-data, its parent chain (already cached) gives us its position in
@@ -975,15 +1022,13 @@ async function buildGlobalDashboard(
         subtreesByTop.set(topId, { nodes, rootIds: [topId] });
     }
 
-    onProgress(0.99, 'Sorting…');
-
     const topLevels = Array.from(topAggrs.entries())
         .map(([topId, v]) => ({ topId, ...v }))
         .filter((t) => t.aggr.incRemReps > 0 || t.aggr.cardReps > 0)
         .sort((a, b) => b.aggr.cardTimeMs + b.aggr.incRemTimeSec * 1000 - (a.aggr.cardTimeMs + a.aggr.incRemTimeSec * 1000));
 
     onProgress(1, 'Done');
-    return { topLevels, summary, parentChainCache, remDataById, subtreesByTop };
+    return { topLevels, summary, subtreesByTop };
 }
 
 // ---------------------------------------------------------------------------
@@ -1633,6 +1678,9 @@ function StudyDashboardPopup() {
     );
     const [summary, setSummary] = useState<SummaryStats | null>(null);
     const runIdRef = useRef(0);
+    // Cached global-mode raw data — survives across period changes.
+    // Invalidated only when the context switches into Global from scratch (per session).
+    const globalDataRef = useRef<LoadedGlobalData | null>(null);
 
     const run = useCallback(async () => {
         if (cardCapMs == null) return;
@@ -1666,10 +1714,26 @@ function StudyDashboardPopup() {
                 setDocTree(tree);
                 setSummary(s);
             } else {
-                const r = await buildGlobalDashboard(plugin, startMs, endMs, cardCapMs, (p, label) => {
+                // Load raw data once and cache. Period changes only re-aggregate (in-memory).
+                if (!globalDataRef.current) {
+                    const loaded = await loadGlobalData(plugin, (p, label) => {
+                        if (runId !== runIdRef.current) return;
+                        // Loading occupies the first 80% of the progress bar.
+                        setProgress({ running: true, percent: 0.8 * p, label });
+                    });
                     if (runId !== runIdRef.current) return;
-                    setProgress({ running: true, percent: p, label });
-                });
+                    globalDataRef.current = loaded;
+                }
+                const r = aggregateGlobalData(
+                    globalDataRef.current,
+                    startMs,
+                    endMs,
+                    cardCapMs,
+                    (p, label) => {
+                        if (runId !== runIdRef.current) return;
+                        setProgress({ running: true, percent: 0.8 + 0.2 * p, label });
+                    }
+                );
                 if (runId !== runIdRef.current) return;
                 setGlobalTops(r.topLevels);
                 setGlobalSubtreesByTop(r.subtreesByTop);

--- a/src/widgets/study_dashboard.tsx
+++ b/src/widgets/study_dashboard.tsx
@@ -401,15 +401,23 @@ async function loadRemData(
     };
 }
 
-async function buildDocumentTree(
+// Period-independent loaded data for Document mode. Cached per (rootRemId, scope).
+interface LoadedDocumentData {
+    rootRemId: string;
+    scope: ScopeMode;
+    remDataList: RemData[];
+    remDataById: Record<string, RemData>;
+    stubData: Record<string, { parentId: string | null; remText: any }>;
+    childMap: Record<string, string[]>;
+    rawRootIds: string[]; // unfiltered roots — period filter applied at aggregate time
+}
+
+async function loadDocumentData(
     plugin: ReturnType<typeof usePlugin>,
     rootRem: PluginRem,
     scope: ScopeMode,
-    startMs: number,
-    endMs: number,
-    cardCapMs: number,
     onProgress: (p: number, label: string) => void
-): Promise<{ tree: BuiltTree; summary: SummaryStats }> {
+): Promise<LoadedDocumentData> {
     onProgress(0.05, 'Gathering rems…');
 
     let inScopeIds: Set<string>;
@@ -443,10 +451,11 @@ async function buildDocumentTree(
     const remDataById: Record<string, RemData> = {};
     for (const rd of remDataList) remDataById[rd.id] = rd;
 
-    onProgress(0.85, 'Building tree…');
+    onProgress(0.85, 'Resolving ancestors…');
 
     // For comprehensive: include structural ancestors not in scope so each in-scope
-    // rem connects upward to a root. We walk parents and add them as ancestor stubs.
+    // rem connects upward to a root. Walk parents in-memory using rd.parentId then
+    // findOne for any ancestor we don't already know.
     const ancestorIds = new Set<string>();
     if (scope === 'comprehensive') {
         for (const rd of remDataList) {
@@ -460,7 +469,7 @@ async function buildDocumentTree(
         }
     }
 
-    // Materialise ancestor stubs
+    // Materialise ancestor stubs in parallel.
     const stubData: Record<string, { parentId: string | null; remText: any }> = {};
     if (ancestorIds.size > 0) {
         const ids = Array.from(ancestorIds);
@@ -471,40 +480,60 @@ async function buildDocumentTree(
         });
     }
 
-    // Build child map
+    onProgress(0.95, 'Building tree…');
+
+    // Build child map (period-independent — just the static hierarchy).
     const allNodeIds = new Set<string>([...Object.keys(remDataById), ...Object.keys(stubData)]);
     const childMap: Record<string, string[]> = {};
-    const rootIds: string[] = [];
+    const rawRootIds: string[] = [];
 
     for (const id of allNodeIds) {
-        const parentId =
-            (remDataById[id]?.parentId ?? stubData[id]?.parentId) || null;
+        const parentId = (remDataById[id]?.parentId ?? stubData[id]?.parentId) || null;
         if (parentId && allNodeIds.has(parentId)) {
             (childMap[parentId] ||= []).push(id);
         } else {
-            rootIds.push(id);
+            rawRootIds.push(id);
         }
     }
 
-    // Compute per-node selfStats and totals, then aggregate bottom-up via DFS.
-    const nodes: Record<string, TreeNode> = {};
+    onProgress(1, 'Loaded');
 
+    return {
+        rootRemId: rootRem._id,
+        scope,
+        remDataList,
+        remDataById,
+        stubData,
+        childMap,
+        rawRootIds,
+    };
+}
+
+// Aggregate already-loaded document data for a specific period. Pure in-memory work.
+function aggregateDocumentData(
+    data: LoadedDocumentData,
+    startMs: number,
+    endMs: number,
+    cardCapMs: number,
+    onProgress: (p: number, label: string) => void
+): { tree: BuiltTree; summary: SummaryStats } {
+    const { remDataList, remDataById, stubData, childMap, rawRootIds } = data;
+    onProgress(0.05, 'Aggregating…');
+
+    const nodes: Record<string, TreeNode> = {};
     function compute(id: string): TreeNode {
         if (nodes[id]) return nodes[id];
-        const data = remDataById[id] || null;
+        const d = remDataById[id] || null;
         const rawChildrenIds = childMap[id] || [];
 
-        const self = data ? statsFromRem(data, startMs, endMs, cardCapMs) : null;
+        const self = d ? statsFromRem(d, startMs, endMs, cardCapMs) : null;
         let aggr = self ? self.self : emptyStats();
-        let aggrIncTagged = data && data.isInc ? 1 : 0;
-        let aggrDismTagged = data && data.isDism ? 1 : 0;
-        let aggrIncTaggedWithReps =
-            data && data.isInc && self && self.hasIncReps ? 1 : 0;
-        let aggrDismTaggedWithReps =
-            data && data.isDism && self && self.hasDismReps ? 1 : 0;
-        let aggrCardsCount = data ? data.cards.length : 0;
+        let aggrIncTagged = d && d.isInc ? 1 : 0;
+        let aggrDismTagged = d && d.isDism ? 1 : 0;
+        let aggrIncTaggedWithReps = d && d.isInc && self && self.hasIncReps ? 1 : 0;
+        let aggrDismTaggedWithReps = d && d.isDism && self && self.hasDismReps ? 1 : 0;
+        let aggrCardsCount = d ? d.cards.length : 0;
 
-        // Keep only children whose subtree has reps in the selected period.
         const childrenIds: string[] = [];
         for (const c of rawChildrenIds) {
             const child = compute(c);
@@ -522,29 +551,27 @@ async function buildDocumentTree(
         nodes[id] = {
             id,
             childrenIds,
-            selfData: data,
+            selfData: d,
             aggr,
             aggrIncTagged,
             aggrDismTagged,
             aggrIncTaggedWithReps,
             aggrDismTaggedWithReps,
             aggrCardsCount,
-            remText: data?.remText ?? stubData[id]?.remText,
+            remText: d?.remText ?? stubData[id]?.remText,
         };
         return nodes[id];
     }
 
-    for (const rid of rootIds) compute(rid);
+    for (const rid of rawRootIds) compute(rid);
 
     // Drop roots whose entire subtree has no reps in the selected period.
-    const filteredRootIds = rootIds.filter((id) => {
+    const filteredRootIds = rawRootIds.filter((id) => {
         const n = nodes[id];
         return n && (n.aggr.incRemReps > 0 || n.aggr.cardReps > 0);
     });
-    rootIds.length = 0;
-    rootIds.push(...filteredRootIds);
 
-    // Summary from root totals: sum aggrs across roots
+    // Summary — walk remDataList directly.
     const summary: SummaryStats = {
         incTaggedCount: 0,
         incTaggedWithRepsCount: 0,
@@ -561,14 +588,11 @@ async function buildDocumentTree(
         cardForgot: 0,
     };
 
-    // Walk all rem-data (not ancestor stubs) to compute summary directly — cleaner than
-    // splitting inc vs dism after-the-fact from aggregated stats.
     for (const rd of remDataList) {
-        const { self, hasIncReps, hasDismReps } = statsFromRem(rd, startMs, endMs, cardCapMs);
+        const { hasIncReps, hasDismReps } = statsFromRem(rd, startMs, endMs, cardCapMs);
         if (rd.isInc) {
             summary.incTaggedCount += 1;
             if (hasIncReps) summary.incTaggedWithRepsCount += 1;
-            // Inc/Dism reps shown separately in summary, so attribute only inc-history reps here.
             let incReps = 0;
             let incTime = 0;
             for (const rep of rd.incHistory) {
@@ -611,13 +635,10 @@ async function buildDocumentTree(
             }
             if (cardHasReps) summary.cardsWithRepsCount += 1;
         }
-        // Unused variable: self — kept above just to compute hasIncReps/hasDismReps.
-        void self;
     }
 
     onProgress(1, 'Done');
-
-    return { tree: { nodes, rootIds }, summary };
+    return { tree: { nodes, rootIds: filteredRootIds }, summary };
 }
 
 // Period-independent loaded data — fetched once per (re)load and reused across
@@ -1681,6 +1702,9 @@ function StudyDashboardPopup() {
     // Cached global-mode raw data — survives across period changes.
     // Invalidated only when the context switches into Global from scratch (per session).
     const globalDataRef = useRef<LoadedGlobalData | null>(null);
+    // Cached document-mode raw data — survives across period changes for the same
+    // (rootRemId, scope). Different rem or scope invalidates and reloads.
+    const docDataRef = useRef<LoadedDocumentData | null>(null);
 
     const run = useCallback(async () => {
         if (cardCapMs == null) return;
@@ -1698,16 +1722,25 @@ function StudyDashboardPopup() {
                     setProgress({ running: false, percent: 0, label: '' });
                     return;
                 }
-                const { tree, summary: s } = await buildDocumentTree(
-                    plugin,
-                    rootRem,
-                    scope,
+                // Reuse cached document data when the rem + scope match; period
+                // changes hit only the aggregate path.
+                const cached = docDataRef.current;
+                if (!cached || cached.rootRemId !== rootRem._id || cached.scope !== scope) {
+                    const loaded = await loadDocumentData(plugin, rootRem, scope, (p, label) => {
+                        if (runId !== runIdRef.current) return;
+                        setProgress({ running: true, percent: 0.8 * p, label });
+                    });
+                    if (runId !== runIdRef.current) return;
+                    docDataRef.current = loaded;
+                }
+                const { tree, summary: s } = aggregateDocumentData(
+                    docDataRef.current!,
                     startMs,
                     endMs,
                     cardCapMs,
                     (p, label) => {
                         if (runId !== runIdRef.current) return;
-                        setProgress({ running: true, percent: p, label });
+                        setProgress({ running: true, percent: 0.8 + 0.2 * p, label });
                     }
                 );
                 if (runId !== runIdRef.current) return;

--- a/src/widgets/study_dashboard.tsx
+++ b/src/widgets/study_dashboard.tsx
@@ -418,66 +418,175 @@ async function loadDocumentData(
     scope: ScopeMode,
     onProgress: (p: number, label: string) => void
 ): Promise<LoadedDocumentData> {
-    onProgress(0.05, 'Gathering rems…');
+    onProgress(0.02, 'Fetching tagged rems…');
 
-    let inScopeIds: Set<string>;
-    let inScopeRems: PluginRem[];
+    // Same bulk strategy as Global: pull inc/dism/cardPriority taggedRems plus all
+    // cards once, then iterate the scope without per-rem hasPowerup / getCards calls.
+    const [incPup, dismPup, cpPup] = await Promise.all([
+        plugin.powerup.getPowerupByCode(powerupCode),
+        plugin.powerup.getPowerupByCode(dismissedPowerupCode),
+        plugin.powerup.getPowerupByCode(CARD_PRIORITY_CODE),
+    ]);
+    const [incRems, dismRems, cpRems, allCards] = await Promise.all([
+        (incPup?.taggedRem() as Promise<PluginRem[] | undefined>) || Promise.resolve([]),
+        (dismPup?.taggedRem() as Promise<PluginRem[] | undefined>) || Promise.resolve([]),
+        (cpPup?.taggedRem() as Promise<PluginRem[] | undefined>) || Promise.resolve([]),
+        plugin.card.getAll(),
+    ]);
 
+    // pluginRemById: every PluginRem we already have (no findOne needed for these).
+    const pluginRemById = new Map<string, PluginRem>();
+    for (const r of cpRems || []) pluginRemById.set(r._id, r);
+    for (const r of incRems || []) pluginRemById.set(r._id, r);
+    for (const r of dismRems || []) pluginRemById.set(r._id, r);
+
+    const incSet = new Set((incRems || []).map((r) => r._id));
+    const dismSet = new Set((dismRems || []).map((r) => r._id));
+
+    const cardsByRem = new Map<string, CardData[]>();
+    for (const c of allCards || []) {
+        const cd: CardData = {
+            id: c._id,
+            remId: c.remId,
+            history: (c as any).repetitionHistory || [],
+        };
+        let arr = cardsByRem.get(c.remId);
+        if (!arr) {
+            arr = [];
+            cardsByRem.set(c.remId, arr);
+        }
+        arr.push(cd);
+    }
+
+    onProgress(0.12, 'Gathering scope…');
+
+    let scopeIds: string[];
     if (scope === 'descendants') {
         const descendants = await rootRem.getDescendants();
         const all = [rootRem, ...descendants];
-        inScopeIds = new Set(all.map((r) => r._id));
-        inScopeRems = all;
+        for (const r of all) {
+            if (!pluginRemById.has(r._id)) pluginRemById.set(r._id, r);
+        }
+        scopeIds = all.map((r) => r._id);
     } else {
-        const scopeIds = await buildComprehensiveScope(plugin, rootRem._id);
-        inScopeIds = new Set(scopeIds);
-        const fetched = await chunked(
-            Array.from(scopeIds),
-            async (id) => plugin.rem.findOne(id),
-            (done, total) =>
-                onProgress(0.05 + 0.15 * (done / Math.max(1, total)), `Loading rems (${done}/${total})`)
-        );
-        inScopeRems = fetched.filter((r): r is PluginRem => !!r);
+        const set = await buildComprehensiveScope(plugin, rootRem._id);
+        scopeIds = Array.from(set);
     }
 
-    onProgress(0.2, `Reading history for ${inScopeRems.length} rems…`);
+    onProgress(0.3, `Resolving ${scopeIds.length} rems…`);
 
-    const remDataList: RemData[] = await chunked(
-        inScopeRems,
-        (r) => loadRemData(plugin, r),
-        (done, total) =>
-            onProgress(0.2 + 0.6 * (done / Math.max(1, total)), `History (${done}/${total})`)
-    );
+    // Any scope ids whose PluginRem we don't already have — fetch in parallel.
+    // For typical KBs this is a small minority since cardPriority covers most.
+    const missingIds: string[] = [];
+    for (const id of scopeIds) {
+        if (!pluginRemById.has(id)) missingIds.push(id);
+    }
+    if (missingIds.length > 0) {
+        await chunked(
+            missingIds,
+            async (id) => {
+                const r = await plugin.rem.findOne(id);
+                if (r) pluginRemById.set(id, r);
+                return null;
+            },
+            (done, total) =>
+                onProgress(0.3 + 0.2 * (done / Math.max(1, total)), `Loading rems (${done}/${total})`)
+        );
+    }
+
+    onProgress(0.5, 'Classifying…');
+
+    // Classify scope rems: data-bearing (inc/dism tagged or has cards) vs structural-only.
+    const remDataList: RemData[] = [];
     const remDataById: Record<string, RemData> = {};
-    for (const rd of remDataList) remDataById[rd.id] = rd;
+    const stubData: Record<string, { parentId: string | null; remText: any }> = {};
+    const taggedScopeIds: string[] = []; // need history reads
 
-    onProgress(0.85, 'Resolving ancestors…');
+    for (const id of scopeIds) {
+        const rem = pluginRemById.get(id);
+        if (!rem) continue;
+        const isInc = incSet.has(id);
+        const isDism = dismSet.has(id);
+        const cards = cardsByRem.get(id) || [];
+        if (isInc || isDism) {
+            taggedScopeIds.push(id);
+        } else if (cards.length > 0) {
+            // Card-only rem: no history to fetch — populate immediately.
+            const rd: RemData = {
+                id,
+                parentId: rem.parent || null,
+                remText: rem.text,
+                isInc: false,
+                isDism: false,
+                incHistory: [],
+                dismHistory: [],
+                cards,
+            };
+            remDataById[id] = rd;
+            remDataList.push(rd);
+        } else {
+            // No data — keep as structural node so the tree stays connected.
+            stubData[id] = { parentId: rem.parent || null, remText: rem.text };
+        }
+    }
 
-    // For comprehensive: include structural ancestors not in scope so each in-scope
-    // rem connects upward to a root. Walk parents in-memory using rd.parentId then
-    // findOne for any ancestor we don't already know.
+    onProgress(0.55, `Reading histories for ${taggedScopeIds.length} tagged rems…`);
+
+    // Read histories only for tagged-in-scope rems — orders of magnitude less than
+    // running loadRemData on every scope rem.
+    await chunked(
+        taggedScopeIds,
+        async (id) => {
+            const rem = pluginRemById.get(id);
+            if (!rem) return null;
+            const isInc = incSet.has(id);
+            const isDism = dismSet.has(id);
+            const cards = cardsByRem.get(id) || [];
+            const [incHistory, dismHistory] = await Promise.all([
+                isInc ? readIncHistoryRaw(rem) : Promise.resolve([] as IncrementalRep[]),
+                isDism ? readDismHistoryRaw(rem) : Promise.resolve([] as IncrementalRep[]),
+            ]);
+            const rd: RemData = {
+                id,
+                parentId: rem.parent || null,
+                remText: rem.text,
+                isInc,
+                isDism,
+                incHistory,
+                dismHistory,
+                cards,
+            };
+            remDataById[id] = rd;
+            remDataList.push(rd);
+            return null;
+        },
+        (done, total) =>
+            onProgress(0.55 + 0.3 * (done / Math.max(1, total)), `Histories (${done}/${total})`)
+    );
+
+    onProgress(0.87, 'Resolving ancestors…');
+
+    // For comprehensive: walk parents to add structural ancestors not in scope.
     const ancestorIds = new Set<string>();
+    const inScopeSet = new Set<string>([...Object.keys(remDataById), ...Object.keys(stubData)]);
     if (scope === 'comprehensive') {
         for (const rd of remDataList) {
             let p = rd.parentId;
-            while (p && !inScopeIds.has(p) && !ancestorIds.has(p)) {
+            while (p && !inScopeSet.has(p) && !ancestorIds.has(p)) {
                 ancestorIds.add(p);
-                const ancestor = await plugin.rem.findOne(p);
+                let ancestor = pluginRemById.get(p);
+                if (!ancestor) {
+                    ancestor = (await plugin.rem.findOne(p)) || undefined;
+                    if (ancestor) pluginRemById.set(p, ancestor);
+                }
                 if (!ancestor) break;
                 p = ancestor.parent || null;
             }
         }
     }
-
-    // Materialise ancestor stubs in parallel.
-    const stubData: Record<string, { parentId: string | null; remText: any }> = {};
-    if (ancestorIds.size > 0) {
-        const ids = Array.from(ancestorIds);
-        await chunked(ids, async (id) => {
-            const r = await plugin.rem.findOne(id);
-            if (r) stubData[id] = { parentId: r.parent || null, remText: r.text };
-            return null;
-        });
+    for (const id of ancestorIds) {
+        const r = pluginRemById.get(id);
+        if (r) stubData[id] = { parentId: r.parent || null, remText: r.text };
     }
 
     onProgress(0.95, 'Building tree…');

--- a/src/widgets/study_dashboard.tsx
+++ b/src/widgets/study_dashboard.tsx
@@ -1184,6 +1184,37 @@ function SummaryCard({ summary }: { summary: SummaryStats }) {
                     )}
                 </div>
             </div>
+            {(() => {
+                const totalItems =
+                    summary.incTaggedCount + summary.dismTaggedCount + summary.cardsCount;
+                const totalWithReps =
+                    summary.incTaggedWithRepsCount +
+                    summary.dismTaggedWithRepsCount +
+                    summary.cardsWithRepsCount;
+                const totalReps = summary.incReps + summary.dismReps + summary.cardReps;
+                // Sum on a common scale (seconds): inc/dism are seconds, cards are ms.
+                const totalTimeSec =
+                    summary.incTimeSec + summary.dismTimeSec + Math.round(summary.cardTimeMs / 1000);
+                return (
+                    <div
+                        style={{
+                            ...rowStyle,
+                            background: 'var(--rn-clr-background-secondary)',
+                            fontWeight: 600,
+                        }}
+                    >
+                        <div>Total</div>
+                        <div style={{ textAlign: 'right' }}>{totalItems}</div>
+                        <div style={{ textAlign: 'right' }}>{totalWithReps}</div>
+                        <div style={{ textAlign: 'right' }}>{totalReps || '-'}</div>
+                        <div style={{ textAlign: 'right' }}>
+                            {totalTimeSec ? formatDuration(totalTimeSec) : '-'}
+                        </div>
+                        <div style={{ textAlign: 'right', color: 'var(--rn-clr-content-tertiary)' }}>-</div>
+                        <div style={{ textAlign: 'right', color: 'var(--rn-clr-content-tertiary)' }}>-</div>
+                    </div>
+                );
+            })()}
         </div>
     );
 }


### PR DESCRIPTION
## v0.2.248 - May 22nd, 2026

### ✨ New: Dismissals Tracked in the Incremental Rem History Widget

Dismissing an Incremental Rem now appears in the [Incremental Rem History](Plugin-Widgets-Reference#221-incremental-rem-history) sidebar:

- Dismissing during a review (queue **Dismiss** button, editor timer **✓ Dismiss** button, or `Ctrl+D` in the queue) adds a 🔴 **Dismissed** badge next to the existing 🟣 **Reviewed** badge on that entry.
- Dismissing in the editor with `Ctrl+D` (no prior review) creates a new entry showing only the 🔴 **Dismissed** badge.

### ✨ Improvement: Editor Review Timer — Dismiss Button Always Available

The **✓ Dismiss** button in the [Editor Review Timer](Reviewing-Items-in-the-Editor#the-workflow) is now shown for every flow that starts a timer — including `Ctrl+Shift+J` (Review in Editor) + **Start Timer** — not only Sequential Review from the IncRem List / Main View. When no further items are queued, Dismiss finalizes the current item and ends the timer in place. The button has also been moved to sit right before the cancel (✕) button.

---

## v0.2.245 - May 20th, 2026

### ✨ New: Study Dashboard

A new popup, opened via the **`Open Study Dashboard`** command (quick code `sdb`), combines period filters and context selectors with a full hierarchy view of your *Incremental*, *Dismissed*, and *Flashcard* activity.

- **Context:** *Global* (whole KB) or *Document* (rem-rooted, with *Descendants Only* and *Comprehensive* sub-scopes — the latter follows the plugin's standard comprehensive expansion of descendants + portals + folder queue + recursive sources + referencing rems + PDF extracts).
- **Period:** Today / Yesterday / Week / This Week / Last Week / Month / This Month / Last Month / Year / This Year / Last Year / All, plus explicit Start/End date inputs for custom ranges. Picking a preset auto-fills the date inputs.
- **Summary table:** three rows (Incremental / Dismissed / Flashcards) plus a bold Total row, with columns for Items, Items-with-reps-in-period, Reps, Time, and (for Flashcards) average Retention and Speed in cards-per-minute.
- **Hierarchy table:** lists every top-level rem with activity in the period, sorted by total time descending, expandable into the full ancestor tree. Each row shows Total Time, Cards (reps + time), Inc. Rems (reps + time, summed across Incremental and Dismissed histories), Retention, and Speed. Structural-only ancestor nodes (italic) keep the tree connected when Comprehensive expansion pulls rems from outside the document.

**Performance design:**
- Bulk-fetches `taggedRem()` for *Incremental*, *Dismissed*, and *cardPriority*, plus a single `card.getAll()`. Because *cardPriority* covers ~all card-bearing rems in a healthy KB, ancestor chain walks need almost no per-rem `findOne` calls.
- The loaded data is cached per session: changing the **period** re-aggregates in memory only (instant) — only changing the **context** or **scope** triggers a reload.
- In Global mode, every top-level rem's subtree is pre-built at load time, so expanding any top-level row is instant.

📖 **Full documentation:** [Study Dashboard](Study-Dashboard).

<img src="./assets/study-dashboard.png" alt="Study Dashboard" width="900">

---

## v0.2.240 - May 20th, 2026

### ✨ Improvement: Tag Labels Replaced by Emoji Badges in the Editor

The `Incremental` and `pdfextract` tag labels in the editor tag bar are now replaced by compact emoji badges — **🔍** for `Incremental` and **✂️** for `pdfextract`. This reduces horizontal clutter while keeping item types identifiable at a glance.

---

## v0.2.239 - May 19th, 2026

### 🐛 Fix: Pin References No Longer Show Raw Text in Lists and Trees

Rem references marked as **pins** (📌) were previously rendered as their full text content, cluttering the IncRem list rows, the Parent Selector tree, and the History sidebars. They now render as a **📌 icon** — hover to see the referenced content as a browser tooltip — keeping each row clean and scannable.

The same fix applies to normal (non-pin) rem references, which previously showed as `[Quote]` in IncRemRow. They now resolve and display their actual text, enclosed in `[brackets]`.

**Affected widgets:** IncRem List / Main View rows, Parent Selector tree nodes, Incremental Rem History sidebar.

### 🐛 Fix: Scroll Position No Longer Resets on Background Refresh

Hovering a pin reference triggers a background data refresh. Previously this reset the scroll position in the IncRem List and Main View widgets (the list briefly replaced itself with a loading placeholder, causing the browser to scroll back to the top). The loading placeholder is now shown **only on the very first load**; background refreshes update data silently without disturbing scroll position.

### ✨ Improvement: IncRem Rows Wrap to 2 Lines

Item titles in the IncRem List, Main View, and Incremental Rem History sidebar now **wrap up to two lines** instead of being hard-truncated at one. This makes longer titles readable at a glance without needing to hover for the tooltip.

### ✨ Improvement: Shield Values Use Subtle Colored Numbers

In the card toolbar (card priority display and answer buttons), the **KB/Doc shield** values previously rendered as full colored badge pills, competing visually with the item's own priority badge. They now render as a **bold number colored by percentile** — same color coding, no background pill — giving the item's priority badge the visual prominence it deserves.
