### PR TITLE
feat: shrink plugin synced storage footprint (v1.0.30)

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -2,6 +2,40 @@
 
 This page documents the major changes and improvements for each version of the Incremental Everything (Plus) plugin.
 
+## v1.0.30 - August 3rd, 2026
+
+Housekeeping release, prompted by the storage limits described in v1.0.29. Everything here reduces what the plugin keeps in — and writes to — RemNote's plugin storage. Two of these were genuine defects that the new limits merely exposed.
+
+### 🐛 Fixed: the Study Dashboard's lifetime statistics had silently stopped updating
+
+The store holding your day-by-day review totals had grown to **1.21MB** — roughly 7,250 daily buckets covering your entire review history — which is past RemNote's new 900KB ceiling for a single plugin value. Writes over that ceiling are *rejected rather than truncated*, and the rejection was being swallowed, so every recomputation was quietly discarded and the dashboard's lifetime figures froze at whatever had last been saved.
+
+The store is now written compactly: your knowledge base's id is recorded once instead of once per day, and each day is a plain row of numbers rather than a block of repeated field names. Same data, **about a third of the size** — no day of history is lost. The conversion runs by itself the next time the plugin starts and needs none of the APIs RemNote removed in 1.27.16, so it works even on the broken build.
+
+One limitation while 1.27.16 stands: this restores the plugin's *ability* to save these statistics, but recomputing fresh ones still walks every flashcard, which needs the removed `card.getAll` back.
+
+### ⚡ Improved: expanding a history row no longer rewrites the whole list
+
+**Flashcard History**, **Visited Rem History** and **IncRem Repetition History** each stored the expanded/collapsed state of every row *in synced storage*. Clicking a chevron therefore rewrote the entire list — in the case of Flashcard History, more than half a megabyte pushed through the sync layer, for a triangle rotating.
+
+That state now lives in the panel itself, and those writes are gone entirely. The visible trade-off: expanded rows no longer stay expanded after you close and reopen a panel.
+
+### ⚡ Improved: leaner history entries
+
+**Flashcard History** now keeps up to 500 characters of a card's front and back (previously 1000), which is ample for the searchable preview these lists exist to provide.
+
+**Visited Rem History** was applying *no limit at all* when recording a visit — the full text of every Rem you navigated to went into storage — while the same panel truncated to 200 characters whenever it filled in missing entries. Both paths now share one limit, so they can no longer disagree.
+
+Existing entries keep their current text and shrink naturally as they are rewritten; nothing is discarded up front.
+
+### 🛠️ New: Synced Storage Key Audit (Debug Widget)
+
+A diagnostic behind the `Debug Incremental Everything` command. It reconstructs every storage key the plugin is capable of writing — from your Incremental Rems, PDFs, documents and videos — probes each one, and reports how many exist, how much space each family occupies, which individual keys are approaching RemNote's 900KB per-key and 10MB total ceilings, and how many orphaned keys are left behind by deleted Rems.
+
+This is what produced the numbers behind the three fixes above, and it is how the storage picture will be verified once RemNote provides deletion and enumeration APIs.
+
+📖 See [Study Dashboard](Study-Dashboard.md) for the statistics affected by the first fix, and [Troubleshooting](Troubleshooting.md) for the Debug Widget tools.
+
 ## v1.0.29 - August 1st, 2026
 
 ### ⚠️ Service notice: the plugin is temporarily out of operation on RemNote 1.27.16

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -10,7 +10,7 @@
   "version": {
     "major": 1,
     "minor": 0,
-    "patch": 29
+    "patch": 30
   },
   "unlisted": false,
   "theme": [],

--- a/src/lib/authoritative_aggregates.ts
+++ b/src/lib/authoritative_aggregates.ts
@@ -19,6 +19,131 @@ import { repCountsForStats } from './incremental_rem/types';
 export const AUTHORITATIVE_AGGREGATES_KEY = 'authoritativeDailyAggregates';
 export const AUTHORITATIVE_LAST_COMPUTED_KEY = 'authoritativeAggregatesLastComputed';
 
+// ---------------------------------------------------------------------------
+// Storage format
+//
+// This key holds one bucket per (day, knowledge base) for the user's ENTIRE
+// review history, so it grows forever — roughly 175 bytes per bucket in the
+// original `DailyAggregate[]` form, of which the six numbers that carry the
+// actual data were a minority: every bucket repeated eight field names and a
+// 24-character kbId. At ~7,250 buckets that reached 1.21MB and blew past
+// RemNote's 900KB per-key ceiling, so every recompute was silently rejected and
+// the dashboard's authoritative figures froze.
+//
+// Buckets are therefore stored keyed by kbId → date → a positional row, which
+// writes the kbId once per KB instead of once per day and drops the field names
+// entirely. Same data, ~5x smaller. `ids` is not stored at all: the authoritative
+// walk never populates it (findOrCreateBucket creates an empty array and nothing
+// pushes to it) — it exists only on the listener-derived aggregates, which live
+// under a different key and keep their original format.
+//
+// Reads accept either shape, so no migration step is needed: the next successful
+// recompute rewrites the key in the compact form.
+// ---------------------------------------------------------------------------
+
+/** [totalTime, cardsCount, cardsTime, incRemsCount, incRemsTime, forgotCount] — times in ms. */
+type CompactRow = [number, number, number, number, number, number];
+
+interface CompactAggregateStore {
+  /** Format version. Absent/array ⇒ the legacy `DailyAggregate[]` form. */
+  v: 2;
+  /** kbId → date (YYYY-MM-DD) → row */
+  kbs: Record<string, Record<string, CompactRow>>;
+}
+
+function isCompactStore(raw: unknown): raw is CompactAggregateStore {
+  return !!raw && !Array.isArray(raw) && typeof raw === 'object' && (raw as any).v === 2;
+}
+
+/** Accepts either storage shape (or junk) and returns plain buckets. */
+export function decodeAuthoritativeAggregates(raw: unknown): DailyAggregate[] {
+  if (!raw) return [];
+
+  if (isCompactStore(raw)) {
+    const out: DailyAggregate[] = [];
+    for (const [kbId, byDate] of Object.entries(raw.kbs || {})) {
+      for (const [date, row] of Object.entries(byDate || {})) {
+        if (!Array.isArray(row)) continue;
+        out.push({
+          date,
+          kbId,
+          totalTime: row[0] || 0,
+          cardsCount: row[1] || 0,
+          cardsTime: row[2] || 0,
+          incRemsCount: row[3] || 0,
+          incRemsTime: row[4] || 0,
+          forgotCount: row[5] || 0,
+          ids: [], // never populated for authoritative buckets; kept for shape compatibility
+        });
+      }
+    }
+    return out;
+  }
+
+  // Legacy: a plain array of DailyAggregate.
+  if (Array.isArray(raw)) return raw.filter((b): b is DailyAggregate => !!b && typeof b === 'object');
+
+  return [];
+}
+
+/**
+ * Rewrite the stored value in the compact form if it is still the legacy array.
+ *
+ * This is deliberately independent of the recompute: recomputing walks every
+ * card (`plugin.card.getAll`, removed in RemNote 1.27.16) and cannot run at all
+ * right now, whereas this only reads the key and writes it back in a smaller
+ * shape — no card data, no rem enumeration, nothing the platform took away.
+ * That matters because the legacy value is over the 900KB per-key ceiling, so
+ * until it shrinks, EVERY write to this key is rejected.
+ *
+ * Idempotent: a value already in v2 form is left alone, so this is safe to run
+ * on every activation. Also safe at the 1000-key cap — the key already exists,
+ * and overwrites of existing keys are still accepted.
+ */
+export async function compactAuthoritativeAggregatesIfNeeded(plugin: RNPlugin): Promise<boolean> {
+  try {
+    const raw = await plugin.storage.getSynced(AUTHORITATIVE_AGGREGATES_KEY);
+    if (!raw || isCompactStore(raw)) return false; // nothing stored, or already compact
+    if (!Array.isArray(raw) || raw.length === 0) return false;
+
+    const beforeBytes = JSON.stringify(raw).length;
+    const payload = encodeAuthoritativeAggregates(decodeAuthoritativeAggregates(raw));
+    const afterBytes = JSON.stringify(payload).length;
+
+    await plugin.storage.setSynced(AUTHORITATIVE_AGGREGATES_KEY, payload);
+    console.log(
+      `[AuthoritativeAggregates] Compacted ${raw.length} buckets: ` +
+        `${(beforeBytes / 1024).toFixed(1)}KB → ${(afterBytes / 1024).toFixed(1)}KB ` +
+        `(${(beforeBytes / afterBytes).toFixed(1)}x smaller, now ` +
+        `${((afterBytes / (900 * 1024)) * 100).toFixed(0)}% of the 900KB per-key limit).`
+    );
+    return true;
+  } catch (err) {
+    console.warn('[AuthoritativeAggregates] Compaction failed', err);
+    return false;
+  }
+}
+
+export function encodeAuthoritativeAggregates(buckets: DailyAggregate[]): CompactAggregateStore {
+  const kbs: Record<string, Record<string, CompactRow>> = {};
+  for (const b of buckets) {
+    if (!b || !b.date || !b.kbId) continue;
+    // Times are milliseconds accumulated from reviewTimeSeconds * 1000, so they
+    // are whole numbers already; rounding only guards against float drift
+    // producing a 17-digit literal in the JSON.
+    const row: CompactRow = [
+      Math.round(b.totalTime || 0),
+      Math.round(b.cardsCount || 0),
+      Math.round(b.cardsTime || 0),
+      Math.round(b.incRemsCount || 0),
+      Math.round(b.incRemsTime || 0),
+      Math.round(b.forgotCount || 0),
+    ];
+    (kbs[b.kbId] ||= {})[b.date] = row;
+  }
+  return { v: 2, kbs };
+}
+
 // Days strictly before this local date are not fully reliable for IncRem stats:
 // the Dismissed powerup (which preserves history when a rem is no longer
 // Incremental) was introduced on 2026-01-30 (commit fc21734). Reviews on rems
@@ -244,19 +369,45 @@ export async function saveAuthoritativeAggregates(
   currentKbBuckets: DailyAggregate[]
 ): Promise<void> {
   const kbId = (await plugin.kb.getCurrentKnowledgeBaseData())._id;
-  const existing =
-    ((await plugin.storage.getSynced(AUTHORITATIVE_AGGREGATES_KEY)) as DailyAggregate[]) || [];
+  const existing = decodeAuthoritativeAggregates(
+    await plugin.storage.getSynced(AUTHORITATIVE_AGGREGATES_KEY)
+  );
   const otherKbs = existing.filter((b) => !!b && b.kbId !== kbId && b.kbId !== UNKNOWN_KB_ID);
-  await plugin.storage.setSynced(AUTHORITATIVE_AGGREGATES_KEY, [...otherKbs, ...currentKbBuckets]);
+  const payload = encodeAuthoritativeAggregates([...otherKbs, ...currentKbBuckets]);
+
+  // This key outgrew RemNote's 900KB per-key ceiling once already, and a write
+  // over it is rejected rather than truncated — which is silent unless we look.
+  // Log the size so a regression shows up in the console instead of as a
+  // dashboard that mysteriously stops updating.
+  const bytes = JSON.stringify(payload).length;
+  const pctOfLimit = (bytes / (900 * 1024)) * 100;
+  if (pctOfLimit >= 50) {
+    console.warn(
+      `[AuthoritativeAggregates] Payload is ${(bytes / 1024).toFixed(1)}KB — ` +
+        `${pctOfLimit.toFixed(0)}% of the 900KB per-key limit. Consider rolling old days up into months.`
+    );
+  } else {
+    console.log(
+      `[AuthoritativeAggregates] Saving ${otherKbs.length + currentKbBuckets.length} buckets, ` +
+        `${(bytes / 1024).toFixed(1)}KB (${pctOfLimit.toFixed(1)}% of the per-key limit).`
+    );
+  }
+
+  await plugin.storage.setSynced(AUTHORITATIVE_AGGREGATES_KEY, payload);
   await plugin.storage.setSynced(AUTHORITATIVE_LAST_COMPUTED_KEY, Date.now());
 }
 
+/**
+ * Takes the raw stored value in EITHER format (legacy array or compact store)
+ * and returns this KB's buckets. Callers pass whatever `getSynced` /
+ * `useSyncedStorageState` handed them; decoding lives here so no consumer has
+ * to know which shape is on disk.
+ */
 export function filterAuthoritativeForKb(
-  aggregates: DailyAggregate[] | null | undefined,
+  aggregates: unknown,
   currentKbId: string
 ): DailyAggregate[] {
-  if (!aggregates) return [];
-  return aggregates.filter((a) => !!a && a.kbId === currentKbId);
+  return decodeAuthoritativeAggregates(aggregates).filter((a) => a.kbId === currentKbId);
 }
 
 /**

--- a/src/lib/consts.ts
+++ b/src/lib/consts.ts
@@ -129,6 +129,15 @@ export const documentCardPriorityShieldHistoryKey = 'document-card-priority-shie
 // clears this KB's shield partition, plus an index listing them for restore.
 export const cardShieldCleanupBackupPrefix = 'card-shield-cleanup-backup-';
 export const cardShieldCleanupBackupIndexKey = 'card-shield-cleanup-backup-index';
+// Characters kept per side (front / back) in the history jump-lists. The stored
+// `text` field is "front back", so one entry holds at most 2×limit + 1 chars.
+// These lists are searched by substring and shown as one-line previews — they are
+// caches for navigation, not a copy of the card, and they live in synced storage
+// where a 900KB per-key ceiling applies. Keep the writer and the widget backfill
+// on the same constant so they cannot drift apart.
+export const flashcardHistoryTextLimit = 500;
+export const remHistoryTextLimit = 200;
+
 // Restore point of a rem's Incremental history, captured by the debug tools
 // before a hand-edit. One synced key per backed-up rem — lives here (not in
 // debug.tsx) so the synced-key audit can reconstruct the family.

--- a/src/lib/history_utils.ts
+++ b/src/lib/history_utils.ts
@@ -4,6 +4,8 @@ export interface IncrementalHistoryData {
     key: number;
     remId: RemId;
     time: number;
+    /** @deprecated Legacy field. Row expansion is component state now — entries
+     *  written before that change still carry it, and it is ignored. */
     open?: boolean;
     kbId?: string;
     text?: string;

--- a/src/lib/synced_key_audit.ts
+++ b/src/lib/synced_key_audit.ts
@@ -55,11 +55,27 @@ import { AUTHORITATIVE_AGGREGATES_KEY, AUTHORITATIVE_LAST_COMPUTED_KEY } from '.
 
 export const SYNCED_KEY_CAP = 1000;
 
+/** RemNote's documented ceilings: 900KB for a single synced value, 10MB for a
+ *  plugin's whole synced footprint. Measured sizes here are the UTF-8 length of
+ *  `JSON.stringify(value)` — a close proxy for what gets synced, not the exact
+ *  on-disk figure, which we have no way to read. */
+export const PER_KEY_BYTE_LIMIT = 900 * 1024;
+export const TOTAL_BYTE_BUDGET = 10 * 1024 * 1024;
+/** Flag a key once it passes half of the per-key ceiling — enough runway to act. */
+const SIZE_WARN_RATIO = 0.5;
+/** How many of the biggest keys to keep for the report. */
+const LARGEST_KEYS_KEPT = 20;
+
 /** Probe concurrency. Each getSynced is an IPC round trip; the bridge chokes
  *  well before this becomes a throughput win, so keep it modest. */
 const PROBE_CONCURRENCY = 12;
 
 export type ProbeState = 'live' | 'nulled' | 'absent';
+
+export interface KeySize {
+  key: string;
+  bytes: number;
+}
 
 export interface FamilyReport {
   family: string;
@@ -72,6 +88,10 @@ export interface FamilyReport {
   /** Keys that exist holding null — almost certainly still consuming a slot. */
   nulled: number;
   absent: number;
+  /** Sum of measured sizes of this family's live keys. */
+  bytes: number;
+  /** The single fattest key in this family, if any. */
+  largest?: KeySize;
   /** Up to 5 example keys that came back live. */
   sample: string[];
   /** Keys safe to sacrifice in the capacity experiment (pure backup/orphan data). */
@@ -104,6 +124,14 @@ export interface AuditResult {
   occupied: number;
   /** cap − occupied: keys that must exist but that we could not name. */
   unaccounted: number;
+  /** Total measured size of every live key we could name. */
+  totalBytes: number;
+  perKeyLimit: number;
+  totalBudget: number;
+  /** The fattest keys found, biggest first. */
+  largestKeys: KeySize[];
+  /** Keys past half the per-key ceiling — the ones worth restructuring. */
+  sizeWarnings: KeySize[];
   disposable: string[];
   kbIds: string[];
   scanned: {
@@ -130,23 +158,46 @@ interface FamilyCandidates {
 
 // --- probing ---------------------------------------------------------------
 
-async function probeKey(plugin: RNPlugin, key: string): Promise<ProbeState> {
+const textEncoder = typeof TextEncoder !== 'undefined' ? new TextEncoder() : null;
+
+/** UTF-8 byte length of a value's JSON form. Falls back to the string length
+ *  where TextEncoder is unavailable, which only under-counts non-ASCII. */
+function measureBytes(value: unknown): number {
+  let json: string;
+  try {
+    json = JSON.stringify(value) ?? '';
+  } catch {
+    return 0; // circular or otherwise unserializable — should not happen for stored data
+  }
+  return textEncoder ? textEncoder.encode(json).length : json.length;
+}
+
+export function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(2)} MB`;
+}
+
+async function probeKey(plugin: RNPlugin, key: string): Promise<{ state: ProbeState; bytes: number }> {
   try {
     const value = await plugin.storage.getSynced(key);
-    if (value === undefined) return 'absent';
-    if (value === null) return 'nulled';
-    return 'live';
+    if (value === undefined) return { state: 'absent', bytes: 0 };
+    if (value === null) return { state: 'nulled', bytes: 0 };
+    // Measure and drop the value immediately — holding thousands of them would
+    // cost more memory than the storage we're auditing.
+    return { state: 'live', bytes: measureBytes(value) };
   } catch {
     // A read that throws tells us nothing about existence; treat as absent so we
     // never over-count, and let the unaccounted figure absorb it.
-    return 'absent';
+    return { state: 'absent', bytes: 0 };
   }
 }
 
 async function probeFamily(
   plugin: RNPlugin,
   candidates: FamilyCandidates,
-  onProgress?: (done: number, total: number) => void
+  onProgress?: (done: number, total: number) => void,
+  onLiveKey?: (entry: KeySize) => void
 ): Promise<FamilyReport> {
   // The same key can be generated twice (e.g. a PDF reachable both directly and
   // as a source); counting it twice would overstate slot usage.
@@ -159,6 +210,7 @@ async function probeFamily(
     live: 0,
     nulled: 0,
     absent: 0,
+    bytes: 0,
     sample: [],
     disposable: [],
     note: candidates.note,
@@ -166,11 +218,14 @@ async function probeFamily(
 
   for (let i = 0; i < keys.length; i += PROBE_CONCURRENCY) {
     const chunk = keys.slice(i, i + PROBE_CONCURRENCY);
-    const states = await Promise.all(chunk.map((k) => probeKey(plugin, k)));
-    states.forEach((state, j) => {
+    const results = await Promise.all(chunk.map((k) => probeKey(plugin, k)));
+    results.forEach(({ state, bytes }, j) => {
       const key = chunk[j];
       if (state === 'live') {
         report.live++;
+        report.bytes += bytes;
+        if (!report.largest || bytes > report.largest.bytes) report.largest = { key, bytes };
+        onLiveKey?.({ key, bytes });
         if (report.sample.length < 5) report.sample.push(key);
         if (candidates.disposable) report.disposable!.push(key);
       } else if (state === 'nulled') {
@@ -502,7 +557,7 @@ async function buildCandidates(
  *  and the live/nulled/absent split cannot be trusted. */
 async function calibrateNullSignal(plugin: RNPlugin): Promise<boolean> {
   const neverWritten = `__ie_key_audit_calibration_${Date.now()}_${Math.random().toString(36).slice(2)}`;
-  const state = await probeKey(plugin, neverWritten);
+  const { state } = await probeKey(plugin, neverWritten);
   if (state !== 'absent') {
     console.warn(
       `[KeyAudit] Calibration: an unwritten key read back as "${state}" — undefined/null are indistinguishable, ` +
@@ -525,12 +580,30 @@ export async function auditSyncedKeys(
   const totalCandidates = candidates.reduce((s, f) => s + f.keys.length, 0);
   let done = 0;
   const reports: FamilyReport[] = [];
+  // Running top-N by size. Kept as a plain sorted array — N is tiny, and the
+  // alternative (retaining every live key's size) would be thousands of entries.
+  const largestKeys: KeySize[] = [];
+  const recordSize = (entry: KeySize) => {
+    if (largestKeys.length < LARGEST_KEYS_KEPT) {
+      largestKeys.push(entry);
+      largestKeys.sort((a, b) => b.bytes - a.bytes);
+    } else if (entry.bytes > largestKeys[largestKeys.length - 1].bytes) {
+      largestKeys[largestKeys.length - 1] = entry;
+      largestKeys.sort((a, b) => b.bytes - a.bytes);
+    }
+  };
+
   for (const family of candidates) {
-    const report = await probeFamily(plugin, family, (chunkDone, chunkTotal) => {
-      onProgress?.(
-        `Probing ${family.family}: ${chunkDone}/${chunkTotal} (${done + chunkDone}/${totalCandidates} total)…`
-      );
-    });
+    const report = await probeFamily(
+      plugin,
+      family,
+      (chunkDone, chunkTotal) => {
+        onProgress?.(
+          `Probing ${family.family}: ${chunkDone}/${chunkTotal} (${done + chunkDone}/${totalCandidates} total)…`
+        );
+      },
+      recordSize
+    );
     done += report.probed;
     reports.push(report);
   }
@@ -548,10 +621,16 @@ export async function auditSyncedKeys(
   // Nulled keys only count as occupied when the absent/null distinction survived
   // calibration; otherwise every unwritten key reads as null and would inflate it.
   const occupied = totals.live + (nullSignalUsable ? totals.nulled : 0);
+  const totalBytes = reports.reduce((s, r) => s + r.bytes, 0);
 
   const result: AuditResult = {
     durationMs: Date.now() - started,
     families: reports,
+    totalBytes,
+    perKeyLimit: PER_KEY_BYTE_LIMIT,
+    totalBudget: TOTAL_BYTE_BUDGET,
+    largestKeys,
+    sizeWarnings: largestKeys.filter((k) => k.bytes >= PER_KEY_BYTE_LIMIT * SIZE_WARN_RATIO),
     totals,
     cap: SYNCED_KEY_CAP,
     occupied,
@@ -575,18 +654,42 @@ export function logAuditResult(result: AuditResult): void {
   );
   console.log(`KB ids seen: ${result.kbIds.join(', ')}`);
   console.table(
-    result.families.map((f) => ({
-      family: f.family,
-      probed: f.probed,
-      live: f.live,
-      nulled: f.nulled,
-      coverage: f.coverage,
-    }))
+    [...result.families]
+      .sort((a, b) => b.bytes - a.bytes)
+      .map((f) => ({
+        family: f.family,
+        probed: f.probed,
+        live: f.live,
+        nulled: f.nulled,
+        size: formatBytes(f.bytes),
+        largest: f.largest ? formatBytes(f.largest.bytes) : '—',
+        coverage: f.coverage,
+      }))
   );
   console.log(
     `TOTAL — probed ${result.totals.probed}, live ${result.totals.live}, nulled ${result.totals.nulled}`
   );
   console.log(`Occupying slots: ${result.occupied} of ${result.cap}`);
+  console.log(
+    `Measured footprint: ${formatBytes(result.totalBytes)} of ${formatBytes(result.totalBudget)} ` +
+      `(${((result.totalBytes / result.totalBudget) * 100).toFixed(1)}% of the plugin budget)`
+  );
+  if (result.largestKeys.length > 0) {
+    console.log(`Largest keys (per-key ceiling ${formatBytes(result.perKeyLimit)}):`);
+    console.table(
+      result.largestKeys.map((k) => ({
+        key: k.key,
+        size: formatBytes(k.bytes),
+        '% of per-key limit': `${((k.bytes / result.perKeyLimit) * 100).toFixed(1)}%`,
+      }))
+    );
+  }
+  for (const warn of result.sizeWarnings) {
+    console.warn(
+      `[KeyAudit] "${warn.key}" is ${formatBytes(warn.bytes)} — ` +
+        `${((warn.bytes / result.perKeyLimit) * 100).toFixed(0)}% of the ${formatBytes(result.perKeyLimit)} per-key ceiling.`
+    );
+  }
   console.log(`Unaccounted (orphans we cannot name): ~${result.unaccounted}`);
   if (!result.nullSignalUsable) {
     console.warn(

--- a/src/register/events.ts
+++ b/src/register/events.ts
@@ -22,6 +22,8 @@ import {
   sourceFloatingActiveIdKey,
   autoFocusQueueDashboardId,
   pendingQueueDashboardRefocusKey,
+  flashcardHistoryTextLimit,
+  remHistoryTextLimit,
 } from '../lib/consts';
 import {
   CardPriorityInfo,
@@ -560,8 +562,8 @@ export function registerQueueCompleteCardListener(plugin: ReactRNPlugin) {
           try {
             const frontRaw = rem?.text ? await safeRemTextToString(plugin, rem.text) : '';
             const backRaw = rem?.backText ? await safeRemTextToString(plugin, rem.backText) : '';
-            frontText = typeof frontRaw === 'string' && frontRaw !== 'Untitled' ? frontRaw.substring(0, 1000) : '';
-            backText = typeof backRaw === 'string' && backRaw !== 'Untitled' ? backRaw.substring(0, 1000) : '';
+            frontText = typeof frontRaw === 'string' && frontRaw !== 'Untitled' ? frontRaw.substring(0, flashcardHistoryTextLimit) : '';
+            backText = typeof backRaw === 'string' && backRaw !== 'Untitled' ? backRaw.substring(0, flashcardHistoryTextLimit) : '';
           } catch (error) {
             console.warn('Error parsing Rem text for flashcard history:', error);
             frontText = '[Complex Media Rem]';
@@ -577,7 +579,6 @@ export function registerQueueCompleteCardListener(plugin: ReactRNPlugin) {
               key: Math.random(),
               remId,
               cardId: effectiveCardId,
-              open: false,
               time: new Date().getTime(),
               kbId: currentKbId,
               text,
@@ -767,8 +768,8 @@ export function registerGlobalRemChangedListener(plugin: ReactRNPlugin) {
                   try {
                     const frontRaw = clusterRem?.text ? await safeRemTextToString(plugin, clusterRem.text) : '';
                     const backRaw = clusterRem?.backText ? await safeRemTextToString(plugin, clusterRem.backText) : '';
-                    frontText = typeof frontRaw === 'string' && frontRaw !== 'Untitled' ? frontRaw.substring(0, 1000) : '';
-                    backText = typeof backRaw === 'string' && backRaw !== 'Untitled' ? backRaw.substring(0, 1000) : '';
+                    frontText = typeof frontRaw === 'string' && frontRaw !== 'Untitled' ? frontRaw.substring(0, flashcardHistoryTextLimit) : '';
+                    backText = typeof backRaw === 'string' && backRaw !== 'Untitled' ? backRaw.substring(0, flashcardHistoryTextLimit) : '';
                   } catch (_e) {
                     frontText = '[Complex Media Rem]';
                   }
@@ -779,7 +780,6 @@ export function registerGlobalRemChangedListener(plugin: ReactRNPlugin) {
                       key: Math.random(),
                       remId: card?.remId,
                       cardId: clusterCardId,
-                      open: false,
                       time: new Date().getTime(),
                       kbId: currentKbId,
                       text,
@@ -1079,8 +1079,16 @@ export function registerGlobalOpenRemListener(plugin: ReactRNPlugin) {
     try {
       const frontRaw = rem?.text ? await safeRemTextToString(plugin, rem.text) : '';
       const backRaw = rem?.backText ? await safeRemTextToString(plugin, rem.backText) : '';
-      frontText = typeof frontRaw === 'string' && frontRaw !== 'Untitled' ? frontRaw : '';
-      backText = typeof backRaw === 'string' && backRaw !== 'Untitled' ? backRaw : '';
+      // Capped to match the widget's own backfill: this writer had no limit at
+      // all, so visiting a Rem with a long body stored the whole thing.
+      frontText =
+        typeof frontRaw === 'string' && frontRaw !== 'Untitled'
+          ? frontRaw.substring(0, remHistoryTextLimit)
+          : '';
+      backText =
+        typeof backRaw === 'string' && backRaw !== 'Untitled'
+          ? backRaw.substring(0, remHistoryTextLimit)
+          : '';
     } catch (error) {
       console.warn('Error parsing Rem text for visited history:', error);
     }
@@ -1091,7 +1099,6 @@ export function registerGlobalOpenRemListener(plugin: ReactRNPlugin) {
       {
         key: Math.random(),
         remId: currentRemId,
-        open: false,
         time: new Date().getTime(),
         kbId: currentKbId,
         text,
@@ -1169,8 +1176,8 @@ function registerDrillCardRatingListener(plugin: ReactRNPlugin) {
         try {
           const frontRaw = drillRem?.text ? await safeRemTextToString(plugin, drillRem.text) : '';
           const backRaw = drillRem?.backText ? await safeRemTextToString(plugin, drillRem.backText) : '';
-          frontText = typeof frontRaw === 'string' && frontRaw !== 'Untitled' ? frontRaw.substring(0, 1000) : '';
-          backText = typeof backRaw === 'string' && backRaw !== 'Untitled' ? backRaw.substring(0, 1000) : '';
+          frontText = typeof frontRaw === 'string' && frontRaw !== 'Untitled' ? frontRaw.substring(0, flashcardHistoryTextLimit) : '';
+          backText = typeof backRaw === 'string' && backRaw !== 'Untitled' ? backRaw.substring(0, flashcardHistoryTextLimit) : '';
         } catch (_e) {
           frontText = '[Complex Media Rem]';
         }
@@ -1181,7 +1188,6 @@ function registerDrillCardRatingListener(plugin: ReactRNPlugin) {
             key: Math.random(),
             remId: card?.remId,
             cardId,
-            open: false,
             time: new Date().getTime(),
             kbId: currentKbId,
             text,

--- a/src/widgets/debug.tsx
+++ b/src/widgets/debug.tsx
@@ -37,6 +37,7 @@ import {
   probeWriteCapacity,
   testNullFreesSlot,
   SYNCED_KEY_CAP,
+  formatBytes,
   AuditResult,
   CapacityReport,
   NullFreesSlotReport,
@@ -1592,7 +1593,7 @@ function Debug() {
       setKeyAudit(result);
       setKeyAuditProgress('');
       await plugin.app.toast(
-        `Audit done — ${result.totals.live + result.totals.nulled} named key(s) of ${result.cap}.`
+        `Audit done — ${result.occupied} named key(s) of ${result.cap}, ${formatBytes(result.totalBytes)} measured.`
       );
     } catch (e) {
       console.error('[KeyAudit] Scan failed', e);
@@ -3635,9 +3636,10 @@ function Debug() {
           them, so this reconstructs every key the plugin can write from the KB (IncRems × PDFs, documents, links,
           videos, …) and probes each with <code>getSynced</code>. <strong>live</strong> = holds a value,{' '}
           <strong>nulled</strong> = the key exists holding <code>null</code> (our "delete" pattern — still occupying a
-          slot). Orphan keys whose rem was deleted can't be named; they show up as <em>unaccounted</em>. Every candidate
-          costs one IPC read, so a large KB can take a few minutes and will feel sluggish while it runs. Full dump in
-          console.
+          slot). Orphan keys whose rem was deleted can't be named; they show up as <em>unaccounted</em>. Sizes are the
+          UTF-8 length of each value's JSON — a close proxy for what syncs, measured against RemNote's{' '}
+          {formatBytes(900 * 1024)} per-key and {formatBytes(10 * 1024 * 1024)} total ceilings. Every candidate costs
+          one IPC read, so a large KB can take a few minutes and will feel sluggish while it runs. Full dump in console.
         </div>
         {keyAuditProgress && (
           <div style={{ fontSize: '11px', color: 'var(--rn-clr-content-secondary)', marginBottom: '8px' }}>
@@ -3658,6 +3660,15 @@ function Debug() {
               <div>Unaccounted (unnameable orphans): <strong style={{ color: keyAudit.unaccounted > 0 ? '#ef4444' : 'inherit' }}>~{keyAudit.unaccounted}</strong></div>
               <div>Live: <strong>{keyAudit.totals.live}</strong> · Nulled: <strong style={{ color: keyAudit.totals.nulled > 0 ? '#ef4444' : 'inherit' }}>{keyAudit.totals.nulled}</strong></div>
               <div>Probed: <strong>{keyAudit.totals.probed}</strong> candidate keys in {(keyAudit.durationMs / 1000).toFixed(1)}s</div>
+              <div>
+                Measured footprint: <strong>{formatBytes(keyAudit.totalBytes)}</strong> / {formatBytes(keyAudit.totalBudget)}{' '}
+                ({((keyAudit.totalBytes / keyAudit.totalBudget) * 100).toFixed(1)}%)
+              </div>
+              <div>
+                Biggest key: <strong style={{ color: keyAudit.sizeWarnings.length > 0 ? '#ef4444' : 'inherit' }}>
+                  {keyAudit.largestKeys[0] ? formatBytes(keyAudit.largestKeys[0].bytes) : '—'}
+                </strong> / {formatBytes(keyAudit.perKeyLimit)} per-key ceiling
+              </div>
               <div style={{ gridColumn: '1 / -1' }}>
                 Scanned: {keyAudit.scanned.allRems} rems ({keyAudit.scanned.incRems} IncRem ·{' '}
                 {keyAudit.scanned.dismissed} Dismissed) · {keyAudit.scanned.pdfPairs} IncRem×PDF pairs ·{' '}
@@ -3669,6 +3680,20 @@ function Debug() {
                 Calibration failed: a key that was never written did not read back as <code>undefined</code>, so
                 "nulled" can't be told apart from "absent". That column is excluded from the occupied count — use the
                 null-frees-slot experiment instead.
+              </div>
+            )}
+            {keyAudit.sizeWarnings.length > 0 && (
+              <div style={{ fontSize: '12px', marginBottom: '8px', padding: '8px', borderRadius: '4px', backgroundColor: 'var(--rn-clr-background-warning)', color: 'var(--rn-clr-content-warning)' }}>
+                <strong>{keyAudit.sizeWarnings.length}</strong> key(s) past half the {formatBytes(keyAudit.perKeyLimit)} per-key
+                ceiling — these are the ones that need a retention window or restructuring, not migration:
+                <ul style={{ margin: '4px 0 0 0', paddingLeft: '18px' }}>
+                  {keyAudit.sizeWarnings.map((k) => (
+                    <li key={k.key} style={{ wordBreak: 'break-all' }}>
+                      <code style={{ fontSize: '10px' }}>{k.key}</code> — {formatBytes(k.bytes)}{' '}
+                      ({((k.bytes / keyAudit.perKeyLimit) * 100).toFixed(0)}%)
+                    </li>
+                  ))}
+                </ul>
               </div>
             )}
             {keyAudit.nullSignalUsable && keyAudit.totals.nulled > 0 && (
@@ -3683,6 +3708,8 @@ function Debug() {
                   <tr style={{ textAlign: 'left', borderBottom: '1px solid var(--rn-clr-background-tertiary)' }}>
                     <th style={{ padding: '4px' }}>Family</th>
                     <th style={{ padding: '4px', textAlign: 'right' }}>Live</th>
+                    <th style={{ padding: '4px', textAlign: 'right' }}>Size</th>
+                    <th style={{ padding: '4px', textAlign: 'right' }}>Largest</th>
                     <th style={{ padding: '4px', textAlign: 'right' }}>Nulled</th>
                     <th style={{ padding: '4px', textAlign: 'right' }}>Probed</th>
                     <th style={{ padding: '4px' }}>Coverage</th>
@@ -3690,7 +3717,7 @@ function Debug() {
                 </thead>
                 <tbody>
                   {[...keyAudit.families]
-                    .sort((a, b) => (b.live + b.nulled) - (a.live + a.nulled))
+                    .sort((a, b) => b.bytes - a.bytes || (b.live + b.nulled) - (a.live + a.nulled))
                     .map((f) => (
                       <tr key={f.family} style={{ borderBottom: '1px solid var(--rn-clr-background-tertiary)' }}>
                         <td style={{ padding: '4px' }}>
@@ -3701,6 +3728,10 @@ function Debug() {
                           )}
                         </td>
                         <td style={{ padding: '4px', textAlign: 'right', fontWeight: 600 }}>{f.live}</td>
+                        <td style={{ padding: '4px', textAlign: 'right' }}>{f.bytes > 0 ? formatBytes(f.bytes) : '—'}</td>
+                        <td style={{ padding: '4px', textAlign: 'right', color: f.largest && f.largest.bytes >= keyAudit.perKeyLimit * 0.5 ? '#ef4444' : 'var(--rn-clr-content-tertiary)' }}>
+                          {f.largest ? formatBytes(f.largest.bytes) : '—'}
+                        </td>
                         <td style={{ padding: '4px', textAlign: 'right', color: f.nulled > 0 ? '#ef4444' : 'inherit' }}>{f.nulled}</td>
                         <td style={{ padding: '4px', textAlign: 'right', color: 'var(--rn-clr-content-tertiary)' }}>{f.probed}</td>
                         <td style={{ padding: '4px', color: f.coverage === 'full' ? '#10b981' : 'var(--rn-clr-content-tertiary)' }}>{f.coverage}</td>
@@ -3709,6 +3740,29 @@ function Debug() {
                 </tbody>
               </table>
             </div>
+            {keyAudit.largestKeys.length > 0 && (
+              <details style={{ marginTop: '8px' }}>
+                <summary style={{ fontSize: '11px', cursor: 'pointer', color: 'var(--rn-clr-content-secondary)' }}>
+                  Largest keys ({keyAudit.largestKeys.length}) — per-key ceiling {formatBytes(keyAudit.perKeyLimit)}
+                </summary>
+                <table style={{ fontSize: '11px', width: '100%', borderCollapse: 'collapse', marginTop: '4px' }}>
+                  <tbody>
+                    {keyAudit.largestKeys.map((k) => {
+                      const pct = (k.bytes / keyAudit.perKeyLimit) * 100;
+                      return (
+                        <tr key={k.key} style={{ borderBottom: '1px solid var(--rn-clr-background-tertiary)' }}>
+                          <td style={{ padding: '3px 4px', wordBreak: 'break-all' }}><code style={{ fontSize: '10px' }}>{k.key}</code></td>
+                          <td style={{ padding: '3px 4px', textAlign: 'right', whiteSpace: 'nowrap', fontWeight: 600 }}>{formatBytes(k.bytes)}</td>
+                          <td style={{ padding: '3px 4px', textAlign: 'right', whiteSpace: 'nowrap', color: pct >= 50 ? '#ef4444' : 'var(--rn-clr-content-tertiary)' }}>
+                            {pct.toFixed(1)}%
+                          </td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              </details>
+            )}
           </div>
         )}
         {nullTestReport && (

--- a/src/widgets/flashcard_history.tsx
+++ b/src/widgets/flashcard_history.tsx
@@ -15,7 +15,7 @@ import { safeRemTextToString } from "../lib/pdfUtils";
 import { PriorityBadge } from "../components";
 import { InlinePriorityEditor } from "../components/InlineEditors";
 import { getCardPriority, CardPriorityInfo, CARD_PRIORITY_CODE } from "../lib/card_priority";
-import { pendingPrioritySaveKey } from "../lib/consts";
+import { pendingPrioritySaveKey, flashcardHistoryTextLimit } from "../lib/consts";
 
 const NUM_TO_LOAD_IN_BATCH = 30;
 
@@ -24,6 +24,8 @@ export interface FlashcardHistoryData {
     remId: RemId;
     cardId: string;
     time: number;
+    /** @deprecated Legacy field. Row expansion is component state now — entries
+     *  written before that change still carry it, and it is ignored. */
     open?: boolean;
     kbId?: string;
     text?: string;
@@ -59,8 +61,8 @@ function FlashcardHistory() {
                     const rem = await plugin.rem.findOne(item.remId);
                     const frontText = await safeRemTextToString(plugin, rem?.text);
                     const backText = await safeRemTextToString(plugin, rem?.backText);
-                    const cleanFront = frontText === 'Untitled' && (!rem?.text || rem.text.length === 0) ? '' : frontText.substring(0, 1000);
-                    const cleanBack = backText === 'Untitled' && (!rem?.backText || rem.backText.length === 0) ? '' : backText.substring(0, 1000);
+                    const cleanFront = frontText === 'Untitled' && (!rem?.text || rem.text.length === 0) ? '' : frontText.substring(0, flashcardHistoryTextLimit);
+                    const cleanBack = backText === 'Untitled' && (!rem?.backText || rem.backText.length === 0) ? '' : backText.substring(0, flashcardHistoryTextLimit);
                     const text = `${cleanFront} ${cleanBack}`.trim();
                     updates.set(item.key, text);
                 } catch (e) {
@@ -140,14 +142,19 @@ function FlashcardHistory() {
         }
     };
 
-    const setData = (itemKey: number, changes: Partial<FlashcardHistoryData>) => {
-        const originalIndex = historyDataRaw.findIndex(x => x.key === itemKey);
-        if (originalIndex !== -1) {
-            const oldData = historyDataRaw[originalIndex];
-            const newData = { ...oldData, ...changes };
-            historyDataRaw.splice(originalIndex, 1, newData);
-            setHistoryData([...historyDataRaw]);
-        }
+    // Row expansion is transient UI state and is deliberately NOT persisted.
+    // It used to live on the stored entry as `open`, which meant every click of a
+    // chevron rewrote the whole history array — half a megabyte of synced storage
+    // per expand/collapse. Keeping it in component state costs nothing and removes
+    // that write entirely.
+    const [openKeys, setOpenKeys] = useState<Set<number>>(new Set());
+    const toggleOpen = (itemKey: number) => {
+        setOpenKeys((prev) => {
+            const next = new Set(prev);
+            if (next.has(itemKey)) next.delete(itemKey);
+            else next.add(itemKey);
+            return next;
+        });
     };
 
     const [numLoaded, setNumLoaded] = React.useState(1);
@@ -202,7 +209,8 @@ function FlashcardHistory() {
                     data={data}
                     remId={data.remId}
                     key={data.key || Math.random()}
-                    setData={(c) => setData(data.key, c)}
+                    open={openKeys.has(data.key)}
+                    toggleOpen={() => toggleOpen(data.key)}
                     closeIndex={() => closeIndex(data.key)}
                 />
             ))}
@@ -272,12 +280,14 @@ function RatingBadge({ score }: { score?: QueueInteractionScore }) {
 function HistoryItem({
     data,
     remId,
-    setData,
+    open,
+    toggleOpen,
     closeIndex,
 }: {
     data: FlashcardHistoryData;
     remId: string;
-    setData: (changes: Partial<FlashcardHistoryData>) => void;
+    open: boolean;
+    toggleOpen: () => void;
     closeIndex: () => void;
 }) {
     const plugin = usePlugin();
@@ -338,12 +348,12 @@ function HistoryItem({
             <div className="flex gap-2 mb-2">
                 <div
                     className="flex items-center justify-center flex-shrink-0 w-6 h-6 rounded-md cursor-pointer hover:bg-gray-200"
-                    onClick={() => setData({ open: !data.open })}
+                    onClick={toggleOpen}
                 >
                     <img
                         src={`${plugin.rootURL}chevron_down.svg`}
                         style={{
-                            transform: `rotate(${data.open ? 0 : -90}deg)`,
+                            transform: `rotate(${open ? 0 : -90}deg)`,
                             transitionProperty: "transform",
                             transitionTimingFunction: "cubic-bezier(0.4, 0, 0.2, 1)",
                             transitionDuration: "150ms",
@@ -413,7 +423,7 @@ function HistoryItem({
                     />
                 </div>
             )}
-            {data.open && (
+            {open && (
                 <div className="m-2">
                     <RemHierarchyEditorTree height="auto" width="100%" remId={remId} />
                 </div>

--- a/src/widgets/incremental_history.tsx
+++ b/src/widgets/incremental_history.tsx
@@ -172,14 +172,18 @@ function IncrementalHistory() {
         }
     };
 
-    const setData = (itemKey: number, changes: Partial<IncrementalHistoryData>) => {
-        const originalIndex = historyDataRaw.findIndex(x => x.key === itemKey);
-        if (originalIndex !== -1) {
-            const oldData = historyDataRaw[originalIndex];
-            const newData = { ...oldData, ...changes };
-            historyDataRaw.splice(originalIndex, 1, newData);
-            setHistoryData([...historyDataRaw]);
-        }
+    // Row expansion is transient UI state and is deliberately NOT persisted.
+    // It used to live on the stored entry as `open`, so every chevron click
+    // rewrote the whole history array to synced storage. Component state costs
+    // nothing and removes that write entirely.
+    const [openKeys, setOpenKeys] = useState<Set<number>>(new Set());
+    const toggleOpen = (itemKey: number) => {
+        setOpenKeys((prev) => {
+            const next = new Set(prev);
+            if (next.has(itemKey)) next.delete(itemKey);
+            else next.add(itemKey);
+            return next;
+        });
     };
 
     const [numLoaded, setNumLoaded] = React.useState(1);
@@ -231,7 +235,8 @@ function IncrementalHistory() {
                     data={data}
                     remId={data.remId}
                     key={data.key || Math.random()}
-                    setData={(c) => setData(data.key, c)}
+                    open={openKeys.has(data.key)}
+                    toggleOpen={() => toggleOpen(data.key)}
                     closeIndex={() => closeIndex(data.key)}
                     percentile={percentileMap[data.remId]}
                 />
@@ -280,13 +285,15 @@ function EventBadge({ eventType }: { eventType?: 'reviewed' | 'created' | 'dismi
 function HistoryItem({
     data,
     remId,
-    setData,
+    open,
+    toggleOpen,
     closeIndex,
     percentile,
 }: {
     data: IncrementalHistoryData;
     remId: string;
-    setData: (changes: Partial<IncrementalHistoryData>) => void;
+    open: boolean;
+    toggleOpen: () => void;
     closeIndex: () => void;
     percentile?: number;
 }) {
@@ -349,12 +356,12 @@ function HistoryItem({
             <div className="flex gap-2 mb-2">
                 <div
                     className="flex items-center justify-center flex-shrink-0 w-6 h-6 rounded-md cursor-pointer hover:bg-gray-200"
-                    onClick={() => setData({ open: !data.open })}
+                    onClick={toggleOpen}
                 >
                     <img
                         src={`${plugin.rootURL}chevron_down.svg`}
                         style={{
-                            transform: `rotate(${data.open ? 0 : -90}deg)`,
+                            transform: `rotate(${open ? 0 : -90}deg)`,
                             transitionProperty: "transform",
                             transitionTimingFunction: "cubic-bezier(0.4, 0, 0.2, 1)",
                             transitionDuration: "150ms",
@@ -423,7 +430,7 @@ function HistoryItem({
                     />
                 </div>
             )}
-            {data.open && (
+            {open && (
                 <div className="m-2">
                     <RemHierarchyEditorTree height="auto" width="100%" remId={remId} />
                 </div>

--- a/src/widgets/index.tsx
+++ b/src/widgets/index.tsx
@@ -24,6 +24,7 @@ import {
 import { enableHideInQueueIntegrationId, pdfHighlightBordersReloadKey, priorityBandColorsReloadKey } from '../lib/consts';
 import { registerIncrementalRemTracker } from '../register/tracker';
 import { cleanupOrphanedReviewGraphs } from '../lib/priority_review_document/cleanup';
+import { compactAuthoritativeAggregatesIfNeeded } from '../lib/authoritative_aggregates';
 import { registerJumpToRemHelper } from '../register/window';
 import { registerPluginHidingCSS, registerPdfHighlightCSS, registerClozeExtractCSS, registerTagBadgeCSS, registerIgnoreTagCSS, registerHighlightBandBadgeCSS, registerTableBandBadgeCSS } from '../lib/ui_helpers';
 
@@ -66,6 +67,12 @@ async function onActivate(plugin: ReactRNPlugin) {
   // Document graph Rem was deleted. Errors are logged inside the helper and
   // must not block activation.
   void cleanupOrphanedReviewGraphs(plugin);
+
+  // Fire-and-forget: shrink the authoritative-aggregates key into its compact
+  // form if it is still the legacy array. Needs no card/rem enumeration, so it
+  // works while those APIs are unavailable — and until it runs, that key sits
+  // over RemNote's 900KB per-key ceiling and every write to it is rejected.
+  void compactAuthoritativeAggregatesIfNeeded(plugin);
 
   registerCallbacks(plugin);
   await registerWidgets(plugin);

--- a/src/widgets/practiced_queues.tsx
+++ b/src/widgets/practiced_queues.tsx
@@ -261,9 +261,11 @@ function PracticedQueues() {
         DAILY_AGGREGATES_KEY,
         []
     );
-    const [authoritativeRaw] = useSyncedStorageState<DailyAggregate[]>(
+    // Stored shape varies (legacy array vs the compact kbId→date→row store), so
+    // this stays untyped and filterAuthoritativeForKb does the decoding.
+    const [authoritativeRaw] = useSyncedStorageState<unknown>(
         AUTHORITATIVE_AGGREGATES_KEY,
-        []
+        null
     );
     const [authoritativeLastComputed] = useSyncedStorageState<number>(
         AUTHORITATIVE_LAST_COMPUTED_KEY,

--- a/src/widgets/rem_history.tsx
+++ b/src/widgets/rem_history.tsx
@@ -11,13 +11,16 @@ import '../style.css';
 import '../App.css';
 import { timeSince } from "../lib/utils";
 import { safeRemTextToString } from "../lib/pdfUtils";
+import { remHistoryTextLimit } from "../lib/consts";
 
 const NUM_TO_LOAD_IN_BATCH = 20;
 
 export interface RemHistoryData {
     key: number;
     remId: RemId;
-    open: boolean;
+    /** @deprecated Legacy field. Row expansion is component state now — entries
+     *  written before that change still carry it, and it is ignored. */
+    open?: boolean;
     time: number;
     kbId?: string;
     text?: string;
@@ -51,8 +54,8 @@ function RemHistory() {
                     const rem = await plugin.rem.findOne(item.remId);
                     const frontText = await safeRemTextToString(plugin, rem?.text);
                     const backText = await safeRemTextToString(plugin, rem?.backText);
-                    const cleanFront = frontText === 'Untitled' && (!rem?.text || rem.text.length === 0) ? '' : frontText.substring(0, 200);
-                    const cleanBack = backText === 'Untitled' && (!rem?.backText || rem.backText.length === 0) ? '' : backText.substring(0, 200);
+                    const cleanFront = frontText === 'Untitled' && (!rem?.text || rem.text.length === 0) ? '' : frontText.substring(0, remHistoryTextLimit);
+                    const cleanBack = backText === 'Untitled' && (!rem?.backText || rem.backText.length === 0) ? '' : backText.substring(0, remHistoryTextLimit);
                     const text = `${cleanFront} ${cleanBack}`.trim();
                     updates.set(item.key, text);
                 } catch (e) {
@@ -128,14 +131,18 @@ function RemHistory() {
         }
     };
 
-    const setData = (itemKey: number, changes: Partial<RemHistoryData>) => {
-        const originalIndex = remDataRaw.findIndex(x => x.key === itemKey);
-        if (originalIndex !== -1) {
-            const oldData = remDataRaw[originalIndex];
-            const newData = { ...oldData, ...changes };
-            remDataRaw.splice(originalIndex, 1, newData);
-            setRemData([...remDataRaw]);
-        }
+    // Row expansion is transient UI state and is deliberately NOT persisted.
+    // It used to live on the stored entry as `open`, so every chevron click
+    // rewrote the whole history array to synced storage. Component state costs
+    // nothing and removes that write entirely.
+    const [openKeys, setOpenKeys] = useState<Set<number>>(new Set());
+    const toggleOpen = (itemKey: number) => {
+        setOpenKeys((prev) => {
+            const next = new Set(prev);
+            if (next.has(itemKey)) next.delete(itemKey);
+            else next.add(itemKey);
+            return next;
+        });
     };
 
     const [numLoaded, setNumLoaded] = React.useState(1);
@@ -173,7 +180,8 @@ function RemHistory() {
                     data={data}
                     remId={data.remId}
                     key={data.key || Math.random()}
-                    setData={(c) => setData(data.key, c)}
+                    open={openKeys.has(data.key)}
+                    toggleOpen={() => toggleOpen(data.key)}
                     closeIndex={() => closeIndex(data.key)}
                 />
             ))}
@@ -192,14 +200,16 @@ function RemHistory() {
 interface RemHistoryItemProps {
     data: RemHistoryData;
     remId: string;
-    setData: (changes: Partial<RemHistoryData>) => void;
+    open: boolean;
+    toggleOpen: () => void;
     closeIndex: () => void;
 }
 
 function RemHistoryItem({
     data,
     remId,
-    setData,
+    open,
+    toggleOpen,
     closeIndex,
 }: RemHistoryItemProps) {
     const plugin = usePlugin();
@@ -216,12 +226,12 @@ function RemHistoryItem({
             <div className="flex gap-2 mb-2">
                 <div
                     className="flex items-center justify-center flex-shrink-0 w-6 h-6 rounded-md cursor-pointer hover:bg-gray-200"
-                    onClick={() => setData({ open: !data.open })}
+                    onClick={toggleOpen}
                 >
                     <img
                         src={`${plugin.rootURL}chevron_down.svg`}
                         style={{
-                            transform: `rotate(${data.open ? 0 : -90}deg)`,
+                            transform: `rotate(${open ? 0 : -90}deg)`,
                             transitionProperty: "transform",
                             transitionTimingFunction: "cubic-bezier(0.4, 0, 0.2, 1)",
                             transitionDuration: "150ms",
@@ -254,7 +264,7 @@ function RemHistoryItem({
                     />
                 </div>
             </div>
-            {data.open && (
+            {open && (
                 <div className="m-2">
                     <RemHierarchyEditorTree height="auto" width="100%" remId={remId} />
                 </div>


### PR DESCRIPTION
RemNote 1.27.16 caps a plugin at 1000 synced keys, 900KB per value and 10MB total. Auditing against those ceilings surfaced two real defects.

- authoritativeDailyAggregates had reached 1.21MB (~7250 day buckets), past the 900KB per-key limit, so every save was rejected — silently — and the Study Dashboard's lifetime stats were frozen. Store it keyed kbId -> date -> positional row instead of an array of named-field objects: 1.21MB -> ~330KB with no history lost. Reads accept either shape; a startup pass rewrites the legacy value in place, needing none of the APIs removed in 1.27.16.

- Flashcard / Visited Rem / IncRem history panels persisted each row's expanded state in the stored entry, so every chevron click rewrote the whole list (>500KB for Flashcard History). Moved to component state.

- Flashcard history text capped at 500 chars per side (was 1000), and the Visited Rem History writer — which had no cap at all while its own backfill truncated at 200 — now shares one constant with it.

Adds a Synced Storage Key Audit to the debug widget: reconstructs and probes every key the plugin can write, reporting per-family counts, per-key sizes against both ceilings, and unnameable orphans. This is what produced the numbers above.

