### PR TITLE
feat: show review history and time spent in orphan card dialogs (v1.0.31) The orphan-card cleanup offered by "Update all inherited Card Priorities" identified cards by rem id and count alone, so the deletion had to be approved without knowing whether those cards carried years of reviews or nothing at all.

### DIFF
--- a/STORAGE_PLAN.md
+++ b/STORAGE_PLAN.md
@@ -1,0 +1,158 @@
+# Plugin storage plan
+
+Working document for reducing what Incremental Everything keeps in RemNote's plugin synced storage. Pick it up at "Phases" — the sections above it exist so the decisions don't have to be re-derived.
+
+Last measured: **2026-08-05**. Last updated: 2026-08-05.
+
+---
+
+## 1. Why this exists
+
+RemNote 1.27.16 introduced plugin safeguards that broke the plugin outright. After the reports, 1.27.20 walked most of them back. Current state:
+
+| Limit | Status |
+|---|---|
+| **900 KB per synced value** | **Enforced.** The only hard constraint. |
+| 1000 synced keys | Warning only ("for now") |
+| 10 MB total synced footprint | Warning only ("for now") |
+| Powerup tag / relationship ceiling | Temporarily raised 5,000 → 100,000 |
+| `card.getAll()` / `rem.getAll()` | Restored, with deprecation warnings |
+
+RemNote have said they are building "a safer replacement for full-database enumeration" and intend to re-introduce limits once authors have workable APIs. **So the pressure is off, but the direction is signposted.** This work is no longer urgent; it is preparation, to be done on our schedule and before re-enforcement.
+
+Two capabilities are still missing and shape everything below:
+
+- **There is no way to delete a synced key.** `setSynced(key, null)` does *not* free the slot — verified by experiment (write a new key at the cap, null an existing one, retry: still rejected). Every key ever written is permanent until RemNote ships a deletion API.
+- **There is no way to enumerate keys.** The audit tool works by *reconstructing* candidate key names from the knowledge base and probing each one, so keys whose rem was deleted can never be named. Those are the "unaccounted" orphans.
+
+---
+
+## 2. Current measurements
+
+From the Synced Storage Key Audit (Debug Widget → `Debug Incremental Everything` → **Scan Keys**), 2026-08-05:
+
+- **841 live keys** of the 1000 advisory ceiling (840 distinct — the review-graph key is counted in two families)
+- **2.16 MB** total, 21.6% of the 10 MB advisory budget
+- **~159 unaccounted** orphans (down from ~352, because `rem.getAll()` was restored and full enumeration could finally name them)
+- 399,071 rems scanned, 3.6M probes, **424s**
+
+| Family | Live keys | Size | Disposition |
+|---|---:|---:|---|
+| Fixed keys (current) | 16 | 1.36 MB | stays |
+| Known PDF rems index | 108 | 562.6 KB | → local |
+| PDF page history | 150 | 156.4 KB | → rem property |
+| List-break snapshots | 42 | 57.5 KB | → rem property |
+| Priority distribution graph data | 11 | 21.8 KB | → local |
+| Debug history backups | 3 | 6.7 KB | → rem property |
+| PDF page range | 204 | 4.4 KB | → rem property |
+| Parent-selector last dest (IncRem) | 114 | 2.1 KB | → rem property |
+| Review graph data | 1 | 1.5 KB | → graph rem |
+| Parent-selector last dest (PDF) | 47 | 893 B | → rem property |
+| Sorting settings (per KB) | 8 | 499 B | stays |
+| Known HTML rems index | 19 | 399 B | → local |
+| PDF current page | 101 | 193 B | → rem property |
+| Active PDF for IncRem | 9 | 171 B | → rem property |
+| Video position / playback rate | 4 | 54 B | → rem property |
+| Legacy globals (read-only) | 3 | 29 B | stays |
+
+Largest individual keys, against the **enforced** 900 KB ceiling:
+
+| Key | Size | % of ceiling |
+|---|---:|---:|
+| `flashcardHistoryData` | 518.9 KB | 57.7% |
+| `authoritativeDailyAggregates` | 300.8 KB | 33.4% |
+| `known_pdf_rems_D2hDszekc6pYb8bVz` | 183.3 KB | 20.4% |
+| `remData` | 129.2 KB | 14.4% |
+| `document-priority-shield-history-key` | 120.1 KB | 13.3% |
+| `document-card-priority-shield-history-key` | 111.9 KB | 12.4% |
+
+**Nothing is currently at risk of the one enforced limit.**
+
+---
+
+## 3. The design rule
+
+For every piece of state, ask:
+
+> **If this key vanished right now, could the plugin reconstruct it from data RemNote already syncs?**
+
+- **Yes → it is a cache.** Belongs in `plugin.storage.setLocal` (persists per device, unsynced, outside the plugin quota). Losing it costs latency, never data.
+- **No → it is the only copy.** Belongs on the rem it describes (hidden powerup property) or, if it is genuinely global, in synced storage with a bound on its growth.
+
+Applied to what we have:
+
+**Caches** — `known_pdf_rems_*` (source of truth is `rem.getSources()`), `known_html_rems_*`, `priority_graph_data_*` (computed from the IncRem + card-priority session caches, already regenerated on demand).
+
+**Only copies** — page position / range / history, parent-selector destinations, list-break snapshots, video positions, debug backups, shield history, and `priority_review_graph_data_*` (a point-in-time snapshot from review-document creation; recomputing later yields different numbers — *not* the same thing as `priority_graph_data_*` despite the similar name).
+
+Guidance from RemNote (Nate) that this follows: put per-rem state on the rem via hidden powerup properties; keep rebuildable indexes in local/session storage; don't build one giant JSON blob under a single key; version any JSON property and bound its history; migrate read-through — check the property, fall back to the legacy key, write the property on the way past.
+
+---
+
+## 4. Decisions already taken
+
+Recorded so they aren't re-litigated.
+
+**A `pdfLinks` property was designed and then dropped.** It existed to make the rem↔PDF association survive removal of the PDF source. On inspection the benefit was thin and the cost real — see below. Without that requirement, the index is a pure cache and `setLocal` is simpler and cheaper than any property.
+
+**"Keep the rem in `known_pdf_rems_*` after its PDF source is removed" was considered and rejected.** What the code does today: association is defined solely by `rem.getSources()` ([`findPDFinRem`](src/lib/pdfUtils.ts#L553)), and [`getInstantRemsForPDF`](src/lib/pdfUtils.ts#L860) — Page Range's first phase — verifies every entry and then overwrites the index with only the verified ids. So a detached chapter is dropped. Retaining it would gain only visibility from the PDF side (the rem stops being a reading item anyway once the source is gone, since `getAllPDFsInRem` finds nothing), while making the index unable to self-heal and creating a real hazard: [`findIncRemFast`](src/lib/pdfUtils.ts#L458) returns the first known rem carrying the Incremental powerup **without checking sources**, so a deliberately-retained stale entry could resolve as "the IncRem for this PDF" and open the wrong chapter.
+
+The underlying goal — *don't lose the reading history when a chapter is detached* — is delivered instead by moving page/range/history onto the rem itself (Phase 3), where it travels with the rem regardless of sources.
+
+**Doc-level shield histories will not be migrated.** They are 120.1 KB and 111.9 KB — 13% of the enforced ceiling — and migrating means tagging the user's own documents with a plugin powerup, which is visible in their editor. They get a retention window instead. Revisit only if they approach 50%.
+
+---
+
+## 5. Already shipped (v1.0.30)
+
+- **`authoritativeDailyAggregates` compacted** — was 1.21 MB (137% of the ceiling, so every write was being silently rejected and the Study Dashboard's lifetime stats were frozen). Now stored `kbId → date → positional row` instead of an array of named-field objects: **1.21 MB → 300.8 KB**, no history lost. Reads accept either shape; a startup pass rewrites the legacy value in place. See [`authoritative_aggregates.ts`](src/lib/authoritative_aggregates.ts).
+- **Row-expansion state removed from synced storage** in the three history widgets. Each chevron click had been rewriting the whole array (>500 KB for Flashcard History).
+- **Text caps** — flashcard history 500 chars/side; visited-rem history 200 (its writer previously had *no* cap while its own backfill truncated at 200).
+- **The audit tool itself** — [`synced_key_audit.ts`](src/lib/synced_key_audit.ts) + the Debug Widget section.
+
+---
+
+## 6. Phases
+
+Ordered by value now that only the 900 KB per-value limit is enforced.
+
+### ▶ Phase 1 — Cache families to local storage
+**Removes ~138 keys, ~585 KB. No user data moves; nothing to migrate.**
+
+`known_pdf_rems_*` (108), `known_html_rems_*` (19), `priority_graph_data_*` (11) → `plugin.storage.setLocal`.
+
+Accept knowingly: the rebuild is the existing "slow phase" full-tree walk, so a new device pays it once per PDF. Local (not session) storage keeps that cost paid once per device. A rebuild also silently drops the historical pollution in the large keys — that 183 KB entry is mostly junk from an old bug, and nothing derivable will reproduce it.
+
+### ▶ Phase 2 — Fix `findIncRemFast` source verification
+A correctness bug independent of storage: it resolves "the IncRem for this PDF" without confirming the candidate still has the PDF as a source. Small, self-contained.
+
+### ⏸ Phase 3 — PDF reading state onto the rem
+**Removes ~464 keys, ~161 KB.** Also delivers history durability for detached chapters.
+
+One hidden slot on the Incremental powerup: `{v:1, bySource: {[pdfRemId]: {page, range, history}}}` — collapsing current page, page range, page history and active PDF into a single versioned property. Keep the existing history cap. **Debounce the writes**: a page turn currently costs a plugin-storage write; on a rem it becomes a KB edit, so writing per turn trades a storage problem for sync churn.
+
+Needs first: a small helper module — `getRemJson` / `setRemJson` over hidden, `onlyProgrammaticModifying` slots with JSON serialized to string, plus `readWithLegacyFallback(remGetter, syncedGetter)` for read-through migration. No bulk migration passes anywhere.
+
+### ⏸ Phase 4 — Small per-rem families
+Parent-selector destinations (114 IncRem + 47 PDF), list-break snapshots (42), debug backups (3), video positions (4). **~210 keys.** The PDF-keyed parent-selector variant needs a home on the PDF rem.
+
+### ⏸ Phase 5 — Review-graph snapshot onto its graph rem
+**13 keys.** The graph rem is plugin-created, so tagging it is invisible, and the data would then die with the document instead of leaking. This family is the purest orphan case: the synced index is empty, so every key ever written is unnameable.
+
+### ⏸ Phase 6 — Retention, not migration
+The two doc-level shield keys have **no pruning at all** — add a retention window. Plus the daily-aggregate rollup (daily for ~2 years, monthly before that).
+
+### ⏸ Phase 7 — Legacy ledger
+Record migrated key names so a future deletion API can sweep them in one pass. Nothing can be reclaimed before that API exists.
+
+**End state:** roughly 27 synced keys — 16 fixed, 8 per-KB sorting, 3 legacy — none of which grow with the size of the knowledge base.
+
+---
+
+## 7. Watch list
+
+- **`flashcardHistoryData`, 518.9 KB (58%)** — the largest key and the closest to the enforced ceiling. Hard-capped at 1000 entries, and the 500-char text cap should pull it toward ~300–350 KB as entries are rewritten. Re-measure before assuming it fell.
+- **The doc-level shield keys** — the only families with no bound of any kind.
+- **RemNote's enumeration replacement** — may change how reverse lookups should work, which touches Phase 1's rebuild path. Worth knowing before investing further.
+- **Audit cost** — 424s and rising, because rem-keyed families are probed against every rem in the KB. Narrow the candidate sets before the next run.
+- **`nulled` column is meaningless** on current builds: an unwritten key reads back as `null`, so absent and nulled are indistinguishable. The audit calibrates for this and excludes the column; use the capacity experiment instead.

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -2,6 +2,23 @@
 
 This page documents the major changes and improvements for each version of the Incremental Everything (Plus) plugin.
 
+## v1.0.31 - August 5th, 2026
+
+### ✨ Improved: orphan card removal now shows what you'd be deleting
+
+The confirmation dialogs of **Update all inherited Card Priorities** used to identify orphan cards by Rem id and count alone — leaving you to approve a deletion with no idea whether those cards carried years of reviews or none at all.
+
+Every dialog in the flow now reports the **length of the review history and the total time spent**:
+
+- the **overview** states the reviews and study time about to be deleted (and, when you chose to keep the reviewed cards, what is being preserved);
+- the **detail pages** show it per missing Rem, and per card when one Rem has several;
+- the **preserve-history prompt** and the *delete ALL* warning quantify what the reviewed cards actually hold;
+- the **final summary** reports the reviews and time genuinely removed — counted from the cards that actually got deleted, so a partial failure can't overstate the loss.
+
+Cards with nothing recorded read `no review history`. Time is summed from each rep's `responseTime`, capped at your **Flashcard Response Time Limit** setting so a single walked-away review can't inflate the figure — the same convention the Study Dashboard uses. Detail pages now show **12 Rems per page** instead of 25, since each entry carries an extra line.
+
+📖 See [Commands → Update all inherited Card Priorities](Plugin-Commands-Reference.md#system--maintenance-commands) for the full cleanup flow.
+
 ## v1.0.30 - August 3rd, 2026
 
 Housekeeping release, prompted by the storage limits described in v1.0.29. Everything here reduces what the plugin keeps in — and writes to — RemNote's plugin storage. Two of these were genuine defects that the new limits merely exposed.

--- a/docs/Plugin-Commands-Reference.md
+++ b/docs/Plugin-Commands-Reference.md
@@ -341,9 +341,10 @@ These commands tag a Rem with one of the [Utilities#queue-display-utilities](Que
     - **Delete all** — remove everything, including reviewed cards (a second confirmation warns that their review/time-spent records will be lost).
 
     If no orphan has any history, this prompt is skipped and all are removed.
-  - Presents the list in pages of **25 Rems at a time** so the dialog always fits on screen
+  - **Every dialog states what would be lost:** the number of reviews and the total time spent — for the whole batch in the overview, and per Rem (and per card, when one Rem has several) in the detail pages. Cards with nothing recorded read `no review history`. Time is summed from each rep's `responseTime`, capped at your **Flashcard Response Time Limit** setting so one walked-away review can't inflate the figure — the same convention the [Study Dashboard](Study-Dashboard.md) uses.
+  - Presents the list in pages of **12 Rems at a time** so the dialog always fits on screen
   - Double-checks each candidate live before removal (transient errors are skipped)
-  - Removes the chosen set in batches of 25 with progress toasts; the final summary reports how many were removed and how many were **preserved**
+  - Removes the chosen set in batches of 25 with progress toasts; the final summary reports how many were removed and how many were **preserved**, each with its review count and time spent (the removed figures count only the cards that were actually deleted, so a partial failure doesn't overstate the loss)
   - You can cancel at any page without affecting already-confirmed removals
 
   Orphan cards are also flagged at **startup**: when the Card Priority cache finishes its background pass, any Rem whose cards exist but whose Rem cannot be found is counted and surfaced via a toast suggesting you run this command — **nothing is deleted automatically at startup**, since a Rem can transiently appear missing before sync finishes hydrating.

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -10,7 +10,7 @@
   "version": {
     "major": 1,
     "minor": 0,
-    "patch": 30
+    "patch": 31
   },
   "unlisted": false,
   "theme": [],

--- a/src/lib/card_priority/batch.ts
+++ b/src/lib/card_priority/batch.ts
@@ -14,6 +14,7 @@ import { CardPriorityInfo } from './types';
 import { calculateNewPriority, setCardPriority } from './index';
 import * as _ from 'remeda';
 import { safeRemTextToString } from '../pdfUtils';
+import { formatDuration } from '../utils';
 
 export async function removeAllCardPriorityTags(plugin: RNPlugin) {
   const confirmed = confirm(
@@ -389,6 +390,41 @@ export async function updateAllCardPriorities(plugin: RNPlugin) {
   }
 }
 
+/** Review-history summary of a single orphan card. */
+interface OrphanCardStats {
+  /** Number of entries in the card's repetitionHistory. */
+  reps: number;
+  /** Total response time, each rep capped at `capMs`. */
+  timeMs: number;
+}
+
+/**
+ * Summarize a card's repetitionHistory for the removal dialogs.
+ *
+ * `reps` is the raw history length (what "review history length" means to the
+ * user, and what `hasHistory` keys off). `timeMs` caps each rep the way the
+ * Study Dashboard does, so one walked-away rep can't dominate the total.
+ */
+function summarizeCardHistory(card: { repetitionHistory?: any[] }, capMs: number): OrphanCardStats {
+  const history = Array.isArray(card.repetitionHistory) ? card.repetitionHistory : [];
+  let timeMs = 0;
+  for (const rep of history) {
+    timeMs += Math.min(Math.max(0, rep?.responseTime || 0), capMs);
+  }
+  return { reps: history.length, timeMs };
+}
+
+/** formatDuration() returns '' for 0 — say so explicitly instead of showing a gap. */
+function describeTime(timeMs: number): string {
+  return formatDuration(Math.round(timeMs / 1000)) || 'no time recorded';
+}
+
+/** e.g. "12 review(s), 8m 4s" or "no review history". */
+function describeStats(stats: OrphanCardStats): string {
+  if (stats.reps === 0) return 'no review history';
+  return `${stats.reps} review(s), ${describeTime(stats.timeMs)}`;
+}
+
 /**
  * Finds all cards that belong to Rems that no longer exist (orphan cards),
  * asks the user for confirmation, and removes them.
@@ -444,9 +480,30 @@ async function removeOrphanCards(plugin: RNPlugin, orphanRemIds: string[]): Prom
   const withHistory = confirmedOrphanCards.filter(hasHistory);
   const withoutHistory = confirmedOrphanCards.filter((c) => !hasHistory(c));
 
+  // Per-card review stats shown in the confirmation dialogs, so the user can
+  // see exactly how much study data each deletion would destroy. Each rep's
+  // responseTime is capped at the flashcard_response_time_limit setting — the
+  // same convention the Study Dashboard / Practiced Queues use.
+  const capSetting = await plugin.settings.getSetting<number>('flashcard_response_time_limit');
+  const capSeconds = typeof capSetting === 'number' && capSetting > 0 ? capSetting : 180;
+  const capMs = capSeconds * 1000;
+  const statsOf = (card: (typeof confirmedOrphanCards)[number]) =>
+    summarizeCardHistory(card, capMs);
+  const sumStats = (cards: typeof confirmedOrphanCards) =>
+    cards.reduce(
+      (acc, c) => {
+        const s = statsOf(c);
+        return { reps: acc.reps + s.reps, timeMs: acc.timeMs + s.timeMs };
+      },
+      { reps: 0, timeMs: 0 }
+    );
+
+  const withHistoryStats = sumStats(withHistory);
+
   console.log(
     `Orphan cards: ${confirmedOrphanCards.length} total — ` +
-    `${withHistory.length} with review history, ${withoutHistory.length} without.`
+    `${withHistory.length} with review history (${withHistoryStats.reps} review(s), ` +
+    `${describeTime(withHistoryStats.timeMs)}), ${withoutHistory.length} without.`
   );
 
   // Decide which set to remove. If none have history, there is nothing to
@@ -458,7 +515,8 @@ async function removeOrphanCards(plugin: RNPlugin, orphanRemIds: string[]): Prom
     const preserveHistory = confirm(
       `🗑️ Remove Orphan Cards\n\n` +
       `Found ${confirmedOrphanCards.length} orphan card(s):\n` +
-      `  • ${withHistory.length} have review history (reviews & time-spent stats)\n` +
+      `  • ${withHistory.length} have review history — ` +
+      `${withHistoryStats.reps} review(s), ${describeTime(withHistoryStats.timeMs)} in total\n` +
       `  • ${withoutHistory.length} have no review history\n\n` +
       `Deleting cards with review history permanently removes those records from RemNote statistics.\n\n` +
       `➡️ OK = delete only the ${withoutHistory.length} card(s) WITHOUT history (keep the ${withHistory.length} with history)\n` +
@@ -471,7 +529,8 @@ async function removeOrphanCards(plugin: RNPlugin, orphanRemIds: string[]): Prom
       const deleteAll = confirm(
         `⚠️ Delete ALL orphan cards?\n\n` +
         `This permanently removes all ${confirmedOrphanCards.length} orphan card(s), including the ` +
-        `${withHistory.length} with review history — their review/time-spent records will be lost.\n\n` +
+        `${withHistory.length} with review history — ${withHistoryStats.reps} review(s) and ` +
+        `${describeTime(withHistoryStats.timeMs)} of study time will be lost.\n\n` +
         `OK = delete all ${confirmedOrphanCards.length}\n` +
         `Cancel = abort (delete nothing)`
       );
@@ -491,17 +550,23 @@ async function removeOrphanCards(plugin: RNPlugin, orphanRemIds: string[]): Prom
   }
 
   const preservedCount = confirmedOrphanCards.length - cardsToRemove.length;
+  const preservedStats = sumStats(confirmedOrphanCards.filter((c) => !cardsToRemove.includes(c)));
+  const removedStats = sumStats(cardsToRemove);
 
-  // Group the cards we will remove by remId for a readable summary
-  const byRemId: Record<string, number> = {};
+  // Group the cards we will remove by remId for a readable summary, carrying
+  // each card's review stats so the detail pages can show what gets lost.
+  const byRemId: Record<string, { count: number; cardStats: OrphanCardStats[] }> = {};
   for (const card of cardsToRemove) {
-    byRemId[card.remId] = (byRemId[card.remId] || 0) + 1;
+    const entry = byRemId[card.remId] || (byRemId[card.remId] = { count: 0, cardStats: [] });
+    entry.count++;
+    entry.cardStats.push(statsOf(card));
   }
 
   // ── Batched confirmation ─────────────────────────────────────────────
-  // Show native confirm() in pages of 25 entries so the dialog stays
-  // short enough to fit on screen without needing to scroll.
-  const confirmPageSize = 25;
+  // Show native confirm() in pages of a few entries so the dialog stays
+  // short enough to fit on screen without needing to scroll. Each entry now
+  // spans 2+ lines (rem id, then its review stats), hence the smaller page.
+  const confirmPageSize = 12;
   const entries = Object.entries(byRemId); // [ [remId, count], ... ]
   const totalPages = Math.ceil(entries.length / confirmPageSize);
 
@@ -509,7 +574,12 @@ async function removeOrphanCards(plugin: RNPlugin, orphanRemIds: string[]): Prom
   const overviewOk = confirm(
     `🗑️ Remove Orphan Cards\n\n` +
     `About to remove ${cardsToRemove.length} card(s) across ${entries.length} missing Rem(s).\n\n` +
-    `${preservedCount > 0 ? `Preserving ${preservedCount} card(s) with review history.\n\n` : ''}` +
+    `Review data that will be deleted: ${removedStats.reps} review(s), ` +
+    `${describeTime(removedStats.timeMs)} of study time.\n\n` +
+    `${preservedCount > 0
+      ? `Preserving ${preservedCount} card(s) with review history ` +
+        `(${preservedStats.reps} review(s), ${describeTime(preservedStats.timeMs)}).\n\n`
+      : ''}` +
     `These cards are no longer reviewable and take up space in your queue.\n\n` +
     `⚠️ This action cannot be undone.\n\n` +
     `You will be shown the list ${totalPages > 1 ? `in ${totalPages} pages of ${confirmPageSize}` : 'now'} to confirm.\n\n` +
@@ -526,7 +596,18 @@ async function removeOrphanCards(plugin: RNPlugin, orphanRemIds: string[]): Prom
   for (let p = 0; p < totalPages; p++) {
     const pageEntries = entries.slice(p * confirmPageSize, (p + 1) * confirmPageSize);
     const lines = pageEntries
-      .map(([remId, count]) => `  • ${count} card(s) — Rem: ${remId}`)
+      .map(([remId, { count, cardStats }]) => {
+        const total = cardStats.reduce(
+          (acc, s) => ({ reps: acc.reps + s.reps, timeMs: acc.timeMs + s.timeMs }),
+          { reps: 0, timeMs: 0 }
+        );
+        // With several cards under one missing rem, list each card's own stats
+        // after the rem-level total so nothing is hidden behind the sum.
+        const perCard = count > 1
+          ? `\n      per card: ${cardStats.map(describeStats).join(' | ')}`
+          : '';
+        return `  • ${count} card(s) — Rem: ${remId}\n      ${describeStats(total)}${perCard}`;
+      })
       .join('\n');
 
     const pageHeader = totalPages > 1
@@ -536,7 +617,7 @@ async function removeOrphanCards(plugin: RNPlugin, orphanRemIds: string[]): Prom
     const pageOk = confirm(
       `🗑️ Remove Orphan Cards — ${pageHeader}` +
       `${lines}\n\n` +
-      `Confirm removal of these ${pageEntries.reduce((s, [, c]) => s + c, 0)} card(s)?`
+      `Confirm removal of these ${pageEntries.reduce((s, [, e]) => s + e.count, 0)} card(s)?`
     );
 
     if (!pageOk) {
@@ -552,6 +633,9 @@ async function removeOrphanCards(plugin: RNPlugin, orphanRemIds: string[]): Prom
 
   let removed = 0;
   let removalErrors = 0;
+  // Tally the review data actually destroyed, so a partial failure doesn't
+  // report reviews/time that are still on disk.
+  const deletedStats: OrphanCardStats = { reps: 0, timeMs: 0 };
   const batchSize = 25;
 
   try {
@@ -560,9 +644,14 @@ async function removeOrphanCards(plugin: RNPlugin, orphanRemIds: string[]): Prom
       await Promise.all(
         batch.map(async (card) => {
           try {
+            const s = statsOf(card);
             await card.remove();
             removed++;
-            console.log(`  ✅ Removed orphan card ${card._id} (remId: ${card.remId})`);
+            deletedStats.reps += s.reps;
+            deletedStats.timeMs += s.timeMs;
+            console.log(
+              `  ✅ Removed orphan card ${card._id} (remId: ${card.remId}) — ${describeStats(s)}`
+            );
           } catch (err) {
             removalErrors++;
             console.error(`  ❌ Failed to remove card ${card._id}:`, err);
@@ -579,8 +668,11 @@ async function removeOrphanCards(plugin: RNPlugin, orphanRemIds: string[]): Prom
 
   const resultMessage =
     `🗑️ Orphan Card Cleanup Complete\n\n` +
-    `• Removed: ${removed} card(s)\n` +
-    `${preservedCount > 0 ? `• Preserved (with review history): ${preservedCount} card(s)\n` : ''}` +
+    `• Removed: ${removed} card(s) — ${deletedStats.reps} review(s), ${describeTime(deletedStats.timeMs)}\n` +
+    `${preservedCount > 0
+      ? `• Preserved (with review history): ${preservedCount} card(s) — ` +
+        `${preservedStats.reps} review(s), ${describeTime(preservedStats.timeMs)}\n`
+      : ''}` +
     `${removalErrors > 0 ? `• Failed: ${removalErrors} card(s) — check console\n` : ''}` +
     `\nThese cards belonged to Rems that no longer exist in your knowledge base.`;
 


### PR DESCRIPTION
Every dialog in the flow now reports the review count and total time
spent: the overview (deleted vs preserved), the per-rem detail pages
(with a per-card breakdown when one rem left several cards), the
preserve-history prompt, the delete-ALL warning, and the final summary.
Cards with no history read "no review history".

Time sums each rep's responseTime capped at the
flashcard_response_time_limit setting, matching the Study Dashboard /
Practiced Queues convention. The final summary tallies only cards whose
remove() succeeded, so a partial failure can't overstate the loss.
Detail pages drop to 12 rems per page since each entry gained a line.
