### PR TITLE
Restructure Outline by Headings, Ignore command, Isolated Card View Setting Expanded to Cover Highlights

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,7 +2,8 @@
   "permissions": {
     "allow": [
       "Bash(grep -n \"period={period}\\\\|period,\" /Users/hugomarins/incremental-everything/src/widgets/study_dashboard.tsx)",
-      "Read(//Users/hugomarins/RemNote-Statistics-Plugin/src/**)"
+      "Read(//Users/hugomarins/RemNote-Statistics-Plugin/src/**)",
+      "Bash(awk '/PowerupSlotCodeMap: \\\\{/,/^};/' /Users/hugomarins/incremental-everything/node_modules/@remnote/plugin-sdk/dist/interfaces.d.ts)"
     ],
     "additionalDirectories": [
       "/Users/hugomarins/incremental-everything.wiki"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,7 +3,11 @@
     "allow": [
       "Bash(grep -n \"period={period}\\\\|period,\" /Users/hugomarins/incremental-everything/src/widgets/study_dashboard.tsx)",
       "Read(//Users/hugomarins/RemNote-Statistics-Plugin/src/**)",
-      "Bash(awk '/PowerupSlotCodeMap: \\\\{/,/^};/' /Users/hugomarins/incremental-everything/node_modules/@remnote/plugin-sdk/dist/interfaces.d.ts)"
+      "Bash(awk '/PowerupSlotCodeMap: \\\\{/,/^};/' /Users/hugomarins/incremental-everything/node_modules/@remnote/plugin-sdk/dist/interfaces.d.ts)",
+      "Bash(awk 'NR==1404,NR==1500' /Users/hugomarins/incremental-everything/src/register/commands.ts)",
+      "Bash(awk 'NR==1820,NR==1900' /Users/hugomarins/incremental-everything/src/register/commands.ts)",
+      "Bash(awk -F: '{print $1, $2}')",
+      "Bash(awk '$1 > 1700 && $1 < 1820')"
     ],
     "additionalDirectories": [
       "/Users/hugomarins/incremental-everything.wiki"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,6 +3,9 @@
     "allow": [
       "Bash(grep -n \"period={period}\\\\|period,\" /Users/hugomarins/incremental-everything/src/widgets/study_dashboard.tsx)",
       "Read(//Users/hugomarins/RemNote-Statistics-Plugin/src/**)"
+    ],
+    "additionalDirectories": [
+      "/Users/hugomarins/incremental-everything.wiki"
     ]
   }
 }

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -10,7 +10,7 @@
   "version": {
     "major": 0,
     "minor": 2,
-    "patch": 254
+    "patch": 255
   },
   "unlisted": false,
   "theme": [],

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -7,7 +7,7 @@
   "version": {
     "major": 0,
     "minor": 2,
-    "patch": 249
+    "patch": 251
   },
   "unlisted": false,
   "theme": [],

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -7,7 +7,7 @@
   "version": {
     "major": 0,
     "minor": 2,
-    "patch": 248
+    "patch": 249
   },
   "unlisted": false,
   "theme": [],

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -10,7 +10,7 @@
   "version": {
     "major": 0,
     "minor": 2,
-    "patch": 253
+    "patch": 254
   },
   "unlisted": false,
   "theme": [],

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -10,7 +10,7 @@
   "version": {
     "major": 0,
     "minor": 2,
-    "patch": 251
+    "patch": 252
   },
   "unlisted": false,
   "theme": [],

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -10,7 +10,7 @@
   "version": {
     "major": 0,
     "minor": 2,
-    "patch": 252
+    "patch": 253
   },
   "unlisted": false,
   "theme": [],

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -4,6 +4,9 @@
   "name": "Incremental Everything",
   "author": "Jamesb and Hugomarins (cont. Jonathangimeno)",
   "repoUrl": "https://github.com/bjsi/incremental-everything",
+  "supportUrl": "https://github.com/bjsi/incremental-everything/issues",
+  "projectUrl": "https://github.com/bjsi/incremental-everything/wiki",
+	"changeLogUrl": "https://github.com/bjsi/incremental-everything/wiki/Changelog",
   "version": {
     "major": 0,
     "minor": 2,

--- a/src/components/IsolatedCardViewer.tsx
+++ b/src/components/IsolatedCardViewer.tsx
@@ -155,6 +155,7 @@ export function IsolatedCardViewer({
       await createRemFromHighlight(plugin as ReactRNPlugin, rem, {
         makeIncremental,
         sourceDocumentId,
+        showPriorityPopupIfNew: makeIncremental,
       });
     } catch (error) {
       console.error('Error creating rem:', error);

--- a/src/lib/cloze_priority.ts
+++ b/src/lib/cloze_priority.ts
@@ -1,7 +1,8 @@
 import { PluginRem, RNPlugin } from '@remnote/plugin-sdk';
 import { defaultPriorityId, priorityStepSizeId } from './consts';
-import { getInitialPriority } from './priority_inheritance';
+import { findClosestAncestorWithAnyPriority } from './priority_inheritance';
 import { getIncrementalRemFromRem } from './incremental_rem';
+import { CARD_PRIORITY_CODE, PRIORITY_SLOT, SOURCE_SLOT } from './card_priority/types';
 
 // Cap on how many step-size decrements (= priority-number increments)
 // can be auto-applied to a new cloze. Even on the 12th cloze, we apply 10 steps.
@@ -62,13 +63,41 @@ export async function computeClozeAutoPriority(
   let parentPriority: number;
   let parentPrioritySource: 'incremental' | 'card-or-inherited';
 
-  const incInfo = await getIncrementalRemFromRem(plugin, parentRem);
-  if (incInfo) {
-    parentPriority = incInfo.priority;
-    parentPrioritySource = 'incremental';
-  } else {
-    parentPriority = await getInitialPriority(plugin, parentRem, defaultPriority);
+  // Cloze-specific precedence: manual cardPriority wins over IncRem on the same rem.
+  // Rationale: IncRem priority targets the incremental side; a manual cardPriority is a
+  // deliberate user choice for the flashcard side, which is what a cloze child inherits.
+  // (createExtract intentionally prefers IncRem and is unaffected.)
+  //
+  //   1. parentRem's own manual cardPriority.
+  //   2. parentRem's own IncRem priority.
+  //   3. Closest ancestor — `findClosestAncestorWithAnyPriority(..., 'Card')` prefers
+  //      manual/incremental cardPriority over IncRem on the same ancestor. This is what
+  //      makes the grandparent's manual cardPriority=8 win over its own IncRem=13.
+  //      Note: NOT getInitialPriority, which walks with 'IncRem' precedence.
+  //   4. Plugin default.
+  const ownPriorityValue = await parentRem.getPowerupProperty(CARD_PRIORITY_CODE, PRIORITY_SLOT);
+  const ownSource = await parentRem.getPowerupProperty(CARD_PRIORITY_CODE, SOURCE_SLOT);
+  const parsedManual =
+    ownPriorityValue && ownSource === 'manual' ? parseInt(ownPriorityValue as string) : NaN;
+
+  if (!isNaN(parsedManual)) {
+    parentPriority = parsedManual;
     parentPrioritySource = 'card-or-inherited';
+  } else {
+    const incInfo = await getIncrementalRemFromRem(plugin, parentRem);
+    if (incInfo) {
+      parentPriority = incInfo.priority;
+      parentPrioritySource = 'incremental';
+    } else {
+      const ancestorInfo = await findClosestAncestorWithAnyPriority(plugin, parentRem, 'Card');
+      if (ancestorInfo) {
+        parentPriority = ancestorInfo.priority;
+        parentPrioritySource = ancestorInfo.sourceType === 'IncRem' ? 'incremental' : 'card-or-inherited';
+      } else {
+        parentPriority = defaultPriority;
+        parentPrioritySource = 'card-or-inherited';
+      }
+    }
   }
 
   // Count existing cloze-extract children (live count — robust to manual deletions)

--- a/src/lib/consts.ts
+++ b/src/lib/consts.ts
@@ -19,7 +19,8 @@ export const betaMaxIntervalId = 'beta-max-interval';
 export const collapseQueueTopBar = 'collapse-queue-top-bar';
 export const defaultPriorityId = 'default-priority';
 export const defaultCardPriorityId = 'defaultCardPriority';
-export const showRemsAsIsolatedInQueueId = 'show-rems-as-isolated-in-queue';
+export const isolatedQueueModeId = 'isolated-queue-view-mode';
+export type IsolatedQueueMode = 'highlights' | 'rems' | 'both' | 'none';
 export const priorityStepSizeId = 'priority-step-size';
 export const enableHideInQueueIntegrationId = 'enable-hide-in-queue-integration';
 

--- a/src/lib/editor_selection.ts
+++ b/src/lib/editor_selection.ts
@@ -1,0 +1,99 @@
+// Editor selection helpers + Omnibar-resilient resolution.
+//
+// Background: Cmd+/ Omnibar steals editor focus before our command's `action`
+// runs. By that point, plugin.editor.getSelection() / getSelectedRem() / focus
+// all return undefined — RemNote's internal commands work because they capture
+// the selection synchronously when the palette opens, but plugins have no
+// such hook. This module caches every positive selection event into session
+// storage and exposes a drop-in replacement for getSelection() that falls back
+// to that cache.
+
+import {
+  AppEvents,
+  RNPlugin,
+  SelectionType,
+} from '@remnote/plugin-sdk';
+
+export const SELECTION_CACHE_KEY = 'lastEditorSelectionCache';
+export const SELECTION_CACHE_TTL_MS = 30_000;
+
+export type CachedSelection =
+  | { kind: 'rem'; remIds: string[]; capturedAt: number }
+  | { kind: 'text'; remId: string; capturedAt: number };
+
+// Subscribe to EditorSelectionChanged once at plugin startup. The handler
+// only WRITES on positive events, so the cache survives Omnibar focus shifts
+// (which fire a clear-selection event that we deliberately ignore).
+export function registerSelectionTracker(plugin: RNPlugin) {
+  plugin.event.addListener(
+    AppEvents.EditorSelectionChanged,
+    undefined,
+    async () => {
+      try {
+        const sel = await plugin.editor.getSelection();
+        if (
+          sel?.type === SelectionType.Rem &&
+          (sel as any).remIds?.length > 0
+        ) {
+          const entry: CachedSelection = {
+            kind: 'rem',
+            remIds: (sel as any).remIds,
+            capturedAt: Date.now(),
+          };
+          await plugin.storage.setSession(SELECTION_CACHE_KEY, entry);
+        } else if (
+          sel?.type === SelectionType.Text &&
+          (sel as any).remId
+        ) {
+          const entry: CachedSelection = {
+            kind: 'text',
+            remId: (sel as any).remId,
+            capturedAt: Date.now(),
+          };
+          await plugin.storage.setSession(SELECTION_CACHE_KEY, entry);
+        }
+        // null / undefined / empty selection: leave the cache alone.
+      } catch {
+        /* best-effort tracker; never throw from a listener */
+      }
+    }
+  );
+}
+
+// Drop-in replacement for `plugin.editor.getSelection()`. Order of precedence:
+//   1. live getSelection() — works for direct shortcut invocations.
+//   2. live getSelectedRem() — sometimes survives focus shifts.
+//   3. fresh cache entry from registerSelectionTracker (above).
+// Returns a value in the SDK's RemSelection|TextSelection shape so callers
+// can drop it in without other refactor.
+export async function getEffectiveSelection(plugin: RNPlugin): Promise<any> {
+  const live = await plugin.editor.getSelection();
+  if (live) return live;
+
+  const remSel = await (plugin.editor as any).getSelectedRem?.();
+  if (remSel?.remIds?.length) return remSel;
+
+  const cached =
+    (await plugin.storage.getSession<CachedSelection>(
+      SELECTION_CACHE_KEY
+    )) || null;
+  const ageMs = cached ? Date.now() - cached.capturedAt : Infinity;
+  if (!cached || ageMs >= SELECTION_CACHE_TTL_MS) return undefined;
+
+  if (cached.kind === 'rem') {
+    return {
+      type: SelectionType.Rem,
+      remIds: cached.remIds,
+    };
+  }
+  // Single-rem cache → synthesize a zero-width text-cursor selection. The
+  // richText/range fields are required by the SDK type but unused by the
+  // multi-rem code paths we care about (they only read remId).
+  return {
+    type: SelectionType.Text,
+    remId: cached.remId,
+    richText: [],
+    isReverse: false,
+    range: { start: 0, end: 0 },
+  };
+}

--- a/src/lib/extract.ts
+++ b/src/lib/extract.ts
@@ -1,0 +1,340 @@
+// "Make Incremental (Extract)" core logic.
+//
+// Lives in lib/ so commands.ts can stay slim. Two registered commands consume
+// this function: `incremental-everything` (Opt+X) and `extract-with-priority`
+// (Opt+Shift+X). It uses getEffectiveSelection() so it works equally well from
+// keyboard shortcuts (live selection) and the Cmd+/ Omnibar (cached selection).
+
+import {
+  BuiltInPowerupCodes,
+  PluginRem,
+  ReactRNPlugin,
+  RICH_TEXT_FORMATTING,
+  RichTextInterface,
+  SelectionType,
+} from '@remnote/plugin-sdk';
+import { currentIncRemKey } from './consts';
+import { initIncrementalRem } from '../register/powerups';
+import {
+  REMOVE_PARENT_POWERUP_CODE,
+  REMOVE_FROM_QUEUE_POWERUP_CODE,
+} from '../register/queue_display_powerups';
+import { getEffectiveSelection } from './editor_selection';
+
+export const createExtract = async (
+  plugin: ReactRNPlugin
+): Promise<PluginRem | PluginRem[] | undefined> => {
+  let selection = await getEffectiveSelection(plugin);
+  const url = await plugin.window.getURL();
+
+  if (url.includes('/flashcards')) {
+    const currentQueueItem = await plugin.queue.getCurrentCard();
+    let isTargetingQueueContext = false;
+
+    if (!selection || !selection.type) {
+      isTargetingQueueContext = true;
+    } else if (currentQueueItem) {
+      if (
+        selection.type === SelectionType.Rem &&
+        selection.remIds.includes(currentQueueItem.remId)
+      ) {
+        isTargetingQueueContext = true;
+      } else if (
+        selection.type === SelectionType.Text &&
+        selection.remId === currentQueueItem.remId &&
+        selection.range.start === selection.range.end
+      ) {
+        isTargetingQueueContext = true;
+      }
+    } else {
+      const currentIncRemId = await plugin.storage.getSession<string>(
+        currentIncRemKey
+      );
+      if (currentIncRemId) {
+        if (
+          selection.type === SelectionType.Rem &&
+          selection.remIds.includes(currentIncRemId)
+        ) {
+          isTargetingQueueContext = true;
+        } else if (
+          selection.type === SelectionType.Text &&
+          selection.remId === currentIncRemId &&
+          selection.range.start === selection.range.end
+        ) {
+          isTargetingQueueContext = true;
+        }
+      }
+    }
+
+    if (isTargetingQueueContext) {
+      let targetRemId = currentQueueItem?.remId;
+      if (!targetRemId) {
+        targetRemId =
+          (await plugin.storage.getSession<string>(currentIncRemKey)) ||
+          undefined;
+      }
+
+      if (targetRemId) {
+        selection = {
+          type: SelectionType.Rem,
+          remIds: [targetRemId],
+        } as any;
+      }
+    }
+  }
+
+  if (!selection) {
+    // plugin.editor.getSelection() returns undefined when focus is inside the
+    // PDF iframe. plugin.reader.addHighlight() also returns null in that
+    // context — it requires a RemNote-internal pending highlight available
+    // only through the PDFHighlightToolbar widget flow. Keyboard shortcuts
+    // cannot create PDF highlights.
+    return;
+  }
+
+  if (
+    selection.type === SelectionType.Text &&
+    selection.range.start === selection.range.end
+  ) {
+    // Fallback empty text selections to Rem selection behavior
+    (selection as any).type = SelectionType.Rem;
+    (selection as any).remIds = [selection.remId];
+  }
+
+  // Extract within extract
+  if (selection.type === SelectionType.Text) {
+    // 1. Fetch the Rem
+    const rem = await plugin.rem.findOne(selection.remId);
+    if (!rem) return;
+
+    // 2. Extract selected text
+    const extractRem = await plugin.rem.createRem();
+    if (!extractRem) return;
+
+    // Look for a reference pin to the original PDF Highlight in the parent
+    let pdfExtractPin: any = null;
+    if (rem.text) {
+      let pdfExtractTagRem: PluginRem | undefined;
+      try {
+        pdfExtractTagRem =
+          (await plugin.rem.findByName(['pdfextract'], null)) || undefined;
+      } catch (e) {
+        // ignore
+      }
+
+      for (const item of rem.text) {
+        if (
+          typeof item === 'object' &&
+          item !== null &&
+          item.i === 'q' &&
+          item._id
+        ) {
+          const referencedRem = await plugin.rem.findOne(item._id);
+          if (referencedRem) {
+            const isPdfHighlight = await referencedRem.hasPowerup(
+              BuiltInPowerupCodes.PDFHighlight
+            );
+            let hasTag = false;
+            if (pdfExtractTagRem) {
+              const tags = await referencedRem.getTagRems();
+              hasTag = tags.some((t) => t._id === pdfExtractTagRem!._id);
+            }
+
+            if (isPdfHighlight || hasTag) {
+              // Copy the exact pin
+              pdfExtractPin = { ...item, pin: true };
+              break;
+            }
+          }
+        }
+      }
+    }
+
+    const newText: any[] = [
+      ...selection.richText,
+      { i: 'q', _id: rem._id, pin: true },
+    ];
+
+    if (pdfExtractPin) {
+      newText.push(' ', pdfExtractPin);
+    }
+
+    await extractRem.setText(newText);
+    await extractRem.setParent(rem);
+
+    // 3. Hide the source rem from queue display when this extract is reviewed.
+    //
+    // Preferred path: tag the PARENT (source rem) with Remove from Queue. This
+    // survives extract relocation cleanly — if the user later deletes the
+    // parent and lets extracts stand on their own, the powerup goes with the
+    // parent and the standalone extracts behave normally.
+    //
+    // Fallback path: if Remove from Queue isn't registered (neither our
+    // Hide-in-Queue integration nor the standalone plugin is active), tag the
+    // EXTRACT itself with Remove Parent (always registered). This works but
+    // has a relocation caveat: if the extract is later moved under a new
+    // parent, that new parent will be hidden too — the user must remove the
+    // powerup manually in that case.
+    //
+    // Detecting via getPowerupByCode (rather than our integration setting
+    // alone) ensures users with only the standalone plugin still hit the
+    // preferred path.
+    const rfqPowerup = await plugin.powerup.getPowerupByCode(
+      REMOVE_FROM_QUEUE_POWERUP_CODE
+    );
+    if (rfqPowerup) {
+      await rem.addPowerup(REMOVE_FROM_QUEUE_POWERUP_CODE);
+    } else {
+      await extractRem.addPowerup(REMOVE_PARENT_POWERUP_CODE);
+    }
+
+    // Make Incremental
+    // Pass the explicit parent since the SDK cache may not yet reflect
+    // `extractRem.setParent(rem)`
+    await initIncrementalRem(plugin, extractRem, { explicitParentId: rem._id });
+    // 4. Locate and Modify
+    const r_start = Math.min(selection.range.start, selection.range.end);
+
+    const frontText = rem.text || [];
+    const backText = rem.backText || [];
+
+    // Plain text extractor — non-text nodes (i:'q' pins etc.) contribute empty
+    // string. This gives us text-only positions that are immune to RemNote's
+    // reference node cursor-width (which counts i:'q' as 2 chars, not 1).
+    const rtPlainStr = (rt: RichTextInterface): string =>
+      rt
+        .map((item: any) =>
+          typeof item === 'string' ? item : item.i === 'm' ? item.text || '' : ''
+        )
+        .join('');
+
+    const frontStr = rtPlainStr(frontText);
+    const backStr = rtPlainStr(backText);
+    const selStr = rtPlainStr(selection.richText as RichTextInterface);
+    const selLen = selStr.length;
+    const hasBackText = backText.length > 0;
+
+    // Detect which section contains the selection via string-matching
+    // (text-only positions). Prefer front; fall back to back; fall back to
+    // r_start heuristic.
+    let isBack = false;
+    let sect_r_start = 0;
+
+    const posInFront = frontStr.indexOf(selStr);
+    const posInBack = hasBackText ? backStr.indexOf(selStr) : -1;
+
+    if (posInFront >= 0 && (posInBack < 0 || r_start < frontStr.length)) {
+      isBack = false;
+      sect_r_start = posInFront;
+    } else if (posInBack >= 0) {
+      isBack = true;
+      sect_r_start = posInBack;
+    } else {
+      // Last resort: use r_start directly (may still be slightly off for rems
+      // with pins)
+      isBack = false;
+      sect_r_start = r_start;
+    }
+
+    const sect_r_end = sect_r_start + selLen;
+
+    // Process rich text using text-only positions (non-text nodes have length
+    // 0 and pass through unchanged). This avoids any mismatch with RemNote's
+    // cursor model for pins.
+    const processRichText = (
+      richText: RichTextInterface,
+      localStart: number,
+      localEnd: number
+    ): RichTextInterface => {
+      const newArray: any[] = [];
+      let currIdx = 0;
+      let pinInserted = false;
+      for (const item of richText) {
+        const isString = typeof item === 'string';
+        const textNode = isString ? { i: 'm' as const, text: item } : (item as any);
+        const nodeLen = textNode.i === 'm' ? textNode.text?.length || 0 : 0;
+
+        if (nodeLen === 0) {
+          // Non-text node: insert the new pin here if the selection ends
+          // exactly at this point
+          if (!pinInserted && currIdx >= localEnd && localEnd > localStart) {
+            newArray.push({ i: 'q', _id: extractRem._id, pin: true });
+            pinInserted = true;
+          }
+          newArray.push(item);
+        } else {
+          const nodeStart = currIdx;
+          const nodeEnd = currIdx + nodeLen;
+
+          if (nodeEnd <= localStart || nodeStart >= localEnd) {
+            newArray.push(item);
+          } else {
+            const textStr = textNode.text || '';
+            const relStart = Math.max(0, localStart - nodeStart);
+            const relEnd = Math.min(nodeLen, localEnd - nodeStart);
+
+            if (relStart > 0) {
+              newArray.push({ ...textNode, text: textStr.substring(0, relStart) });
+            }
+            newArray.push({
+              ...textNode,
+              text: textStr.substring(relStart, relEnd),
+              [RICH_TEXT_FORMATTING.HIGHLIGHT]: 6, // RemColor.Blue = 6
+            });
+            if (nodeEnd >= localEnd) {
+              newArray.push({ i: 'q', _id: extractRem._id, pin: true });
+              pinInserted = true;
+            }
+            if (relEnd < nodeLen) {
+              newArray.push({ ...textNode, text: textStr.substring(relEnd) });
+            }
+          }
+          currIdx += nodeLen;
+        }
+      }
+      if (!pinInserted && localEnd <= currIdx && localStart < currIdx) {
+        newArray.push({ i: 'q', _id: extractRem._id, pin: true });
+      }
+      return newArray;
+    };
+
+    // 6. Save the Changes
+    if (isBack) {
+      await rem.setBackText(processRichText(backText, sect_r_start, sect_r_end));
+    } else {
+      await rem.setText(processRichText(frontText, sect_r_start, sect_r_end));
+    }
+
+    return extractRem;
+  } else if (selection.type === SelectionType.Rem) {
+    const rems = (await plugin.rem.findMany(selection.remIds)) || [];
+    // Single outer flag bracket for the entire batch — each initIncrementalRem
+    // skips its own flag management so the flag stays UP for the whole loop.
+    await plugin.storage.setSession('plugin_operation_active', true);
+    try {
+      for (const rem of rems) {
+        await initIncrementalRem(plugin, rem, { skipFlagManagement: true });
+      }
+    } finally {
+      // Don't clear the flag — each initIncrementalRem fires
+      // pendingInheritanceCascade, and the cascade tracker will clear the flag
+      // when the cascade completes. Only clear defensively if no rems were
+      // processed (e.g., empty selection).
+      if (rems.length === 0) {
+        await plugin.storage.setSession('plugin_operation_active', false);
+      }
+    }
+    return rems;
+  } else {
+    // WebReader or other reader selection — fall back to addHighlight +
+    // initIncrementalRem. Note: PDF iframe selections are unreachable here
+    // because getSelection() returns undefined for them and we already
+    // returned early above.
+    const highlight = await plugin.reader.addHighlight();
+    if (!highlight) {
+      return;
+    }
+    await initIncrementalRem(plugin, highlight);
+    return highlight;
+  }
+};

--- a/src/lib/highlightActions.ts
+++ b/src/lib/highlightActions.ts
@@ -7,7 +7,13 @@ import {
   RichTextInterface,
   RichTextElementInterface,
 } from '@remnote/plugin-sdk';
-import { parentSelectorWidgetId, powerupCode, allIncrementalRemKey } from './consts';
+import {
+  parentSelectorWidgetId,
+  powerupCode,
+  allIncrementalRemKey,
+  incrementalQueueActiveKey,
+  currentIncRemKey,
+} from './consts';
 import { initIncrementalRem } from './incremental_rem';
 import { IncrementalRem } from './incremental_rem';
 import { removeIncrementalRemCache } from './incremental_rem/cache';
@@ -328,8 +334,26 @@ export const createRemUnderParent = async (
 
   // Clean up the original highlight
   await removeIncrementalRemCache(plugin, highlightRem._id);
-  // Remove "Incremental" powerup from the highlight
-  await highlightRem.removePowerup(powerupCode);
+
+  // If the highlight is the current queue item, removing its powerup will tear
+  // down the queue widget before its own tracker can react. Fire the queue
+  // advance simultaneously so the IPC reaches RemNote before the widget sandbox
+  // is destroyed (same pattern as the Dismiss button in answer_buttons.tsx).
+  const isQueueActive = await plugin.storage.getSession<boolean>(incrementalQueueActiveKey);
+  const currentQueueRemId = isQueueActive
+    ? await plugin.storage.getSession<string>(currentIncRemKey)
+    : undefined;
+  const highlightIsCurrentQueueItem =
+    !!isQueueActive && currentQueueRemId === highlightRem._id;
+
+  if (highlightIsCurrentQueueItem) {
+    await Promise.allSettled([
+      highlightRem.removePowerup(powerupCode),
+      plugin.queue.removeCurrentCardFromQueue(true),
+    ]);
+  } else {
+    await highlightRem.removePowerup(powerupCode);
+  }
   // Removed setHighlightColor('Yellow') -> CSS now handles styling via "pdfextract" tag
 
   const actionText = makeIncremental ? 'incremental rem' : 'rem';

--- a/src/lib/outline_restructure.ts
+++ b/src/lib/outline_restructure.ts
@@ -283,16 +283,23 @@ export async function applyPlan(
   };
 }
 
-// Revert applies snapshot ops in REVERSE order so that any rem whose old
-// parent was itself moved during the original apply ends up correctly placed.
+// Revert applies snapshot ops in FORWARD order. Original positions are
+// captured in document order (0, 1, 2, ...); restoring forward means each
+// setParent inserts at an index that already has the prior siblings in place,
+// so positions line up naturally. Iterating backward instead causes RemNote
+// to clamp high positions to the (still-empty) end of the list, which then
+// shuffles every subsequent insert and corrupts the order.
+//
+// When a moved rem's old parent was ALSO moved during the original apply,
+// forward order still works because that parent appears earlier in the ops
+// list (we collected candidates depth-first, so parents precede children).
 export async function revertSnapshot(
   plugin: RNPlugin,
   snapshot: OutlineSnapshot
 ): Promise<void> {
   await plugin.storage.setSession('plugin_operation_active', true);
   try {
-    for (let i = snapshot.ops.length - 1; i >= 0; i--) {
-      const op = snapshot.ops[i];
+    for (const op of snapshot.ops) {
       const rem = await plugin.rem.findOne(op.remId);
       if (!rem) continue;
       await rem.setParent(op.oldParentId, op.oldPosition);

--- a/src/lib/outline_restructure.ts
+++ b/src/lib/outline_restructure.ts
@@ -1,0 +1,282 @@
+// Restructure Outline by Headings
+//
+// Algorithm + state types for the "Restructure Outline by Headings" command.
+// Detects H1..H6 in a flat candidate list and re-nests paragraphs and lower
+// headings under their preceding higher-level heading.
+
+import { RNPlugin, PluginRem } from '@remnote/plugin-sdk';
+import { safeRemTextToString } from './pdfUtils';
+
+export type HeadingLevel = 1 | 2 | 3 | 4 | 5 | 6;
+
+// Detection. The SDK types getFontSize as 'H1'|'H2'|'H3'|undefined, but at
+// runtime it also returns 'H4'|'H5'|'H6' (confirmed via probe). Cast accordingly.
+export async function getHeadingLevel(rem: PluginRem): Promise<HeadingLevel | null> {
+  try {
+    const size = (await (rem as any).getFontSize?.()) as string | undefined;
+    if (!size || size[0] !== 'H') return null;
+    const lvl = parseInt(size.slice(1), 10);
+    if (lvl >= 1 && lvl <= 6) return lvl as HeadingLevel;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export type OutlineCandidate = {
+  remId: string;
+  level: HeadingLevel | null; // null = paragraph
+  text: string;               // plain text for display
+  originalParentId: string;
+  originalPosition: number;
+  hasChildren: boolean;
+  // For paragraphs with children: true = keep children attached (move together),
+  // false = flatten (children become independent candidates inline at this position).
+  // Default true. Always true for childless rems / for headings (headings are
+  // always recursed regardless of this flag).
+  preserveChildren: boolean;
+  // Depth in the ORIGINAL tree, relative to the scope root (root's direct children = 0).
+  // Used to render the "Before" panel with the input's existing indentation.
+  originalDepth: number;
+};
+
+export type ProposedNode = {
+  candidate: OutlineCandidate;
+  children: ProposedNode[];
+};
+
+export type PlanOp = {
+  remId: string;
+  newParentId: string;
+  newPosition: number;
+};
+
+export type OutlinePlan = {
+  scopeRootId: string;
+  minHeadingLevel: number; // smallest level present, 0 if none
+  ops: PlanOp[];
+  proposedTree: ProposedNode[]; // top-level proposed nodes (children of scopeRoot)
+};
+
+export type SnapshotOp = {
+  remId: string;
+  oldParentId: string;
+  oldPosition: number;
+};
+
+export type OutlineSnapshot = {
+  timestamp: number;
+  scopeRootId: string;
+  scopeRootText: string;
+  ops: SnapshotOp[];
+};
+
+// ─── Collecting candidates ──────────────────────────────────────────────────
+
+// Walk a set of input rems (depth-first, document order) and flatten them
+// into a candidate list. `inputRems` are the entry points: for a single-rem
+// command invocation those are the selected rem's children; for multi-rem
+// they are the selected rems themselves.
+//
+// preserveMap lets the preview UI override the default per-rem "preserve
+// children" decision. Default: childless rems and headings get preserveChildren=true
+// (no effect since they have no children, or headings always recurse anyway);
+// non-heading rems WITH children get true by default (keep their subtree
+// intact unless the user toggles "Flatten").
+export async function collectCandidates(
+  plugin: RNPlugin,
+  inputRems: PluginRem[],
+  preserveMap: Record<string, boolean> = {}
+): Promise<OutlineCandidate[]> {
+  const out: OutlineCandidate[] = [];
+
+  const visit = async (rem: PluginRem, depth: number) => {
+    const level = await getHeadingLevel(rem);
+    const children = (await rem.getChildrenRem()) || [];
+    const hasChildren = children.length > 0;
+    const text = await safeRemTextToString(plugin, (rem as any).text);
+    const parentId = (rem as any).parent as string;
+    let pos = 0;
+    try {
+      const p = await (rem as any).positionAmongstSiblings?.();
+      if (typeof p === 'number') pos = p;
+    } catch { /* ignore */ }
+
+    const remId = rem._id;
+    // Default: paragraphs with children keep them; everything else trivially true.
+    const preserveDefault = level === null && hasChildren ? true : true;
+    const preserveChildren =
+      remId in preserveMap ? preserveMap[remId] : preserveDefault;
+
+    out.push({
+      remId,
+      level,
+      text,
+      originalParentId: parentId,
+      originalPosition: pos,
+      hasChildren,
+      preserveChildren,
+      originalDepth: depth,
+    });
+
+    // Recurse:
+    //   - headings: always (they are structural)
+    //   - paragraphs without preserveChildren: yes (flatten)
+    //   - paragraphs with preserveChildren: no (subtree moves as one unit)
+    const recurse = level !== null || !preserveChildren;
+    if (recurse) {
+      for (const child of children) {
+        await visit(child, depth + 1);
+      }
+    }
+  };
+
+  for (const rem of inputRems) {
+    await visit(rem, 0);
+  }
+  return out;
+}
+
+// ─── Plan ───────────────────────────────────────────────────────────────────
+
+// Build a reparenting plan from the flat candidate list.
+// Heading stack: when we encounter H_n we pop until the top has level < n,
+// attach this heading to the top (or scope root), then push it. Paragraphs
+// attach to the current top heading (or scope root) but don't push.
+export function buildPlan(
+  candidates: OutlineCandidate[],
+  scopeRootId: string
+): OutlinePlan {
+  const headingLevels = candidates
+    .filter((c) => c.level !== null)
+    .map((c) => c.level as number);
+
+  if (headingLevels.length === 0) {
+    return { scopeRootId, minHeadingLevel: 0, ops: [], proposedTree: [] };
+  }
+  const minHeadingLevel = Math.min(...headingLevels);
+
+  type StackEntry = { candidate: OutlineCandidate; node: ProposedNode };
+  const stack: StackEntry[] = [];
+  const tree: ProposedNode[] = [];
+
+  const ops: PlanOp[] = [];
+  const positionByParent: Record<string, number> = {};
+  const nextPos = (parentId: string): number => {
+    const p = positionByParent[parentId] ?? 0;
+    positionByParent[parentId] = p + 1;
+    return p;
+  };
+
+  for (const c of candidates) {
+    const node: ProposedNode = { candidate: c, children: [] };
+
+    if (c.level !== null) {
+      // Pop until the stack top has a STRICTLY lower level than this heading.
+      while (
+        stack.length > 0 &&
+        (stack[stack.length - 1].candidate.level as number) >= c.level
+      ) {
+        stack.pop();
+      }
+      const parentId =
+        stack.length > 0
+          ? stack[stack.length - 1].candidate.remId
+          : scopeRootId;
+      if (stack.length > 0) {
+        stack[stack.length - 1].node.children.push(node);
+      } else {
+        tree.push(node);
+      }
+      ops.push({ remId: c.remId, newParentId: parentId, newPosition: nextPos(parentId) });
+      stack.push({ candidate: c, node });
+    } else {
+      // Paragraph: attach to current top heading (or root if no heading yet).
+      const parentId =
+        stack.length > 0
+          ? stack[stack.length - 1].candidate.remId
+          : scopeRootId;
+      if (stack.length > 0) {
+        stack[stack.length - 1].node.children.push(node);
+      } else {
+        tree.push(node);
+      }
+      ops.push({ remId: c.remId, newParentId: parentId, newPosition: nextPos(parentId) });
+      // Paragraphs do NOT push onto the heading stack.
+    }
+  }
+
+  return { scopeRootId, minHeadingLevel, ops, proposedTree: tree };
+}
+
+// ─── Apply / Revert ─────────────────────────────────────────────────────────
+
+// Apply the plan and return a snapshot for undo. Captures each rem's CURRENT
+// parent and position BEFORE moving, so revert can restore the exact prior state.
+export async function applyPlan(
+  plugin: RNPlugin,
+  plan: OutlinePlan
+): Promise<OutlineSnapshot> {
+  const snapshotOps: SnapshotOp[] = [];
+
+  // Capture pre-state for every rem we'll touch.
+  for (const op of plan.ops) {
+    const rem = await plugin.rem.findOne(op.remId);
+    if (!rem) continue;
+    const oldParentId = (rem as any).parent as string;
+    let oldPosition = 0;
+    try {
+      const p = await (rem as any).positionAmongstSiblings?.();
+      if (typeof p === 'number') oldPosition = p;
+    } catch { /* ignore */ }
+    snapshotOps.push({ remId: op.remId, oldParentId, oldPosition });
+  }
+
+  // Apply in plan order. setParent with positionAmongstSiblings places the rem
+  // at the requested index in the new parent's child list. Document order is
+  // preserved because we increment positions per-parent as we build the plan.
+  await plugin.storage.setSession('plugin_operation_active', true);
+  try {
+    for (const op of plan.ops) {
+      const rem = await plugin.rem.findOne(op.remId);
+      if (!rem) continue;
+      await rem.setParent(op.newParentId, op.newPosition);
+    }
+  } finally {
+    await plugin.storage.setSession('plugin_operation_active', false);
+  }
+
+  const scopeRoot = await plugin.rem.findOne(plan.scopeRootId);
+  const scopeRootText = scopeRoot
+    ? await safeRemTextToString(plugin, (scopeRoot as any).text)
+    : 'Untitled';
+
+  return {
+    timestamp: Date.now(),
+    scopeRootId: plan.scopeRootId,
+    scopeRootText,
+    ops: snapshotOps,
+  };
+}
+
+// Revert applies snapshot ops in REVERSE order so that any rem whose old
+// parent was itself moved during the original apply ends up correctly placed.
+export async function revertSnapshot(
+  plugin: RNPlugin,
+  snapshot: OutlineSnapshot
+): Promise<void> {
+  await plugin.storage.setSession('plugin_operation_active', true);
+  try {
+    for (let i = snapshot.ops.length - 1; i >= 0; i--) {
+      const op = snapshot.ops[i];
+      const rem = await plugin.rem.findOne(op.remId);
+      if (!rem) continue;
+      await rem.setParent(op.oldParentId, op.oldPosition);
+    }
+  } finally {
+    await plugin.storage.setSession('plugin_operation_active', false);
+  }
+}
+
+// Storage key for the last-applied snapshot (session-scoped, single slot).
+export const OUTLINE_SNAPSHOT_KEY = 'lastOutlineRestructureSnapshot';

--- a/src/lib/outline_restructure.ts
+++ b/src/lib/outline_restructure.ts
@@ -186,6 +186,24 @@ export function buildPlan(
 
   const ops: PlanOp[] = [];
   const positionByParent: Record<string, number> = {};
+
+  // For the scope root, start position counting at the smallest original
+  // position of any candidate that was already a direct child of it. This
+  // keeps the restructured subtree where the user's selection was — unselected
+  // siblings ABOVE the selection stay above, those BELOW stay below. Without
+  // this, the algorithm would pack the restructured rems at positions 0, 1,
+  // 2, ... in the scope root, pushing every unselected sibling downward.
+  // Single-rem invocations are unaffected: the scope root is the selected
+  // rem itself, and its descendants are positioned from 0 as before.
+  const rootDirectChildren = candidates.filter(
+    (c) => c.originalParentId === scopeRootId
+  );
+  if (rootDirectChildren.length > 0) {
+    positionByParent[scopeRootId] = Math.min(
+      ...rootDirectChildren.map((c) => c.originalPosition)
+    );
+  }
+
   const nextPos = (parentId: string): number => {
     const p = positionByParent[parentId] ?? 0;
     positionByParent[parentId] = p + 1;

--- a/src/lib/outline_restructure.ts
+++ b/src/lib/outline_restructure.ts
@@ -9,6 +9,29 @@ import { safeRemTextToString } from './pdfUtils';
 
 export type HeadingLevel = 1 | 2 | 3 | 4 | 5 | 6;
 
+// Powerup-property bookkeeping rems (e.g. the "Size" rem RemNote creates under
+// every Header heading) show up in getChildrenRem() but aren't user content —
+// they'd clutter the preview AND get incorrectly reparented if we touched them.
+// Filter via every isPowerup*/isSlot* flag the SDK exposes.
+export async function isMetaRem(rem: PluginRem): Promise<boolean> {
+  try {
+    const checks = await Promise.all([
+      (rem as any).isPowerupProperty?.(),
+      (rem as any).isPowerupPropertyListItem?.(),
+      (rem as any).isPowerupSlot?.(),
+      (rem as any).isSlot?.(),
+    ]);
+    return checks.some((v) => v === true);
+  } catch {
+    return false;
+  }
+}
+
+async function filterStructural(rems: PluginRem[]): Promise<PluginRem[]> {
+  const flags = await Promise.all(rems.map((r) => isMetaRem(r)));
+  return rems.filter((_, i) => !flags[i]);
+}
+
 // Detection. The SDK types getFontSize as 'H1'|'H2'|'H3'|undefined, but at
 // runtime it also returns 'H4'|'H5'|'H6' (confirmed via probe). Cast accordingly.
 export async function getHeadingLevel(rem: PluginRem): Promise<HeadingLevel | null> {
@@ -92,7 +115,8 @@ export async function collectCandidates(
 
   const visit = async (rem: PluginRem, depth: number) => {
     const level = await getHeadingLevel(rem);
-    const children = (await rem.getChildrenRem()) || [];
+    const rawChildren = (await rem.getChildrenRem()) || [];
+    const children = await filterStructural(rawChildren);
     const hasChildren = children.length > 0;
     const text = await safeRemTextToString(plugin, (rem as any).text);
     const parentId = (rem as any).parent as string;

--- a/src/lib/ui_helpers.ts
+++ b/src/lib/ui_helpers.ts
@@ -106,6 +106,24 @@ export async function registerPdfHighlightCSS(plugin: ReactRNPlugin) {
   await plugin.app.registerCSS('pdf-inc-highlight-styling', css);
 }
 
+export async function registerIgnoreTagCSS(plugin: ReactRNPlugin) {
+  const css = `
+    /* Shrink and dim rems tagged with #ignore so they read as archived snippets */
+    [data-rem-container-tags~="ignore"] .rem-text * {
+      font-size: 0.85rem !important;
+    }
+    [data-rem-container-tags~="ignore"] .rem-text:not(:focus-within):not(:hover) * {
+      opacity: 0.88;
+    }
+
+    /* Hide the #ignore tag chip in the editor tag bar to declutter */
+    [data-rem-tags~="ignore"] .hierarchy-editor__tag-bar__tag {
+      display: none;
+    }
+  `;
+  await plugin.app.registerCSS('ignore-tag-styling', css);
+}
+
 export async function registerTagBadgeCSS(plugin: ReactRNPlugin) {
   const css = `
     [data-rem-tags~="incremental"] .hierarchy-editor__tag-bar__tag {

--- a/src/register/commands.ts
+++ b/src/register/commands.ts
@@ -65,6 +65,11 @@ import {
   transformCase,
   transformTitleCase,
 } from '../lib/text_case_converter_utils';
+import {
+  OUTLINE_SNAPSHOT_KEY,
+  OutlineSnapshot,
+  revertSnapshot,
+} from '../lib/outline_restructure';
 
 
 export async function registerCommands(plugin: ReactRNPlugin) {
@@ -2177,6 +2182,111 @@ export async function registerCommands(plugin: ReactRNPlugin) {
         start: textSelection.range.start,
         end: textSelection.range.start + fullText.length,
       });
+    },
+  });
+
+  // ─── Restructure Outline by Headings ──────────────────────────────────────
+  //
+  // Re-nests a flat or mis-pasted document so that paragraphs and lower-level
+  // headings sit under their preceding higher-level heading.
+  //   - Selection contains multiple rems → walk those rems + descendants.
+  //   - Selection is a single rem (or just a focused rem with no range)
+  //     → walk that rem's descendants; the rem itself stays as container root.
+  // Opens a side-by-side preview popup before applying anything; the actual
+  // reparenting + undo snapshot live in lib/outline_restructure.ts.
+  plugin.app.registerCommand({
+    id: 'restructure_outline_by_headings',
+    name: 'Restructure Outline by Headings',
+    quickCode: 'roh',
+    action: async () => {
+      const selection = await plugin.editor.getSelection();
+      let scopeRootId: string | undefined;
+      let inputRemIds: string[] = [];
+
+      if (selection?.type === SelectionType.Rem && selection.remIds?.length) {
+        if (selection.remIds.length === 1) {
+          // Single rem selected in the outline → that rem is the container,
+          // its children are the entry points for the walk.
+          const root = await plugin.rem.findOne(selection.remIds[0]);
+          if (!root) {
+            await plugin.app.toast('Selected rem not found.');
+            return;
+          }
+          scopeRootId = root._id;
+          const children = (await root.getChildrenRem()) || [];
+          inputRemIds = children.map((c) => c._id);
+        } else {
+          // Multi-rem selection → scope root is the common parent (we use the
+          // first selected rem's parent as a proxy; users typically select
+          // siblings). The selected rems themselves are the entry points.
+          const first = await plugin.rem.findOne(selection.remIds[0]);
+          if (!first) {
+            await plugin.app.toast('Selection invalid.');
+            return;
+          }
+          scopeRootId = (first as any).parent as string;
+          inputRemIds = selection.remIds;
+        }
+      } else {
+        // Text selection or no selection → fall back to focused rem as the
+        // container root, walk its children.
+        let rootId: string | undefined;
+        if (selection?.type === SelectionType.Text && selection.remId) {
+          rootId = selection.remId;
+        } else {
+          const focused = await plugin.focus.getFocusedRem();
+          if (focused) rootId = focused._id;
+        }
+        if (!rootId) {
+          await plugin.app.toast('No rem selected or focused.');
+          return;
+        }
+        const root = await plugin.rem.findOne(rootId);
+        if (!root) {
+          await plugin.app.toast('Rem not found.');
+          return;
+        }
+        scopeRootId = root._id;
+        const children = (await root.getChildrenRem()) || [];
+        inputRemIds = children.map((c) => c._id);
+      }
+
+      if (!scopeRootId || inputRemIds.length === 0) {
+        await plugin.app.toast(
+          'Nothing to restructure (no descendants in scope).'
+        );
+        return;
+      }
+
+      await plugin.widget.openPopup('outline_restructure_preview', {
+        scopeRootId,
+        inputRemIds,
+      });
+    },
+  });
+
+  // Reverts the most recent Restructure Outline by Headings operation in this
+  // session. Same action as the Undo button on the sidebar widget.
+  plugin.app.registerCommand({
+    id: 'revert_last_outline_restructure',
+    name: 'Revert Last Outline Restructure',
+    quickCode: 'rolr',
+    action: async () => {
+      const snapshot = await plugin.storage.getSession<OutlineSnapshot>(
+        OUTLINE_SNAPSHOT_KEY
+      );
+      if (!snapshot) {
+        await plugin.app.toast('No recent outline restructure to revert.');
+        return;
+      }
+      try {
+        await revertSnapshot(plugin, snapshot);
+        await plugin.storage.setSession(OUTLINE_SNAPSHOT_KEY, undefined);
+        await plugin.app.toast('Outline restructure reverted.');
+      } catch (e) {
+        console.error('[outline-restructure] revert failed:', e);
+        await plugin.app.toast(`Revert failed: ${(e as any)?.message ?? e}`);
+      }
     },
   });
 

--- a/src/register/commands.ts
+++ b/src/register/commands.ts
@@ -2180,6 +2180,88 @@ export async function registerCommands(plugin: ReactRNPlugin) {
     },
   });
 
+  // TEMP PROBE — remove after H4-H6 detection is figured out.
+  // Run this command with the cursor inside an H1/H2/H3/H4/H5/H6 rem to see
+  // exactly what the SDK exposes for each heading level (typed getFontSize,
+  // the Header powerup's Size slot, raw object fields, and DOM classes).
+  plugin.app.registerCommand({
+    id: 'debug_probe_heading_level',
+    name: 'Debug: Probe Heading Level of Focused Rem',
+    quickCode: 'phl',
+    action: async () => {
+      const focused = await plugin.focus.getFocusedRem();
+      if (!focused) {
+        await plugin.app.toast('No focused rem.');
+        console.log('[heading-probe] no focused rem');
+        return;
+      }
+
+      // 1. Typed SDK call (documented as H1|H2|H3|undefined).
+      let fontSizeViaApi: any = undefined;
+      try { fontSizeViaApi = await (focused as any).getFontSize?.(); }
+      catch (e) { fontSizeViaApi = `THREW: ${(e as any)?.message}`; }
+
+      // 2. Header powerup membership + its `Size` slot (the likely storage
+      //    location for H4/H5/H6 since the SDK type for getFontSize lags).
+      let hasHeaderPowerup: any = undefined;
+      let headerSizeAsString: any = undefined;
+      let headerSizeAsRichText: any = undefined;
+      let headerSizeAsRem: any = undefined;
+      try {
+        hasHeaderPowerup = await focused.hasPowerup(BuiltInPowerupCodes.Header);
+      } catch (e) { hasHeaderPowerup = `THREW: ${(e as any)?.message}`; }
+      try {
+        headerSizeAsString = await (focused as any).getPowerupProperty?.(
+          BuiltInPowerupCodes.Header, 'Size'
+        );
+      } catch (e) { headerSizeAsString = `THREW: ${(e as any)?.message}`; }
+      try {
+        headerSizeAsRichText = await (focused as any).getPowerupPropertyAsRichText?.(
+          BuiltInPowerupCodes.Header, 'Size'
+        );
+      } catch (e) { headerSizeAsRichText = `THREW: ${(e as any)?.message}`; }
+      try {
+        headerSizeAsRem = await (focused as any).getPowerupPropertyAsRem?.(
+          BuiltInPowerupCodes.Header, 'Size'
+        );
+      } catch (e) { headerSizeAsRem = `THREW: ${(e as any)?.message}`; }
+
+      // 3. Dump every enumerable, non-function property of the rem object —
+      //    catches any hidden field RemNote sets that the typed SDK omits.
+      const rawKeys = Object.keys(focused as any);
+      const rawSnapshot: Record<string, any> = {};
+      for (const k of rawKeys) {
+        try {
+          const v = (focused as any)[k];
+          if (typeof v !== 'function') rawSnapshot[k] = v;
+        } catch { /* skip */ }
+      }
+
+      // 4. DOM classes — last-resort signal (h4/h5/h6 styling lives here even
+      //    if no API exposes the level).
+      const domClassesByRemId: string[] = [];
+      try {
+        const els = document.querySelectorAll(`[data-rem-id="${focused._id}"]`);
+        els.forEach((el) => domClassesByRemId.push(el.className));
+      } catch { /* not in main document */ }
+
+      console.log('[heading-probe] focused rem _id:', focused._id);
+      console.log('[heading-probe] getFontSize() →', fontSizeViaApi);
+      console.log('[heading-probe] hasPowerup(Header):', hasHeaderPowerup);
+      console.log('[heading-probe] Header.Size (string):', headerSizeAsString);
+      console.log('[heading-probe] Header.Size (rich text):', headerSizeAsRichText);
+      console.log('[heading-probe] Header.Size (as rem):', headerSizeAsRem);
+      console.log('[heading-probe] rem keys:', rawKeys);
+      console.log('[heading-probe] rem snapshot:', rawSnapshot);
+      console.log('[heading-probe] DOM classes for this remId:', domClassesByRemId);
+      console.log('[heading-probe] full rem object (inspectable):', focused);
+
+      await plugin.app.toast(
+        `Heading probe logged. getFontSize=${JSON.stringify(fontSizeViaApi)} | Header.Size=${JSON.stringify(headerSizeAsString)}`
+      );
+    },
+  });
+
   const skipMasteryDrill = Boolean(
     await plugin.settings.getSetting('skip_mastery_drill')
   );

--- a/src/register/commands.ts
+++ b/src/register/commands.ts
@@ -8,6 +8,7 @@ import {
   RichTextInterface,
   RemType,
   QueueInteractionScore,
+  AppEvents,
 } from '@remnote/plugin-sdk';
 import {
   powerupCode,
@@ -2186,6 +2187,58 @@ export async function registerCommands(plugin: ReactRNPlugin) {
     },
   });
 
+  // ─── Selection cache for Omnibar-invoked commands ────────────────────────
+  //
+  // Cmd+/ Omnibar steals editor focus before our command runs. By the time the
+  // action fires, plugin.editor.getSelection() / getSelectedRem() / focus all
+  // return undefined — RemNote's internal commands work because they capture
+  // the selection synchronously when the palette opens, but plugins have no
+  // such hook. Workaround: cache every non-empty selection as it happens, with
+  // a TTL, and let the command fall back to that cache when live APIs are empty.
+  //
+  // The cache is only WRITTEN on positive selection events (so opening the
+  // Omnibar — which fires a clear-selection event — doesn't wipe what we had).
+  const SELECTION_CACHE_KEY = 'lastEditorSelectionCache';
+  const SELECTION_CACHE_TTL_MS = 30_000;
+  type CachedSelection =
+    | { kind: 'rem'; remIds: string[]; capturedAt: number }
+    | { kind: 'text'; remId: string; capturedAt: number };
+
+  plugin.event.addListener(
+    AppEvents.EditorSelectionChanged,
+    undefined,
+    async () => {
+      try {
+        const sel = await plugin.editor.getSelection();
+        if (
+          sel?.type === SelectionType.Rem &&
+          (sel as any).remIds?.length > 0
+        ) {
+          const entry: CachedSelection = {
+            kind: 'rem',
+            remIds: (sel as any).remIds,
+            capturedAt: Date.now(),
+          };
+          await plugin.storage.setSession(SELECTION_CACHE_KEY, entry);
+        } else if (
+          sel?.type === SelectionType.Text &&
+          (sel as any).remId
+        ) {
+          const entry: CachedSelection = {
+            kind: 'text',
+            remId: (sel as any).remId,
+            capturedAt: Date.now(),
+          };
+          await plugin.storage.setSession(SELECTION_CACHE_KEY, entry);
+        }
+        // null / undefined / empty selection: leave the cache alone so an
+        // Omnibar focus shift doesn't blow away the user's last real choice.
+      } catch {
+        /* swallow — best-effort tracker */
+      }
+    }
+  );
+
   // ─── Restructure Outline by Headings ──────────────────────────────────────
   //
   // Re-nests a flat or mis-pasted document so that paragraphs and lower-level
@@ -2200,15 +2253,62 @@ export async function registerCommands(plugin: ReactRNPlugin) {
     name: 'Restructure Outline by Headings',
     quickCode: 'roh',
     action: async () => {
-      const selection = await plugin.editor.getSelection();
+      // Cmd+/ Omnibar invocation blurs the editor, which makes
+      // plugin.editor.getSelection() / getSelectedRem() / focus all return
+      // undefined by the time the action fires. Try the live APIs first
+      // (which work fine for direct keyboard-shortcut invocations), then
+      // fall back to the EditorSelectionChanged cache populated above.
+      const remSel = await (plugin.editor as any).getSelectedRem?.();
+      const fullSel = await plugin.editor.getSelection();
+      const focusedRem = await plugin.focus.getFocusedRem();
+
+      let remIds: string[] | undefined;
+      let textRemId: string | undefined;
+      let resolvedFocusedRemId: string | undefined = focusedRem?._id;
+
+      if (remSel?.remIds?.length) {
+        remIds = remSel.remIds;
+      } else if (
+        fullSel?.type === SelectionType.Rem &&
+        (fullSel as any).remIds?.length
+      ) {
+        remIds = (fullSel as any).remIds;
+      } else if (
+        fullSel?.type === SelectionType.Text &&
+        (fullSel as any).remId
+      ) {
+        textRemId = (fullSel as any).remId;
+      }
+
+      // Live APIs empty → consult the cache. Only honor it if no live signal
+      // is present at all (so a real single-rem focus never gets shadowed by
+      // a stale multi-rem selection from earlier).
+      if (!remIds && !textRemId && !resolvedFocusedRemId) {
+        const cached =
+          (await plugin.storage.getSession<CachedSelection>(
+            SELECTION_CACHE_KEY
+          )) || null;
+        const ageMs = cached ? Date.now() - cached.capturedAt : Infinity;
+        console.log(
+          '[outline-restructure] live selection empty; cache age (ms):',
+          ageMs,
+          'cache:',
+          cached
+        );
+        if (cached && ageMs < SELECTION_CACHE_TTL_MS) {
+          if (cached.kind === 'rem') remIds = cached.remIds;
+          else if (cached.kind === 'text') resolvedFocusedRemId = cached.remId;
+        }
+      }
+
       let scopeRootId: string | undefined;
       let inputRemIds: string[] = [];
 
-      if (selection?.type === SelectionType.Rem && selection.remIds?.length) {
-        if (selection.remIds.length === 1) {
+      if (remIds && remIds.length > 0) {
+        if (remIds.length === 1) {
           // Single rem selected in the outline → that rem is the container,
           // its children are the entry points for the walk.
-          const root = await plugin.rem.findOne(selection.remIds[0]);
+          const root = await plugin.rem.findOne(remIds[0]);
           if (!root) {
             await plugin.app.toast('Selected rem not found.');
             return;
@@ -2226,24 +2326,18 @@ export async function registerCommands(plugin: ReactRNPlugin) {
           // Multi-rem selection → scope root is the common parent (we use the
           // first selected rem's parent as a proxy; users typically select
           // siblings). The selected rems themselves are the entry points.
-          const first = await plugin.rem.findOne(selection.remIds[0]);
+          const first = await plugin.rem.findOne(remIds[0]);
           if (!first) {
             await plugin.app.toast('Selection invalid.');
             return;
           }
           scopeRootId = (first as any).parent as string;
-          inputRemIds = selection.remIds;
+          inputRemIds = remIds;
         }
       } else {
         // Text selection or no selection → fall back to focused rem as the
         // container root, walk its children.
-        let rootId: string | undefined;
-        if (selection?.type === SelectionType.Text && selection.remId) {
-          rootId = selection.remId;
-        } else {
-          const focused = await plugin.focus.getFocusedRem();
-          if (focused) rootId = focused._id;
-        }
+        const rootId = textRemId ?? resolvedFocusedRemId;
         if (!rootId) {
           await plugin.app.toast('No rem selected or focused.');
           return;

--- a/src/register/commands.ts
+++ b/src/register/commands.ts
@@ -1394,6 +1394,42 @@ export async function registerCommands(plugin: ReactRNPlugin) {
   });
 
   plugin.app.registerCommand({
+    id: 'toggle-ignore-tag',
+    name: 'Toggle Ignore Tag',
+    description: 'Tag/untag the focused Rem with #ignore — marks already-read snippets that were left for archive/consultation only.',
+    keyboardShortcut: 'ctrl+shift+i',
+    quickCode: 'ign',
+    action: async () => {
+      const rem = await plugin.focus.getFocusedRem();
+      if (!rem) {
+        await plugin.app.toast('No focused Rem.');
+        return;
+      }
+
+      let ignoreTagRem = await plugin.rem.findByName(['ignore'], null);
+      if (!ignoreTagRem) {
+        ignoreTagRem = await plugin.rem.createRem();
+        if (!ignoreTagRem) {
+          await plugin.app.toast('Could not create #ignore tag.');
+          return;
+        }
+        await ignoreTagRem.setText(['ignore']);
+      }
+
+      const tags = await rem.getTagRems();
+      const alreadyTagged = tags.some((t) => t._id === ignoreTagRem!._id);
+
+      if (alreadyTagged) {
+        await rem.removeTag(ignoreTagRem._id);
+        await plugin.app.toast('Removed #ignore.');
+      } else {
+        await rem.addTag(ignoreTagRem._id);
+        await plugin.app.toast('Tagged with #ignore.');
+      }
+    },
+  });
+
+  plugin.app.registerCommand({
     id: 'test-mobile-detection',
     name: '🧪 Test Mobile & Platform Detection',
     action: async () => {

--- a/src/register/commands.ts
+++ b/src/register/commands.ts
@@ -2239,6 +2239,47 @@ export async function registerCommands(plugin: ReactRNPlugin) {
     }
   );
 
+  // Drop-in replacement for `plugin.editor.getSelection()` that recovers the
+  // selection when invoked via Cmd+/ Omnibar (which blurs the editor before
+  // the command runs). Order of precedence:
+  //   1. live getSelection() — works for direct shortcut invocations.
+  //   2. live getSelectedRem() — sometimes survives focus shifts.
+  //   3. fresh cache entry from the EditorSelectionChanged listener (above).
+  // Returns a synthetic selection in the SDK's shape so existing call sites
+  // need only swap the API call, no other refactor.
+  const getEffectiveSelection = async () => {
+    const live = await plugin.editor.getSelection();
+    if (live) return live;
+
+    const remSel = await (plugin.editor as any).getSelectedRem?.();
+    if (remSel?.remIds?.length) return remSel;
+
+    const cached =
+      (await plugin.storage.getSession<CachedSelection>(
+        SELECTION_CACHE_KEY
+      )) || null;
+    const ageMs = cached ? Date.now() - cached.capturedAt : Infinity;
+    if (!cached || ageMs >= SELECTION_CACHE_TTL_MS) return undefined;
+
+    if (cached.kind === 'rem') {
+      return {
+        type: SelectionType.Rem,
+        remIds: cached.remIds,
+      } as any;
+    } else {
+      // Single-rem cache → synthesize a zero-width text-cursor selection.
+      // The richText/range fields are required by the SDK type but unused
+      // by the downstream code paths we care about (they only read remId).
+      return {
+        type: SelectionType.Text,
+        remId: cached.remId,
+        richText: [],
+        isReverse: false,
+        range: { start: 0, end: 0 },
+      } as any;
+    }
+  };
+
   // ─── Restructure Outline by Headings ──────────────────────────────────────
   //
   // Re-nests a flat or mis-pasted document so that paragraphs and lower-level

--- a/src/register/commands.ts
+++ b/src/register/commands.ts
@@ -69,6 +69,7 @@ import {
   OUTLINE_SNAPSHOT_KEY,
   OutlineSnapshot,
   revertSnapshot,
+  isMetaRem,
 } from '../lib/outline_restructure';
 
 
@@ -2214,7 +2215,13 @@ export async function registerCommands(plugin: ReactRNPlugin) {
           }
           scopeRootId = root._id;
           const children = (await root.getChildrenRem()) || [];
-          inputRemIds = children.map((c) => c._id);
+          // Drop powerup-property bookkeeping rems (e.g. the auto "Size" child
+          // on Header headings); they aren't content and must not be moved.
+          const filtered: typeof children = [];
+          for (const c of children) {
+            if (!(await isMetaRem(c))) filtered.push(c);
+          }
+          inputRemIds = filtered.map((c) => c._id);
         } else {
           // Multi-rem selection → scope root is the common parent (we use the
           // first selected rem's parent as a proxy; users typically select
@@ -2248,7 +2255,11 @@ export async function registerCommands(plugin: ReactRNPlugin) {
         }
         scopeRootId = root._id;
         const children = (await root.getChildrenRem()) || [];
-        inputRemIds = children.map((c) => c._id);
+        const filtered: typeof children = [];
+        for (const c of children) {
+          if (!(await isMetaRem(c))) filtered.push(c);
+        }
+        inputRemIds = filtered.map((c) => c._id);
       }
 
       if (!scopeRootId || inputRemIds.length === 0) {

--- a/src/register/commands.ts
+++ b/src/register/commands.ts
@@ -513,6 +513,18 @@ export async function registerCommands(plugin: ReactRNPlugin) {
                       : '⇔'; // fallback
       const remType = rem.type;
 
+      // Inherited cloze/card hint properties from the original rem must be stripped from
+      // the new cloze rem. Otherwise RemNote treats orphaned hints as belonging to the
+      // newly-created cloze and renders them in the wrong position.
+      const stripInheritedHintProps = (n: any) => {
+        delete n[RICH_TEXT_FORMATTING.CLOZE_HINT];
+        delete n[RICH_TEXT_FORMATTING.CARD_HINT_FRONT];
+        delete n[RICH_TEXT_FORMATTING.CARD_HINT_BACK];
+        delete n[RICH_TEXT_FORMATTING.MULTILINE_CARD_HINT];
+        delete n[RICH_TEXT_FORMATTING.HIDDEN_CLOZE];
+        delete n[RICH_TEXT_FORMATTING.REVEALED_CLOZE];
+      };
+
       // Process one rich text section. localStart/localEnd are section-relative character positions.
       // - Delimiter nodes (i:'s') → replaced by arrowChar.
       // - Existing cloze marks outside the selection → stripped, yellow highlight + red font applied.
@@ -549,6 +561,7 @@ export async function registerCommands(plugin: ReactRNPlugin) {
             const baseNode: any = { ...node };
             const hadCloze = RICH_TEXT_FORMATTING.CLOZE in baseNode;
             delete baseNode[RICH_TEXT_FORMATTING.CLOZE];
+            stripInheritedHintProps(baseNode);
 
             if (!inSel) {
               if (hadCloze) {
@@ -579,6 +592,7 @@ export async function registerCommands(plugin: ReactRNPlugin) {
             const baseNode: any = { ...node };
             const hadCloze = RICH_TEXT_FORMATTING.CLOZE in baseNode;
             delete baseNode[RICH_TEXT_FORMATTING.CLOZE];
+            stripInheritedHintProps(baseNode);
             if (inSel) {
               arr.push({ ...baseNode, [RICH_TEXT_FORMATTING.CLOZE]: clozeId });
             } else if (hadCloze) {

--- a/src/register/commands.ts
+++ b/src/register/commands.ts
@@ -8,7 +8,6 @@ import {
   RichTextInterface,
   RemType,
   QueueInteractionScore,
-  AppEvents,
 } from '@remnote/plugin-sdk';
 import {
   powerupCode,
@@ -72,276 +71,17 @@ import {
   revertSnapshot,
   isMetaRem,
 } from '../lib/outline_restructure';
+import {
+  registerSelectionTracker,
+  getEffectiveSelection,
+} from '../lib/editor_selection';
+import { createExtract } from '../lib/extract';
 
 
 export async function registerCommands(plugin: ReactRNPlugin) {
-  const createExtract = async (): Promise<PluginRem | PluginRem[] | undefined> => {
-    let selection = await plugin.editor.getSelection();
-    const url = await plugin.window.getURL();
-
-    if (url.includes('/flashcards')) {
-      const currentQueueItem = await plugin.queue.getCurrentCard();
-      let isTargetingQueueContext = false;
-
-      if (!selection || !selection.type) {
-        isTargetingQueueContext = true;
-      } else if (currentQueueItem) {
-        if (selection.type === SelectionType.Rem && selection.remIds.includes(currentQueueItem.remId)) {
-          isTargetingQueueContext = true;
-        } else if (selection.type === SelectionType.Text && selection.remId === currentQueueItem.remId && selection.range.start === selection.range.end) {
-          isTargetingQueueContext = true;
-        }
-      } else {
-        const currentIncRemId = await plugin.storage.getSession<string>(currentIncRemKey);
-        if (currentIncRemId) {
-          if (selection.type === SelectionType.Rem && selection.remIds.includes(currentIncRemId)) {
-            isTargetingQueueContext = true;
-          } else if (selection.type === SelectionType.Text && selection.remId === currentIncRemId && selection.range.start === selection.range.end) {
-            isTargetingQueueContext = true;
-          }
-        }
-      }
-
-      if (isTargetingQueueContext) {
-        let targetRemId = currentQueueItem?.remId;
-        if (!targetRemId) {
-          targetRemId = await plugin.storage.getSession<string>(currentIncRemKey) || undefined;
-        }
-
-        if (targetRemId) {
-          selection = {
-            type: SelectionType.Rem,
-            remIds: [targetRemId]
-          } as any;
-        }
-      }
-    }
-
-    if (!selection) {
-      // plugin.editor.getSelection() returns undefined when focus is inside the PDF
-      // iframe. plugin.reader.addHighlight() also returns null in that context —
-      // it requires a RemNote-internal pending highlight available only through the
-      // PDFHighlightToolbar widget flow. Keyboard shortcuts cannot create PDF highlights.
-      return;
-    }
-
-    if (selection.type === SelectionType.Text && selection.range.start === selection.range.end) {
-      // Fallback empty text selections to Rem selection behavior
-      (selection as any).type = SelectionType.Rem;
-      (selection as any).remIds = [selection.remId];
-    }
-
-    // Extract within extract
-    if (selection.type === SelectionType.Text) {
-      // 1. Fetch the Rem
-      const rem = await plugin.rem.findOne(selection.remId);
-      if (!rem) return;
-
-      // 2. Extract selected text
-      const extractRem = await plugin.rem.createRem();
-      if (!extractRem) return;
-
-      // Look for a reference pin to the original PDF Highlight in the parent
-      let pdfExtractPin: any = null;
-      if (rem.text) {
-        let pdfExtractTagRem: PluginRem | undefined;
-        try {
-          pdfExtractTagRem = await plugin.rem.findByName(['pdfextract'], null) || undefined;
-        } catch (e) {
-          // ignore
-        }
-
-        for (const item of rem.text) {
-          if (typeof item === 'object' && item !== null && item.i === 'q' && item._id) {
-            const referencedRem = await plugin.rem.findOne(item._id);
-            if (referencedRem) {
-              const isPdfHighlight = await referencedRem.hasPowerup(BuiltInPowerupCodes.PDFHighlight);
-              let hasTag = false;
-              if (pdfExtractTagRem) {
-                const tags = await referencedRem.getTagRems();
-                hasTag = tags.some(t => t._id === pdfExtractTagRem!._id);
-              }
-
-              if (isPdfHighlight || hasTag) {
-                // Copy the exact pin
-                pdfExtractPin = { ...item, pin: true };
-                break;
-              }
-            }
-          }
-        }
-      }
-
-      const newText: any[] = [
-        ...selection.richText,
-        { i: 'q', _id: rem._id, pin: true }
-      ];
-
-      if (pdfExtractPin) {
-        newText.push(' ', pdfExtractPin);
-      }
-
-      await extractRem.setText(newText);
-      await extractRem.setParent(rem);
-
-      // 3. Hide the source rem from queue display when this extract is reviewed.
-      //
-      // Preferred path: tag the PARENT (source rem) with Remove from Queue. This
-      // survives extract relocation cleanly — if the user later deletes the parent
-      // and lets extracts stand on their own, the powerup goes with the parent
-      // and the standalone extracts behave normally.
-      //
-      // Fallback path: if Remove from Queue isn't registered (neither our
-      // Hide-in-Queue integration nor the standalone plugin is active), tag the
-      // EXTRACT itself with Remove Parent (always registered). This works but
-      // has a relocation caveat: if the extract is later moved under a new
-      // parent, that new parent will be hidden too — the user must remove the
-      // powerup manually in that case.
-      //
-      // Detecting via getPowerupByCode (rather than our integration setting alone)
-      // ensures users with only the standalone plugin still hit the preferred path.
-      const rfqPowerup = await plugin.powerup.getPowerupByCode(REMOVE_FROM_QUEUE_POWERUP_CODE);
-      if (rfqPowerup) {
-        await rem.addPowerup(REMOVE_FROM_QUEUE_POWERUP_CODE);
-      } else {
-        await extractRem.addPowerup(REMOVE_PARENT_POWERUP_CODE);
-      }
-
-      // Make Incremental
-      // Pass the explicit parent since the SDK cache may not yet reflect `extractRem.setParent(rem)`
-      await initIncrementalRem(plugin, extractRem, { explicitParentId: rem._id });
-      // 4. Locate and Modify
-      const r_start = Math.min(selection.range.start, selection.range.end);
-
-      const frontText = rem.text || [];
-      const backText  = rem.backText || [];
-
-      // Plain text extractor — non-text nodes (i:'q' pins etc.) contribute empty string.
-      // This gives us text-only positions that are immune to RemNote's reference node
-      // cursor-width (which counts i:'q' as 2 chars, not 1).
-      const rtPlainStr = (rt: RichTextInterface): string =>
-        rt.map((item: any) => typeof item === 'string' ? item : (item.i === 'm' ? (item.text || '') : '')).join('');
-
-      const frontStr = rtPlainStr(frontText);
-      const backStr  = rtPlainStr(backText);
-      const selStr   = rtPlainStr(selection.richText as RichTextInterface);
-      const selLen   = selStr.length;
-      const hasBackText = backText.length > 0;
-
-      // Detect which section contains the selection via string-matching (text-only positions).
-      // Prefer front; fall back to back; fall back to r_start heuristic.
-      let isBack = false;
-      let sect_r_start = 0;
-
-      const posInFront = frontStr.indexOf(selStr);
-      const posInBack  = hasBackText ? backStr.indexOf(selStr) : -1;
-
-      if (posInFront >= 0 && (posInBack < 0 || r_start < frontStr.length)) {
-        isBack = false;
-        sect_r_start = posInFront;
-      } else if (posInBack >= 0) {
-        isBack = true;
-        sect_r_start = posInBack;
-      } else {
-        // Last resort: use r_start directly (may still be slightly off for rems with pins)
-        isBack = false;
-        sect_r_start = r_start;
-      }
-
-      const sect_r_end = sect_r_start + selLen;
-
-      // Process rich text using text-only positions (non-text nodes have length 0 and pass
-      // through unchanged). This avoids any mismatch with RemNote's cursor model for pins.
-      const processRichText = (richText: RichTextInterface, localStart: number, localEnd: number): RichTextInterface => {
-        const newArray: any[] = [];
-        let currIdx = 0;
-        let pinInserted = false;
-        for (const item of richText) {
-          const isString = typeof item === 'string';
-          const textNode = isString ? { i: 'm' as const, text: item } : (item as any);
-          const nodeLen = textNode.i === 'm' ? (textNode.text?.length || 0) : 0;
-
-          if (nodeLen === 0) {
-            // Non-text node: insert the new pin here if the selection ends exactly at this point
-            if (!pinInserted && currIdx >= localEnd && localEnd > localStart) {
-              newArray.push({ i: 'q', _id: extractRem._id, pin: true });
-              pinInserted = true;
-            }
-            newArray.push(item);
-          } else {
-            const nodeStart = currIdx;
-            const nodeEnd   = currIdx + nodeLen;
-
-            if (nodeEnd <= localStart || nodeStart >= localEnd) {
-              newArray.push(item);
-            } else {
-              const textStr  = textNode.text || '';
-              const relStart = Math.max(0, localStart - nodeStart);
-              const relEnd   = Math.min(nodeLen, localEnd - nodeStart);
-
-              if (relStart > 0) {
-                newArray.push({ ...textNode, text: textStr.substring(0, relStart) });
-              }
-              newArray.push({
-                ...textNode,
-                text: textStr.substring(relStart, relEnd),
-                [RICH_TEXT_FORMATTING.HIGHLIGHT]: 6, // RemColor.Blue = 6
-              });
-              if (nodeEnd >= localEnd) {
-                newArray.push({ i: 'q', _id: extractRem._id, pin: true });
-                pinInserted = true;
-              }
-              if (relEnd < nodeLen) {
-                newArray.push({ ...textNode, text: textStr.substring(relEnd) });
-              }
-            }
-            currIdx += nodeLen;
-          }
-        }
-        if (!pinInserted && localEnd <= currIdx && localStart < currIdx) {
-          newArray.push({ i: 'q', _id: extractRem._id, pin: true });
-        }
-        return newArray;
-      };
-
-      // 6. Save the Changes
-      if (isBack) {
-        await rem.setBackText(processRichText(backText, sect_r_start, sect_r_end));
-      } else {
-        await rem.setText(processRichText(frontText, sect_r_start, sect_r_end));
-      }
-
-      return extractRem;
-    } else if (selection.type === SelectionType.Rem) {
-      const rems = (await plugin.rem.findMany(selection.remIds)) || [];
-      // Single outer flag bracket for the entire batch — each initIncrementalRem
-      // skips its own flag management so the flag stays UP for the whole loop.
-      await plugin.storage.setSession('plugin_operation_active', true);
-      try {
-        for (const rem of rems) {
-          await initIncrementalRem(plugin, rem, { skipFlagManagement: true });
-        }
-      } finally {
-        // Don't clear the flag — each initIncrementalRem fires pendingInheritanceCascade,
-        // and the cascade tracker will clear the flag when the cascade completes.
-        // Only clear defensively if no rems were processed (e.g., empty selection).
-        if (rems.length === 0) {
-          await plugin.storage.setSession('plugin_operation_active', false);
-        }
-      }
-      return rems;
-    } else {
-      // WebReader or other reader selection — fall back to addHighlight + initIncrementalRem.
-      // Note: PDF iframe selections are unreachable here because getSelection() returns
-      // undefined for them and we already returned early above.
-      const highlight = await plugin.reader.addHighlight();
-      if (!highlight) {
-        return;
-      }
-      await initIncrementalRem(plugin, highlight);
-      return highlight;
-    }
-  };
+  // Subscribe to EditorSelectionChanged so getEffectiveSelection() can recover
+  // multi-rem selections after Cmd+/ Omnibar steals focus. See lib/editor_selection.ts.
+  registerSelectionTracker(plugin);
 
 
 
@@ -352,7 +92,7 @@ export async function registerCommands(plugin: ReactRNPlugin) {
     keyboardShortcut: 'opt+shift+x',
     quickCode: 'ep',
     action: async () => {
-      const result = await createExtract();
+      const result = await createExtract(plugin);
       if (!result) {
         return;
       }
@@ -1158,7 +898,7 @@ export async function registerCommands(plugin: ReactRNPlugin) {
     name: 'Make Incremental (Extract)',
     quickCode: 'ext',
     action: async () => {
-      createExtract();
+      createExtract(plugin);
     },
   });
 
@@ -1868,8 +1608,9 @@ export async function registerCommands(plugin: ReactRNPlugin) {
 
       } else {
         // Editor context: dismiss focused Incremental Rem(s)
-        // Supports both single-focus and multi-select
-        const selection = await plugin.editor.getSelection();
+        // Supports both single-focus and multi-select (the latter via the
+        // Omnibar-resilient selection helper).
+        const selection = await getEffectiveSelection(plugin);
         const remsToDissmiss: PluginRem[] = [];
 
         if (selection?.type === SelectionType.Rem) {
@@ -2060,8 +1801,9 @@ export async function registerCommands(plugin: ReactRNPlugin) {
         return;
       }
 
-      // Determine target rems: multi-select → all selected; otherwise → focused rem
-      const selection = await plugin.editor.getSelection();
+      // Determine target rems: multi-select → all selected; otherwise → focused rem.
+      // Uses the Omnibar-resilient selection helper so Cmd+/ invocations work too.
+      const selection = await getEffectiveSelection(plugin);
       let targetRems: PluginRem[] = [];
 
       if (selection?.type === SelectionType.Rem && selection.remIds.length > 0) {
@@ -2134,7 +1876,7 @@ export async function registerCommands(plugin: ReactRNPlugin) {
               next === 'upper' ? (s) => s.toUpperCase() : (s) => s.toLowerCase()
             );
 
-      const selection = await plugin.editor.getSelection();
+      const selection = await getEffectiveSelection(plugin);
 
       // Multi-rem path: when one or more whole rems are selected in the outline,
       // transform each rem's text (and back text, for concept/descriptor rems).
@@ -2187,99 +1929,6 @@ export async function registerCommands(plugin: ReactRNPlugin) {
     },
   });
 
-  // ─── Selection cache for Omnibar-invoked commands ────────────────────────
-  //
-  // Cmd+/ Omnibar steals editor focus before our command runs. By the time the
-  // action fires, plugin.editor.getSelection() / getSelectedRem() / focus all
-  // return undefined — RemNote's internal commands work because they capture
-  // the selection synchronously when the palette opens, but plugins have no
-  // such hook. Workaround: cache every non-empty selection as it happens, with
-  // a TTL, and let the command fall back to that cache when live APIs are empty.
-  //
-  // The cache is only WRITTEN on positive selection events (so opening the
-  // Omnibar — which fires a clear-selection event — doesn't wipe what we had).
-  const SELECTION_CACHE_KEY = 'lastEditorSelectionCache';
-  const SELECTION_CACHE_TTL_MS = 30_000;
-  type CachedSelection =
-    | { kind: 'rem'; remIds: string[]; capturedAt: number }
-    | { kind: 'text'; remId: string; capturedAt: number };
-
-  plugin.event.addListener(
-    AppEvents.EditorSelectionChanged,
-    undefined,
-    async () => {
-      try {
-        const sel = await plugin.editor.getSelection();
-        if (
-          sel?.type === SelectionType.Rem &&
-          (sel as any).remIds?.length > 0
-        ) {
-          const entry: CachedSelection = {
-            kind: 'rem',
-            remIds: (sel as any).remIds,
-            capturedAt: Date.now(),
-          };
-          await plugin.storage.setSession(SELECTION_CACHE_KEY, entry);
-        } else if (
-          sel?.type === SelectionType.Text &&
-          (sel as any).remId
-        ) {
-          const entry: CachedSelection = {
-            kind: 'text',
-            remId: (sel as any).remId,
-            capturedAt: Date.now(),
-          };
-          await plugin.storage.setSession(SELECTION_CACHE_KEY, entry);
-        }
-        // null / undefined / empty selection: leave the cache alone so an
-        // Omnibar focus shift doesn't blow away the user's last real choice.
-      } catch {
-        /* swallow — best-effort tracker */
-      }
-    }
-  );
-
-  // Drop-in replacement for `plugin.editor.getSelection()` that recovers the
-  // selection when invoked via Cmd+/ Omnibar (which blurs the editor before
-  // the command runs). Order of precedence:
-  //   1. live getSelection() — works for direct shortcut invocations.
-  //   2. live getSelectedRem() — sometimes survives focus shifts.
-  //   3. fresh cache entry from the EditorSelectionChanged listener (above).
-  // Returns a synthetic selection in the SDK's shape so existing call sites
-  // need only swap the API call, no other refactor.
-  const getEffectiveSelection = async () => {
-    const live = await plugin.editor.getSelection();
-    if (live) return live;
-
-    const remSel = await (plugin.editor as any).getSelectedRem?.();
-    if (remSel?.remIds?.length) return remSel;
-
-    const cached =
-      (await plugin.storage.getSession<CachedSelection>(
-        SELECTION_CACHE_KEY
-      )) || null;
-    const ageMs = cached ? Date.now() - cached.capturedAt : Infinity;
-    if (!cached || ageMs >= SELECTION_CACHE_TTL_MS) return undefined;
-
-    if (cached.kind === 'rem') {
-      return {
-        type: SelectionType.Rem,
-        remIds: cached.remIds,
-      } as any;
-    } else {
-      // Single-rem cache → synthesize a zero-width text-cursor selection.
-      // The richText/range fields are required by the SDK type but unused
-      // by the downstream code paths we care about (they only read remId).
-      return {
-        type: SelectionType.Text,
-        remId: cached.remId,
-        richText: [],
-        isReverse: false,
-        range: { start: 0, end: 0 },
-      } as any;
-    }
-  };
-
   // ─── Restructure Outline by Headings ──────────────────────────────────────
   //
   // Re-nests a flat or mis-pasted document so that paragraphs and lower-level
@@ -2294,52 +1943,26 @@ export async function registerCommands(plugin: ReactRNPlugin) {
     name: 'Restructure Outline by Headings',
     quickCode: 'roh',
     action: async () => {
-      // Cmd+/ Omnibar invocation blurs the editor, which makes
-      // plugin.editor.getSelection() / getSelectedRem() / focus all return
-      // undefined by the time the action fires. Try the live APIs first
-      // (which work fine for direct keyboard-shortcut invocations), then
-      // fall back to the EditorSelectionChanged cache populated above.
-      const remSel = await (plugin.editor as any).getSelectedRem?.();
-      const fullSel = await plugin.editor.getSelection();
-      const focusedRem = await plugin.focus.getFocusedRem();
+      // Resolves live editor selection if present, else the cached selection
+      // from the EditorSelectionChanged tracker (lib/editor_selection.ts) —
+      // necessary for Cmd+/ Omnibar invocations which blur the editor.
+      const selection = await getEffectiveSelection(plugin);
+      const focusedRem = selection ? undefined : await plugin.focus.getFocusedRem();
 
       let remIds: string[] | undefined;
       let textRemId: string | undefined;
-      let resolvedFocusedRemId: string | undefined = focusedRem?._id;
+      const resolvedFocusedRemId: string | undefined = focusedRem?._id;
 
-      if (remSel?.remIds?.length) {
-        remIds = remSel.remIds;
-      } else if (
-        fullSel?.type === SelectionType.Rem &&
-        (fullSel as any).remIds?.length
+      if (
+        selection?.type === SelectionType.Rem &&
+        selection.remIds?.length
       ) {
-        remIds = (fullSel as any).remIds;
+        remIds = selection.remIds;
       } else if (
-        fullSel?.type === SelectionType.Text &&
-        (fullSel as any).remId
+        selection?.type === SelectionType.Text &&
+        selection.remId
       ) {
-        textRemId = (fullSel as any).remId;
-      }
-
-      // Live APIs empty → consult the cache. Only honor it if no live signal
-      // is present at all (so a real single-rem focus never gets shadowed by
-      // a stale multi-rem selection from earlier).
-      if (!remIds && !textRemId && !resolvedFocusedRemId) {
-        const cached =
-          (await plugin.storage.getSession<CachedSelection>(
-            SELECTION_CACHE_KEY
-          )) || null;
-        const ageMs = cached ? Date.now() - cached.capturedAt : Infinity;
-        console.log(
-          '[outline-restructure] live selection empty; cache age (ms):',
-          ageMs,
-          'cache:',
-          cached
-        );
-        if (cached && ageMs < SELECTION_CACHE_TTL_MS) {
-          if (cached.kind === 'rem') remIds = cached.remIds;
-          else if (cached.kind === 'text') resolvedFocusedRemId = cached.remId;
-        }
+        textRemId = selection.remId;
       }
 
       let scopeRootId: string | undefined;

--- a/src/register/commands.ts
+++ b/src/register/commands.ts
@@ -2114,32 +2114,68 @@ export async function registerCommands(plugin: ReactRNPlugin) {
     keyboardShortcut: 'shift+F3',
     quickCode: 'case',
     action: async () => {
-      const selection = await plugin.editor.getSelectedText();
-      if (!selection?.richText?.length) {
+      const richTextToPlain = (rt: any[] | undefined): string =>
+        (rt || [])
+          .map((e: any) => (typeof e === 'string' ? e : e?.text ?? ''))
+          .join('');
+
+      const applyNextCase = (richText: any[], fullText: string, next: 'lower' | 'title' | 'upper') =>
+        next === 'title'
+          ? transformTitleCase(richText, fullText)
+          : transformCase(
+              richText,
+              next === 'upper' ? (s) => s.toUpperCase() : (s) => s.toLowerCase()
+            );
+
+      const selection = await plugin.editor.getSelection();
+
+      // Multi-rem path: when one or more whole rems are selected in the outline,
+      // transform each rem's text (and back text, for concept/descriptor rems).
+      if (selection?.type === SelectionType.Rem && selection.remIds?.length) {
+        const rems = (await plugin.rem.findMany(selection.remIds)) || [];
+        if (rems.length === 0) {
+          await plugin.app.toast('No rems found in selection.');
+          return;
+        }
+
+        // Detect the current case from all text concatenated, so the cycle
+        // (lower → title → upper → lower) advances consistently for the batch.
+        const combined = rems
+          .map((r) => `${richTextToPlain(r.text as any[])}\n${richTextToPlain(r.backText as any[])}`)
+          .join('\n');
+        const next = nextCase(detectCase(combined));
+
+        for (const rem of rems) {
+          const frontRT = (rem.text || []) as any[];
+          if (frontRT.length > 0) {
+            const frontFull = richTextToPlain(frontRT);
+            await rem.setText(applyNextCase(frontRT, frontFull, next));
+          }
+          const backRT = (rem.backText || []) as any[];
+          if (backRT.length > 0) {
+            const backFull = richTextToPlain(backRT);
+            await rem.setBackText(applyNextCase(backRT, backFull, next));
+          }
+        }
+        return;
+      }
+
+      // Single-rem path: transform just the selected text range.
+      const textSelection = await plugin.editor.getSelectedText();
+      if (!textSelection?.richText?.length) {
         await plugin.app.toast('No text selected.');
         return;
       }
 
-      const fullText = selection.richText
-        .map((e: any) => (typeof e === 'string' ? e : e?.text ?? ''))
-        .join('');
-
-      const current = detectCase(fullText);
-      const next = nextCase(current);
-
-      const transformed =
-        next === 'title'
-          ? transformTitleCase(selection.richText, fullText)
-          : transformCase(
-            selection.richText,
-            next === 'upper' ? (s) => s.toUpperCase() : (s) => s.toLowerCase()
-          );
+      const fullText = richTextToPlain(textSelection.richText);
+      const next = nextCase(detectCase(fullText));
+      const transformed = applyNextCase(textSelection.richText, fullText, next);
 
       await plugin.editor.delete();
       await plugin.editor.insertRichText(transformed);
       await plugin.editor.selectText({
-        start: selection.range.start,
-        end: selection.range.start + fullText.length,
+        start: textSelection.range.start,
+        end: textSelection.range.start + fullText.length,
       });
     },
   });

--- a/src/register/settings.ts
+++ b/src/register/settings.ts
@@ -94,7 +94,7 @@ export async function registerPluginSettings(plugin: ReactRNPlugin) {
     id: betaFirstReviewIntervalId,
     title: 'First Review Interval (Beta Scheduler)',
     description:
-      'Interval in days assigned after completing the first review. Not to be confused with "Initial Interval", which controls when a new IncRem first appears in the queue (before any review). Only used when the Beta Scheduler is enabled.',
+      'Interval in days assigned after completing the first review. Not to be confused with "Initial Interval", which controls when a new IncRem first appears in the queue (before any review). Only used when the Beta Scheduler is enabled. Default: 5 days.',
     defaultValue: 5,
   });
 
@@ -102,7 +102,7 @@ export async function registerPluginSettings(plugin: ReactRNPlugin) {
     id: betaMaxIntervalId,
     title: 'Max Interval (Beta Scheduler)',
     description:
-      'Upper bound in days the interval gradually approaches. The interval will never exceed this value. Only used when the Beta Scheduler is enabled.',
+      'Upper bound in days the interval gradually approaches. The interval will never exceed this value. Only used when the Beta Scheduler is enabled. Default: 30 days.',
     defaultValue: 30,
   });
 

--- a/src/register/settings.ts
+++ b/src/register/settings.ts
@@ -13,7 +13,7 @@ import {
   alwaysUseLightModeOnMobileId,
   alwaysUseLightModeOnWebId,
   remnoteEnvironmentId,
-  showRemsAsIsolatedInQueueId,
+  isolatedQueueModeId,
   displayFsrsDsrId,
   fsrsWeightsId,
   displayQueueToolbarPriorityId,
@@ -245,12 +245,37 @@ export async function registerPluginSettings(plugin: ReactRNPlugin) {
     defaultValue: true,
   });
 
-  plugin.settings.registerBooleanSetting({
-    id: showRemsAsIsolatedInQueueId,
-    title: 'Show regular Rems in isolated view (Queue)',
+  plugin.settings.registerDropdownSetting({
+    id: isolatedQueueModeId,
+    title: 'Use Isolated Card View in Queue for',
     description:
-      'When enabled, incremental Rems that are plain Rems will use the isolated card view in the queue instead of the full document context. Switch back to context with the button in the queue.',
-    defaultValue: false,
+      'Choose which incremental items use the isolated card view as their default view in the queue. ' +
+      'Highlights that do NOT use the isolated card view will be shown inside the PDF/HTML reader instead, ' +
+      'and regular Rems that do NOT use it will be shown in the full document context. ' +
+      'You can always toggle between the two views with the button in the queue — this setting only determines the initial view.',
+    defaultValue: 'highlights',
+    options: [
+      {
+        key: 'highlights',
+        label: 'Highlights (PDF/HTML)',
+        value: 'highlights',
+      },
+      {
+        key: 'rems',
+        label: 'Regular Rems',
+        value: 'rems',
+      },
+      {
+        key: 'both',
+        label: 'Both',
+        value: 'both',
+      },
+      {
+        key: 'none',
+        label: 'None',
+        value: 'none',
+      },
+    ],
   });
 
   plugin.settings.registerBooleanSetting({

--- a/src/register/widgets.ts
+++ b/src/register/widgets.ts
@@ -285,6 +285,27 @@ export async function registerWidgets(plugin: ReactRNPlugin) {
     },
   });
 
+  // Outline Restructure preview popup (Before | After + per-rem preserve toggles).
+  plugin.app.registerWidget('outline_restructure_preview', WidgetLocation.Popup, {
+    dimensions: {
+      width: 1100,
+      height: 800,
+    },
+  });
+
+  // Outline Restructure undo banner — appears in the sidebar after an apply,
+  // stays until the user clicks Undo or dismisses it.
+  plugin.app.registerWidget(
+    'outline_restructure_undo',
+    WidgetLocation.SidebarEnd,
+    {
+      dimensions: {
+        width: '100%',
+        height: 'auto',
+      },
+    }
+  );
+
   // Mastery Drill widgets are gated behind the 'skip_mastery_drill' setting.
   if (!skipMasteryDrill) {
     // Mastery Drill popup

--- a/src/widgets/incremental_history.tsx
+++ b/src/widgets/incremental_history.tsx
@@ -30,6 +30,9 @@ function IncrementalHistory() {
     // Search State
     const [searchText, setSearchText] = useState("");
 
+    // Event-type filter (radio buttons under the search box)
+    const [filterEvent, setFilterEvent] = useState<'ALL' | 'reviewed' | 'created' | 'dismissed'>('ALL');
+
     // KB-wide priority percentile map for IncRem priority badges
     const [percentileMap, setPercentileMap] = useState<Record<string, number>>({});
 
@@ -115,7 +118,18 @@ function IncrementalHistory() {
                 return item.kbId === currentKbId;
             });
 
-            // 2. Search Filter
+            // 2. Event-type filter. "dismissed" includes both standalone dismissals
+            //    and reviewed-and-then-dismissed entries (which display both badges).
+            if (filterEvent !== 'ALL') {
+                filtered = filtered.filter((item) => {
+                    if (filterEvent === 'dismissed') {
+                        return item.eventType === 'dismissed' || !!item.wasDismissed;
+                    }
+                    return item.eventType === filterEvent;
+                });
+            }
+
+            // 3. Search Filter
             if (searchText.trim().length > 0) {
                 const lowerSearch = searchText.toLowerCase();
                 const tokens = lowerSearch.split(/\s+/).filter(t => t.length > 0);
@@ -147,7 +161,7 @@ function IncrementalHistory() {
             setFilteredData(filtered);
         }
         filterData();
-    }, [historyDataRaw, plugin, searchText]);
+    }, [historyDataRaw, plugin, searchText, filterEvent]);
 
     const closeIndex = (itemKey: number) => {
         // Find index in original list
@@ -192,6 +206,20 @@ function IncrementalHistory() {
                     value={searchText}
                     onChange={(e) => setSearchText(e.target.value)}
                 />
+                <div className="flex flex-wrap gap-4 mt-2 text-sm rn-clr-content-primary">
+                    <label className="flex items-center gap-1 cursor-pointer">
+                        <input type="radio" checked={filterEvent === 'ALL'} onChange={() => setFilterEvent('ALL')} /> All
+                    </label>
+                    <label className="flex items-center gap-1 cursor-pointer">
+                        <input type="radio" checked={filterEvent === 'reviewed'} onChange={() => setFilterEvent('reviewed')} /> Reviewed
+                    </label>
+                    <label className="flex items-center gap-1 cursor-pointer">
+                        <input type="radio" checked={filterEvent === 'created'} onChange={() => setFilterEvent('created')} /> Created
+                    </label>
+                    <label className="flex items-center gap-1 cursor-pointer">
+                        <input type="radio" checked={filterEvent === 'dismissed'} onChange={() => setFilterEvent('dismissed')} /> Dismissed
+                    </label>
+                </div>
             </div>
             {filteredData.length === 0 && (
                 <div className="p-2 rn-clr-content-primary">

--- a/src/widgets/index.tsx
+++ b/src/widgets/index.tsx
@@ -25,7 +25,7 @@ import { enableHideInQueueIntegrationId } from '../lib/consts';
 import { registerIncrementalRemTracker } from '../register/tracker';
 import { cleanupOrphanedReviewGraphs } from '../lib/priority_review_document/cleanup';
 import { registerJumpToRemHelper } from '../register/window';
-import { registerPluginHidingCSS, registerPdfHighlightCSS, registerClozeExtractCSS, registerTagBadgeCSS } from '../lib/ui_helpers';
+import { registerPluginHidingCSS, registerPdfHighlightCSS, registerClozeExtractCSS, registerTagBadgeCSS, registerIgnoreTagCSS } from '../lib/ui_helpers';
 
 async function onActivate(plugin: ReactRNPlugin) {
   //Debug
@@ -75,6 +75,7 @@ async function onActivate(plugin: ReactRNPlugin) {
   await registerPluginHidingCSS(plugin);
   await registerClozeExtractCSS(plugin);
   await registerTagBadgeCSS(plugin);
+  await registerIgnoreTagCSS(plugin);
 
   await registerCommands(plugin);
 

--- a/src/widgets/outline_restructure_preview.tsx
+++ b/src/widgets/outline_restructure_preview.tsx
@@ -13,6 +13,7 @@ import {
   buildPlan,
   applyPlan,
   getHeadingLevel,
+  isMetaRem,
   HeadingLevel,
   ProposedNode,
   OUTLINE_SNAPSHOT_KEY,
@@ -37,13 +38,23 @@ async function buildBeforeTree(
   const visit = async (rem: PluginRem): Promise<BeforeNode> => {
     const level = await getHeadingLevel(rem);
     const text = await safeRemTextToString(plugin, (rem as any).text);
-    const childRems = (await rem.getChildrenRem()) || [];
+    const rawChildren = (await rem.getChildrenRem()) || [];
+    // Skip powerup-property bookkeeping rems (e.g. the auto-created "Size"
+    // child every Header heading gets) so the Before panel matches what the
+    // user sees in RemNote.
+    const childRems: PluginRem[] = [];
+    for (const c of rawChildren) {
+      if (!(await isMetaRem(c))) childRems.push(c);
+    }
     const children: BeforeNode[] = [];
     for (const c of childRems) children.push(await visit(c));
     return { remId: rem._id, level, text, children };
   };
   const out: BeforeNode[] = [];
-  for (const r of entryRems) out.push(await visit(r));
+  for (const r of entryRems) {
+    if (await isMetaRem(r)) continue;
+    out.push(await visit(r));
+  }
   return out;
 }
 

--- a/src/widgets/outline_restructure_preview.tsx
+++ b/src/widgets/outline_restructure_preview.tsx
@@ -1,0 +1,488 @@
+import {
+  renderWidget,
+  usePlugin,
+  useRunAsync,
+  WidgetLocation,
+  PluginRem,
+} from '@remnote/plugin-sdk';
+import React, { useEffect, useMemo, useState } from 'react';
+import '../style.css';
+import '../App.css';
+import {
+  collectCandidates,
+  buildPlan,
+  applyPlan,
+  getHeadingLevel,
+  HeadingLevel,
+  OutlineCandidate,
+  ProposedNode,
+  OUTLINE_SNAPSHOT_KEY,
+} from '../lib/outline_restructure';
+import { safeRemTextToString } from '../lib/pdfUtils';
+
+// ─── Tree-row rendering helpers ─────────────────────────────────────────────
+
+type BeforeNode = {
+  remId: string;
+  level: HeadingLevel | null;
+  text: string;
+  children: BeforeNode[];
+};
+
+// Recursively walks the CURRENT tree state for the given entry rems and
+// builds a display-only tree. Mirrors what the user sees in RemNote today.
+async function buildBeforeTree(
+  plugin: any,
+  entryRems: PluginRem[]
+): Promise<BeforeNode[]> {
+  const visit = async (rem: PluginRem): Promise<BeforeNode> => {
+    const level = await getHeadingLevel(rem);
+    const text = await safeRemTextToString(plugin, (rem as any).text);
+    const childRems = (await rem.getChildrenRem()) || [];
+    const children: BeforeNode[] = [];
+    for (const c of childRems) children.push(await visit(c));
+    return { remId: rem._id, level, text, children };
+  };
+  const out: BeforeNode[] = [];
+  for (const r of entryRems) out.push(await visit(r));
+  return out;
+}
+
+const HEADING_COLORS: Record<number, string> = {
+  1: '#1e3a8a', // blue-900
+  2: '#1d4ed8', // blue-700
+  3: '#0369a1', // sky-700
+  4: '#0d9488', // teal-600
+  5: '#65a30d', // lime-600
+  6: '#a16207', // yellow-700
+};
+
+function badgeFor(level: HeadingLevel | null) {
+  if (level === null) {
+    return (
+      <span
+        style={{
+          display: 'inline-block',
+          minWidth: 22,
+          textAlign: 'center',
+          color: 'var(--rn-clr-content-tertiary)',
+          fontSize: 10,
+          fontFamily: 'monospace',
+        }}
+      >
+        ¶
+      </span>
+    );
+  }
+  return (
+    <span
+      style={{
+        display: 'inline-block',
+        minWidth: 22,
+        textAlign: 'center',
+        background: HEADING_COLORS[level],
+        color: 'white',
+        fontSize: 10,
+        fontWeight: 700,
+        padding: '1px 4px',
+        borderRadius: 3,
+        fontFamily: 'monospace',
+      }}
+    >
+      H{level}
+    </span>
+  );
+}
+
+// One row in either Before or After tree. `changed` highlights rows whose
+// parent in the proposed plan differs from the current parent.
+function Row(props: {
+  level: HeadingLevel | null;
+  text: string;
+  depth: number;
+  changed?: boolean;
+  toggle?: React.ReactNode;
+  hiddenChildrenCount?: number;
+}) {
+  const { level, text, depth, changed, toggle, hiddenChildrenCount } = props;
+  return (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'flex-start',
+        gap: 6,
+        paddingLeft: 4 + depth * 14,
+        paddingTop: 1,
+        paddingBottom: 1,
+        borderLeft: changed
+          ? '2px solid #f59e0b'
+          : '2px solid transparent',
+        background: changed ? 'rgba(245, 158, 11, 0.08)' : 'transparent',
+      }}
+    >
+      {badgeFor(level)}
+      <span
+        style={{
+          flex: 1,
+          fontSize: 12,
+          color: 'var(--rn-clr-content-primary)',
+          wordBreak: 'break-word',
+          lineHeight: 1.35,
+        }}
+      >
+        {text || 'Untitled'}
+        {hiddenChildrenCount && hiddenChildrenCount > 0 ? (
+          <span
+            style={{
+              marginLeft: 6,
+              fontSize: 10,
+              color: 'var(--rn-clr-content-tertiary)',
+              fontStyle: 'italic',
+            }}
+          >
+            +{hiddenChildrenCount} child{hiddenChildrenCount > 1 ? 'ren' : ''}
+          </span>
+        ) : null}
+      </span>
+      {toggle}
+    </div>
+  );
+}
+
+// ─── Widget ──────────────────────────────────────────────────────────────────
+
+type WidgetContext = {
+  scopeRootId: string;
+  inputRemIds: string[]; // top-level entry rems for the walk
+};
+
+const OutlineRestructurePreview = () => {
+  const plugin = usePlugin();
+
+  const ctx = useRunAsync(
+    async () => await plugin.widget.getWidgetContext<WidgetLocation.Popup>(),
+    []
+  ) as WidgetContext | undefined;
+
+  // preserveMap: per-rem override of preserveChildren. Defaults true for
+  // paragraph rems that have children (the algorithm's default). Toggling
+  // a row to "Flatten" sets false, which makes the children appear as
+  // independent candidates in the After tree.
+  const [preserveMap, setPreserveMap] = useState<Record<string, boolean>>({});
+  const [busy, setBusy] = useState(false);
+  const [version, setVersion] = useState(0); // bumped on toggle to re-derive
+
+  const data = useRunAsync(async () => {
+    if (!ctx) return undefined;
+
+    const inputRems = (await plugin.rem.findMany(ctx.inputRemIds)) || [];
+    if (inputRems.length === 0) return undefined;
+
+    const before = await buildBeforeTree(plugin, inputRems);
+    const candidates = await collectCandidates(plugin, inputRems, preserveMap);
+    const plan = buildPlan(candidates, ctx.scopeRootId);
+
+    // Map original parent for each candidate so we can flag "changed" in the
+    // After tree (newParent !== originalParent).
+    const originalParentByRem: Record<string, string> = {};
+    for (const c of candidates) originalParentByRem[c.remId] = c.originalParentId;
+    const newParentByRem: Record<string, string> = {};
+    for (const op of plan.ops) newParentByRem[op.remId] = op.newParentId;
+
+    return {
+      before,
+      candidates,
+      plan,
+      originalParentByRem,
+      newParentByRem,
+    };
+  }, [ctx, version]);
+
+  // Headings/paragraphs counts for the status bar.
+  const counts = useMemo(() => {
+    if (!data) return { headings: 0, paragraphs: 0, moved: 0 };
+    let h = 0;
+    let p = 0;
+    for (const c of data.candidates) {
+      if (c.level !== null) h++;
+      else p++;
+    }
+    let moved = 0;
+    for (const c of data.candidates) {
+      if (
+        data.originalParentByRem[c.remId] !== data.newParentByRem[c.remId]
+      ) {
+        moved++;
+      }
+    }
+    return { headings: h, paragraphs: p, moved };
+  }, [data]);
+
+  // Render the Before tree (current state, full subtrees).
+  const renderBefore = (nodes: BeforeNode[], depth = 0): React.ReactNode => {
+    return nodes.map((n) => (
+      <React.Fragment key={n.remId}>
+        <Row level={n.level} text={n.text} depth={depth} />
+        {n.children.length > 0 ? renderBefore(n.children, depth + 1) : null}
+      </React.Fragment>
+    ));
+  };
+
+  // Render the After tree from the proposed plan. Each row shows the per-rem
+  // preserve/flatten toggle when applicable.
+  const renderAfter = (nodes: ProposedNode[], depth = 0): React.ReactNode => {
+    if (!data) return null;
+    return nodes.map((n) => {
+      const c = n.candidate;
+      const isChanged =
+        data.originalParentByRem[c.remId] !== data.newParentByRem[c.remId];
+
+      // The toggle appears only for non-heading rems that have children in
+      // the original tree. Headings always recurse; childless rems have nothing
+      // to preserve.
+      const showToggle = c.level === null && c.hasChildren;
+      const currentlyPreserving =
+        preserveMap[c.remId] !== undefined ? preserveMap[c.remId] : true;
+
+      // If preserveChildren is true, the rem's children are NOT in the candidate
+      // list — they ride along as opaque subtree. Show a small "+N children" hint.
+      // We don't know the count without re-querying; rough approximation: 1+.
+      const hiddenChildHint =
+        showToggle && currentlyPreserving ? 1 : 0;
+
+      const toggle = showToggle ? (
+        <button
+          onClick={() => {
+            setPreserveMap((prev) => ({
+              ...prev,
+              [c.remId]: !currentlyPreserving,
+            }));
+            setVersion((v) => v + 1);
+          }}
+          title={
+            currentlyPreserving
+              ? 'Children currently kept attached. Click to flatten and re-organize them by heading rules.'
+              : 'Children currently flattened. Click to keep them attached as an opaque subtree.'
+          }
+          style={{
+            fontSize: 10,
+            padding: '1px 6px',
+            borderRadius: 3,
+            border: '1px solid var(--rn-clr-border-subtle)',
+            background: currentlyPreserving
+              ? 'var(--rn-clr-background-elevation-10)'
+              : '#fef3c7',
+            color: 'var(--rn-clr-content-secondary)',
+            cursor: 'pointer',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {currentlyPreserving ? '⏷ Preserve' : '⏵ Flatten'}
+        </button>
+      ) : undefined;
+
+      return (
+        <React.Fragment key={c.remId}>
+          <Row
+            level={c.level}
+            text={c.text}
+            depth={depth}
+            changed={isChanged}
+            toggle={toggle}
+            hiddenChildrenCount={hiddenChildHint}
+          />
+          {n.children.length > 0 ? renderAfter(n.children, depth + 1) : null}
+        </React.Fragment>
+      );
+    });
+  };
+
+  const onApply = async () => {
+    if (!data || busy) return;
+    setBusy(true);
+    try {
+      const snapshot = await applyPlan(plugin, data.plan);
+      await plugin.storage.setSession(OUTLINE_SNAPSHOT_KEY, snapshot);
+      await plugin.app.toast(
+        `Outline restructured: ${counts.moved} rem${counts.moved === 1 ? '' : 's'} moved.`
+      );
+      await plugin.widget.closePopup();
+    } catch (e) {
+      console.error('[outline-restructure] apply failed:', e);
+      await plugin.app.toast(`Restructure failed: ${(e as any)?.message ?? e}`);
+      setBusy(false);
+    }
+  };
+
+  const onCancel = () => {
+    plugin.widget.closePopup();
+  };
+
+  // ─── Render ───────────────────────────────────────────────────────────────
+
+  if (!ctx) {
+    return (
+      <div style={{ padding: 16, color: 'var(--rn-clr-content-tertiary)' }}>
+        No context.
+      </div>
+    );
+  }
+
+  if (!data) {
+    return (
+      <div style={{ padding: 16, color: 'var(--rn-clr-content-tertiary)' }}>
+        Analyzing outline…
+      </div>
+    );
+  }
+
+  const noHeadings = data.plan.minHeadingLevel === 0;
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        height: '100%',
+        background: 'var(--rn-clr-background-primary)',
+        color: 'var(--rn-clr-content-primary)',
+      }}
+    >
+      <div
+        style={{
+          padding: '12px 16px',
+          borderBottom: '1px solid var(--rn-clr-border-subtle)',
+          flexShrink: 0,
+        }}
+      >
+        <div style={{ fontSize: 14, fontWeight: 600 }}>
+          Restructure Outline by Headings
+        </div>
+        <div
+          style={{
+            fontSize: 11,
+            color: 'var(--rn-clr-content-tertiary)',
+            marginTop: 4,
+          }}
+        >
+          {noHeadings
+            ? 'No headings detected in the selection. Nothing to restructure.'
+            : `${counts.headings} heading${counts.headings === 1 ? '' : 's'} · ${counts.paragraphs} paragraph${counts.paragraphs === 1 ? '' : 's'} · ${counts.moved} would move`}
+        </div>
+      </div>
+
+      <div
+        style={{
+          flex: 1,
+          minHeight: 0,
+          display: 'grid',
+          gridTemplateColumns: '1fr 1fr',
+          gap: 0,
+        }}
+      >
+        <div
+          style={{
+            borderRight: '1px solid var(--rn-clr-border-subtle)',
+            overflow: 'auto',
+            padding: '8px 8px 8px 12px',
+          }}
+        >
+          <div
+            style={{
+              fontSize: 11,
+              fontWeight: 700,
+              color: 'var(--rn-clr-content-secondary)',
+              textTransform: 'uppercase',
+              letterSpacing: '0.05em',
+              marginBottom: 6,
+            }}
+          >
+            Before
+          </div>
+          {renderBefore(data.before)}
+        </div>
+        <div
+          style={{
+            overflow: 'auto',
+            padding: '8px 12px 8px 8px',
+          }}
+        >
+          <div
+            style={{
+              fontSize: 11,
+              fontWeight: 700,
+              color: 'var(--rn-clr-content-secondary)',
+              textTransform: 'uppercase',
+              letterSpacing: '0.05em',
+              marginBottom: 6,
+            }}
+          >
+            After
+          </div>
+          {noHeadings ? (
+            <div
+              style={{
+                fontSize: 12,
+                color: 'var(--rn-clr-content-tertiary)',
+                fontStyle: 'italic',
+              }}
+            >
+              (no changes — no headings to anchor on)
+            </div>
+          ) : (
+            renderAfter(data.plan.proposedTree)
+          )}
+        </div>
+      </div>
+
+      <div
+        style={{
+          padding: '10px 16px',
+          borderTop: '1px solid var(--rn-clr-border-subtle)',
+          display: 'flex',
+          justifyContent: 'flex-end',
+          gap: 8,
+          flexShrink: 0,
+        }}
+      >
+        <button
+          onClick={onCancel}
+          disabled={busy}
+          style={{
+            padding: '6px 14px',
+            border: '1px solid var(--rn-clr-border-subtle)',
+            background: 'transparent',
+            color: 'var(--rn-clr-content-primary)',
+            borderRadius: 4,
+            cursor: 'pointer',
+            fontSize: 13,
+          }}
+        >
+          Cancel
+        </button>
+        <button
+          onClick={onApply}
+          disabled={busy || noHeadings || counts.moved === 0}
+          style={{
+            padding: '6px 14px',
+            border: '1px solid transparent',
+            background:
+              busy || noHeadings || counts.moved === 0 ? '#94a3b8' : '#2563eb',
+            color: 'white',
+            borderRadius: 4,
+            cursor:
+              busy || noHeadings || counts.moved === 0
+                ? 'not-allowed'
+                : 'pointer',
+            fontSize: 13,
+            fontWeight: 600,
+          }}
+        >
+          {busy ? 'Applying…' : 'Apply'}
+        </button>
+      </div>
+    </div>
+  );
+};
+
+renderWidget(OutlineRestructurePreview);

--- a/src/widgets/outline_restructure_preview.tsx
+++ b/src/widgets/outline_restructure_preview.tsx
@@ -5,7 +5,7 @@ import {
   WidgetLocation,
   PluginRem,
 } from '@remnote/plugin-sdk';
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import '../style.css';
 import '../App.css';
 import {
@@ -14,7 +14,6 @@ import {
   applyPlan,
   getHeadingLevel,
   HeadingLevel,
-  OutlineCandidate,
   ProposedNode,
   OUTLINE_SNAPSHOT_KEY,
 } from '../lib/outline_restructure';
@@ -151,7 +150,7 @@ function Row(props: {
 
 // ─── Widget ──────────────────────────────────────────────────────────────────
 
-type WidgetContext = {
+type WidgetContextData = {
   scopeRootId: string;
   inputRemIds: string[]; // top-level entry rems for the walk
 };
@@ -159,10 +158,13 @@ type WidgetContext = {
 const OutlineRestructurePreview = () => {
   const plugin = usePlugin();
 
-  const ctx = useRunAsync(
+  const rawCtx = useRunAsync(
     async () => await plugin.widget.getWidgetContext<WidgetLocation.Popup>(),
     []
-  ) as WidgetContext | undefined;
+  );
+  // openPopup's second arg arrives under contextData, not directly on the
+  // context object — same shape RemNote uses for every popup in this codebase.
+  const ctx = (rawCtx as any)?.contextData as WidgetContextData | undefined;
 
   // preserveMap: per-rem override of preserveChildren. Defaults true for
   // paragraph rems that have children (the algorithm's default). Toggling

--- a/src/widgets/outline_restructure_undo.tsx
+++ b/src/widgets/outline_restructure_undo.tsx
@@ -1,0 +1,109 @@
+import {
+  renderWidget,
+  usePlugin,
+  useTrackerPlugin,
+} from '@remnote/plugin-sdk';
+import React, { useState } from 'react';
+import '../style.css';
+import '../App.css';
+import {
+  OUTLINE_SNAPSHOT_KEY,
+  OutlineSnapshot,
+  revertSnapshot,
+} from '../lib/outline_restructure';
+
+export const OutlineRestructureUndo = () => {
+  const plugin = usePlugin();
+  // Tracks the snapshot reactively from session storage so the widget appears
+  // immediately after a restructure and disappears after revert / dismiss.
+  const snapshot = useTrackerPlugin(
+    async (rp) =>
+      (await rp.storage.getSession<OutlineSnapshot>(OUTLINE_SNAPSHOT_KEY)) ||
+      null,
+    []
+  );
+
+  const [dismissed, setDismissed] = useState<number | null>(null);
+  const [reverting, setReverting] = useState(false);
+
+  if (!snapshot) return null;
+  // Per-snapshot dismissal: once the user X's a snapshot, hide it until a new
+  // restructure replaces it (we key dismissal on timestamp).
+  if (dismissed === snapshot.timestamp) return null;
+
+  const onUndo = async () => {
+    if (reverting) return;
+    setReverting(true);
+    try {
+      await revertSnapshot(plugin, snapshot);
+      await plugin.storage.setSession(OUTLINE_SNAPSHOT_KEY, undefined);
+      await plugin.app.toast('Outline restructure reverted.');
+    } catch (e) {
+      console.error('[outline-restructure] revert failed:', e);
+      await plugin.app.toast(`Revert failed: ${(e as any)?.message ?? e}`);
+    } finally {
+      setReverting(false);
+    }
+  };
+
+  const onDismiss = () => setDismissed(snapshot.timestamp);
+
+  const movedCount = snapshot.ops.length;
+  const when = new Date(snapshot.timestamp);
+  const hh = String(when.getHours()).padStart(2, '0');
+  const mm = String(when.getMinutes()).padStart(2, '0');
+
+  const containerStyle: React.CSSProperties = {
+    backgroundColor: 'var(--rn-clr-background-elevation-10)',
+    border: '1px solid var(--rn-clr-border-subtle)',
+    color: 'var(--rn-clr-content-primary)',
+    boxShadow: 'var(--rn-box-shadow-1)',
+  };
+
+  return (
+    <div
+      style={containerStyle}
+      className="flex flex-col gap-2 p-3 rounded-lg mb-2"
+    >
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <span style={{ fontSize: 16 }}>↩</span>
+          <span className="font-semibold text-sm">Outline Restructured</span>
+        </div>
+        <button
+          onClick={onDismiss}
+          className="hover:opacity-75"
+          style={{ color: 'var(--rn-clr-content-tertiary)' }}
+          title="Hide this notification (does not revert)"
+        >
+          ✕
+        </button>
+      </div>
+
+      <div
+        className="text-xs"
+        style={{ color: 'var(--rn-clr-content-secondary)' }}
+      >
+        <span className="font-bold">{movedCount}</span>{' '}
+        rem{movedCount === 1 ? '' : 's'} moved in{' '}
+        <span style={{ fontStyle: 'italic' }}>{snapshot.scopeRootText}</span>{' '}
+        at {hh}:{mm}.
+      </div>
+
+      <button
+        onClick={onUndo}
+        disabled={reverting}
+        className="w-full py-1 px-2 text-white text-sm font-medium rounded transition-colors"
+        style={{
+          background: reverting ? '#94a3b8' : '#ef4444',
+          cursor: reverting ? 'not-allowed' : 'pointer',
+          border: 'none',
+        }}
+      >
+        {reverting ? 'Reverting…' : 'Undo Restructure'}
+      </button>
+    </div>
+  );
+};
+
+renderWidget(OutlineRestructureUndo);

--- a/src/widgets/priority_shield_graph.tsx
+++ b/src/widgets/priority_shield_graph.tsx
@@ -29,6 +29,7 @@ interface ShieldHistoryEntry {
 
 interface ChartData {
   date: string;
+  originalDate: string;
   absolute: number | null;
   relative: number | null;
   universeSize: number; // NEW: Universe size for the chart
@@ -37,6 +38,24 @@ interface ChartData {
   processingPercentage?: number;
   weightedShield?: number | null;
 }
+
+type TimePeriod = 'month' | '3m' | '6m' | 'year' | 'all';
+
+const TIME_PERIOD_OPTIONS: { value: TimePeriod; label: string }[] = [
+  { value: 'month', label: '1M' },
+  { value: '3m', label: '3M' },
+  { value: '6m', label: '6M' },
+  { value: 'year', label: '1Y' },
+  { value: 'all', label: 'All' },
+];
+
+const PERIOD_TO_DAYS: Record<TimePeriod, number | null> = {
+  month: 30,
+  '3m': 90,
+  '6m': 180,
+  year: 365,
+  all: null,
+};
 
 function PriorityShieldGraph() {
   const plugin = usePlugin();
@@ -50,6 +69,7 @@ function PriorityShieldGraph() {
   }>>({});
 
   const [showWeightedShield, setShowWeightedShield] = useState(false);
+  const [timePeriod, setTimePeriod] = useState<TimePeriod>('3m');
 
   const getZState = (title: string) => {
     return zoomState[title] || {
@@ -120,8 +140,19 @@ function PriorityShieldGraph() {
     const sortedData = unsortedData.sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
     return sortedData.map(item => ({
       ...item,
+      originalDate: item.date,
       date: dayjs(item.date).format('MMM DD'),
     }));
+  };
+
+  const filterByPeriod = <T extends { originalDate?: string }>(data: T[] | null | undefined, period: TimePeriod): T[] => {
+    if (!data || data.length === 0) return [];
+    const days = PERIOD_TO_DAYS[period];
+    if (days === null) return data;
+    const cutoff = dayjs().subtract(days, 'day').startOf('day');
+    const filtered = data.filter(d => d.originalDate && dayjs(d.originalDate).isAfter(cutoff));
+    // If the period filter removes everything (e.g. very old data), fall back to full data
+    return filtered.length > 0 ? filtered : data;
   };
 
   // --- Incremental Rem Data ---
@@ -588,10 +619,15 @@ function PriorityShieldGraph() {
     );
   };
 
-  const hasKbData = kbChartData && kbChartData.length > 0;
-  const hasDocData = docChartData && docChartData.length > 0;
-  const hasCardKbData = cardKbChartData && cardKbChartData.length > 0;
-  const hasCardDocData = cardDocChartData && cardDocChartData.length > 0;
+  const filteredKbChartData = filterByPeriod(kbChartData, timePeriod);
+  const filteredDocChartData = filterByPeriod(docChartData, timePeriod);
+  const filteredCardKbChartData = filterByPeriod(cardKbChartData, timePeriod);
+  const filteredCardDocChartData = filterByPeriod(cardDocChartData, timePeriod);
+
+  const hasKbData = filteredKbChartData.length > 0;
+  const hasDocData = filteredDocChartData.length > 0;
+  const hasCardKbData = filteredCardKbChartData.length > 0;
+  const hasCardDocData = filteredCardDocChartData.length > 0;
 
   if (!hasKbData && !hasDocData && !hasCardKbData && !hasCardDocData) {
     return <div className="p-4">No history data found. Start reviewing to build your graph!</div>;
@@ -602,25 +638,46 @@ function PriorityShieldGraph() {
     <div className="p-4 flex flex-col" style={{ width: '1030px' }}>
       <div className="flex flex-col items-center mb-6 relative">
         <h3 className="text-lg font-bold">Priority Shield History</h3>
-        <label className="flex items-center gap-1.5 mt-2 text-sm cursor-pointer select-none" style={{ color: 'var(--rn-clr-content-secondary)' }}>
-          <input
-            type="checkbox"
-            checked={showWeightedShield}
-            onChange={(e) => setShowWeightedShield(e.target.checked)}
-            style={{ cursor: 'pointer' }}
-          />
-          Show Weighted Shield
-        </label>
+        <div className="flex items-center gap-4 mt-2 text-sm flex-wrap justify-center" style={{ color: 'var(--rn-clr-content-secondary)' }}>
+          <label className="flex items-center gap-1.5 cursor-pointer select-none">
+            <input
+              type="checkbox"
+              checked={showWeightedShield}
+              onChange={(e) => setShowWeightedShield(e.target.checked)}
+              style={{ cursor: 'pointer' }}
+            />
+            Show Weighted Shield
+          </label>
+          <div className="flex items-center gap-2 select-none" role="radiogroup" aria-label="Time period">
+            <span className="text-xs uppercase tracking-wider opacity-70">Period:</span>
+            {TIME_PERIOD_OPTIONS.map(opt => (
+              <label key={opt.value} className="flex items-center gap-1 cursor-pointer">
+                <input
+                  type="radio"
+                  name="time-period"
+                  value={opt.value}
+                  checked={timePeriod === opt.value}
+                  onChange={() => {
+                    setTimePeriod(opt.value);
+                    setZoomState({});
+                  }}
+                  style={{ cursor: 'pointer' }}
+                />
+                {opt.label}
+              </label>
+            ))}
+          </div>
+        </div>
       </div>
 
       {/* Show document-level charts if we have an effective scope (original or current) */}
       {effectiveDocScopeId && hasDocData && renderChart(
-        docChartData!,
+        filteredDocChartData,
         `📄 ${documentName || 'Document'} IncRem Shield`,
         '#e74c3c', '#f39c12', '#9b59b6'
       )}
       {effectiveDocScopeId && hasCardDocData && renderChart(
-        cardDocChartData!,
+        filteredCardDocChartData,
         `📄 ${documentName || 'Document'} Card Shield`,
         '#d35400', '#f1c40f', '#16a085'
       )}
@@ -630,12 +687,12 @@ function PriorityShieldGraph() {
       )}
 
       {hasKbData && renderChart(
-        kbChartData,
+        filteredKbChartData,
         '🌐 Knowledge Base IncRem Shield',
         '#8884d8', '#82ca9d', '#e91e63'
       )}
       {hasCardKbData && renderChart(
-        cardKbChartData,
+        filteredCardKbChartData,
         '🌐 Knowledge Base Card Shield',
         '#c0392b', '#e67e22', '#2980b9'
       )}

--- a/src/widgets/queue.tsx
+++ b/src/widgets/queue.tsx
@@ -18,7 +18,8 @@ import {
   shouldHideIncEverythingKey,
   currentIncrementalRemTypeKey,
   activeHighlightIdKey,
-  showRemsAsIsolatedInQueueId,
+  isolatedQueueModeId,
+  IsolatedQueueMode,
   powerupCode,
   currentHostDocumentIdKey,
 } from '../lib/consts';
@@ -30,7 +31,7 @@ type ViewMode = 'isolated' | 'context';
 
 export function QueueComponent() {
   const plugin = usePlugin();
-  const [viewMode, setViewMode] = useState<ViewMode>('isolated');
+  const [viewMode, setViewMode] = useState<ViewMode | undefined>(undefined);
   const [sourceDocName, setSourceDocName] = useState<string | undefined>();
   const [showSpark, setShowSpark] = useState(false);
 
@@ -61,10 +62,15 @@ export function QueueComponent() {
     [ctx?.remId]
   );
 
-  const showRemsAsIsolated = useTrackerPlugin(
-    (rp) => rp.settings.getSetting<boolean>(showRemsAsIsolatedInQueueId),
+  const isolatedMode = useTrackerPlugin(
+    async (rp) => {
+      const value = await rp.settings.getSetting<IsolatedQueueMode>(isolatedQueueModeId);
+      return (value || 'highlights') as IsolatedQueueMode;
+    },
     []
   );
+  const isolatedDefaultForHighlight = isolatedMode === 'highlights' || isolatedMode === 'both';
+  const isolatedDefaultForRem = isolatedMode === 'rems' || isolatedMode === 'both';
 
   // This hook signals the component's state.
   useEffect(() => {
@@ -163,9 +169,11 @@ export function QueueComponent() {
     }
   }, [hasIncrementalPowerup, plugin]);
 
-  // Reset view mode when switching to a new rem
+  // Reset view mode when switching to a new rem.
+  // The default view mode is computed once `remAndType` and the user setting
+  // have resolved, in the effect below — so we clear it here.
   useEffect(() => {
-    setViewMode('isolated');
+    setViewMode(undefined);
     setSourceDocName(undefined);
   }, [ctx?.remId]);
 
@@ -183,22 +191,37 @@ export function QueueComponent() {
     loadSourceDocName();
   }, [remAndType, plugin]);
 
-  // Helper to determine if we should show isolated view
-  // Only show isolated view for PDF/HTML highlights, NOT for regular rems
-  // Regular rems benefit from the rich ExtractViewer with descendants and metadata
+  // The isolated card view is supported for highlights AND regular rems.
+  // The user setting controls the DEFAULT view; the user can always toggle.
   const isHighlightType = remAndType?.type === 'pdf-highlight' || remAndType?.type === 'html-highlight';
   const isRemType = remAndType?.type === 'rem';
-  const shouldShowIsolated = viewMode === 'isolated' && (isHighlightType || (isRemType && showRemsAsIsolated));
+  const supportsIsolated = isHighlightType || isRemType;
 
-  // Trigger a single spark when entering context view for highlights or isolated-rem mode
+  // Initialize viewMode once we know the item type and the setting has loaded.
   useEffect(() => {
-    if (viewMode === 'context' && (isHighlightType || (isRemType && showRemsAsIsolated))) {
+    if (viewMode !== undefined) return;
+    if (!remAndType || isolatedMode === undefined) return;
+    if (!supportsIsolated) {
+      setViewMode('context');
+      return;
+    }
+    const defaultIsolated = isHighlightType
+      ? isolatedDefaultForHighlight
+      : isolatedDefaultForRem;
+    setViewMode(defaultIsolated ? 'isolated' : 'context');
+  }, [viewMode, remAndType, isolatedMode, supportsIsolated, isHighlightType, isolatedDefaultForHighlight, isolatedDefaultForRem]);
+
+  const shouldShowIsolated = viewMode === 'isolated' && supportsIsolated;
+
+  // Trigger a single spark when entering context view for items that support isolated view
+  useEffect(() => {
+    if (viewMode === 'context' && supportsIsolated) {
       setShowSpark(true);
       const timer = setTimeout(() => setShowSpark(false), 1800);
       return () => clearTimeout(timer);
     }
     setShowSpark(false);
-  }, [viewMode, isHighlightType, isRemType, showRemsAsIsolated]);
+  }, [viewMode, supportsIsolated]);
 
   // AFTER ALL HOOKS, NOW you can return early
   if (!ctx?.remId) return null;
@@ -208,13 +231,13 @@ export function QueueComponent() {
 
   if (remAndType?.type === 'rem' && !shouldRenderEditorForRemType) return null;
 
-  // Get the rem to display in isolated view (highlights and optionally rems)
+  // Get the rem to display in isolated view (highlights and rems)
   const getIsolatedRem = () => {
     if (!remAndType) return null;
     if (isHighlightType) {
       return (remAndType as any).extract;
     }
-    if (isRemType && showRemsAsIsolated) {
+    if (isRemType) {
       return remAndType.rem;
     }
     return null;
@@ -225,7 +248,7 @@ export function QueueComponent() {
   return (
     <div className="incremental-everything-element" style={{ height: '100%' }}>
       <div className="box-border p-2" style={{ height: `100vh`, position: 'relative' }}>
-        {viewMode === 'context' && (isHighlightType || (isRemType && showRemsAsIsolated)) && (
+        {viewMode === 'context' && supportsIsolated && (
           <div style={{ position: 'absolute', top: 12, right: 12, zIndex: 10 }}>
             <style>{`
               .inc-back-btn {
@@ -282,7 +305,7 @@ export function QueueComponent() {
             sourceDocumentName={isHighlightType ? sourceDocName : undefined}
             sourceDocumentId={isHighlightType ? remAndType.rem._id : undefined}
             sourceType={remAndType.type}
-            onViewInContext={(isHighlightType || (isRemType && showRemsAsIsolated)) ? () => setViewMode('context') : undefined}
+            onViewInContext={supportsIsolated ? () => setViewMode('context') : undefined}
           />
         ) : remAndType.type === 'pdf' ||
           remAndType.type === 'html' ||


### PR DESCRIPTION
## v0.2.255 - May 25th, 2026

### ✨ New: Restructure Outline by Headings (`roh`)

A new [**Restructure Outline by Headings**](Utilities#restructure-outline-by-headings) command (`quick: roh`) re-nests a flat or mis-pasted document so paragraphs and lower-level headings sit under their preceding higher-level heading. Built for the common case of pasting structured web content into RemNote — which often arrives as a flat list of siblings, or with `H2`s mis-indented under paragraphs instead of their parent `H1`.

- **Scope-aware:** single rem selected → operates on its descendants; multi-rem → on those rems plus descendants, slotting the restructured subtree back into the selection's original position so unselected siblings keep their relative order around it.
- **Before | After preview popup:** every row that would move is highlighted; non-heading rems with children get an inline **⏷ Preserve / ⏵ Flatten** toggle so you can opt in/out of pulling each subtree into the candidate flow. Toggle re-runs the algorithm live.
- **All six heading levels supported:** H1–H6, including heading-level skips (e.g. `H1 → H3` with no `H2` nests the `H3` directly under the `H1`).
- **Undoable:** after applying, an **Outline Restructured** banner appears in the sidebar with an **Undo Restructure** button; also available as the `Revert Last Outline Restructure` command (`quick: rolr`). Restores every moved rem to its exact prior parent and position.

### ✨ Improvement: Text Case Converter Now Works on Multi-Rem Selections

[**Text Case Converter**](Utilities#text-case-converter) (`Shift+F3`) previously only cycled the text **within a single rem**. It now also detects when one or more **whole rems** are selected in the outline and applies the next case (Title → UPPER → lower) to every selected rem's text — including the **back text** of concept/descriptor rems. The cycle stage is detected from the combined text of the batch so all rems advance together, while Title Case is still computed per rem so each one's first/last-word rule is respected.

### ✨ Improvement: Multi-Rem Commands Now Work via `Cmd+/` Omnibar

RemNote blurs the editor when the `Cmd+/` Omnibar opens, which caused plugin commands invoked via palette-search to lose access to whatever multi-rem selection the user had — they would silently no-op or fall back to the focused rem only. A new internal selection cache (subscribed to `EditorSelectionChanged`) restores this behavior for every multi-rem-aware command in the plugin:

- **Make Incremental (Extract)** / **Extract with Priority**
- **Dismiss Incremental Rem**
- **Paste Rem Sources**
- **Text Case Converter**
- **Restructure Outline by Headings**

See [Utilities → Omnibar Selection Recovery](Utilities#omnibar-selection-recovery) for the technical details.

---

## v0.2.254 - May 24th, 2026

### ✨ New: Toggle Ignore Tag (`Ctrl+Shift+I`)

Adds/removes an `#ignore` tag on the focused editor Rem. Ignored rems are visually shrunk and dimmed so they read as archived snippets, and the `#ignore` chip is hidden from the editor tag bar to declutter. Use it during Incremental Reading on snippets you've already read but didn't find important enough to make Incremental — they remain in place for archive or future consultation, and the de-emphasized styling signals that they need not be re-processed.

---

## v0.2.252 - May 22nd, 2026

### ✨ Improvement: Isolated Card View Setting Expanded to Cover Highlights

The previous **Show regular Rems in isolated view (Queue)** boolean has been replaced by a dropdown — [**Use Isolated Card View in Queue for**](Plugin-Settings-Reference#queue-display) — letting you pick which item types open in the [Isolated Card Viewer](Plugin-Widgets-Reference) by default in the queue:

- **Highlights (PDF/HTML)** *(default)* — only highlights open in the card view; regular Rems open in their full document context.
- **Regular Rems** — only regular Rems open in the card view; highlights open in the PDF/HTML reader.
- **Both** — highlights and regular Rems both open in the card view.
- **None** — neither type opens in the card view by default; highlights go to the PDF/HTML reader and regular Rems to the full document context.

The toggle button in the queue is now **always** available regardless of the setting — the setting only determines the *initial* view for each item, and you can flip back and forth at any time.

### 🐛 Fix: "Create Incremental Rem" From Isolated Card Viewer No Longer Breaks the Queue

When using the **Create Rem** / **Create Incremental Rem** buttons in the Isolated Card Viewer on a highlight that *is* the current queue item, the queue would advance to a blank page. Removing the *Incremental* powerup from the current queue item tears down the queue widget's sandbox before its own tracker can react and advance the queue. The fix mirrors the existing Dismiss button pattern: when the highlight is the current queue item, the powerup removal and the queue advance are now fired simultaneously so both IPC messages reach RemNote before the widget is destroyed.
