### PR TITLE
Synced storage optimization

### DIFF
--- a/STORAGE_PLAN.md
+++ b/STORAGE_PLAN.md
@@ -2,7 +2,7 @@
 
 Working document for reducing what Incremental Everything keeps in RemNote's plugin synced storage. Pick it up at "Phases" — the sections above it exist so the decisions don't have to be re-derived.
 
-Last measured: **2026-08-05**. Last updated: 2026-08-05.
+Last measured: **2026-08-05**. Last updated: 2026-08-05 (Phases 2, 3 and 5 done).
 
 ---
 
@@ -123,21 +123,37 @@ Ordered by value now that only the 900 KB per-value limit is enforced.
 
 Accept knowingly: the rebuild is the existing "slow phase" full-tree walk, so a new device pays it once per PDF. Local (not session) storage keeps that cost paid once per device. A rebuild also silently drops the historical pollution in the large keys — that 183 KB entry is mostly junk from an old bug, and nothing derivable will reproduce it.
 
-### ▶ Phase 2 — Fix `findIncRemFast` source verification
-A correctness bug independent of storage: it resolves "the IncRem for this PDF" without confirming the candidate still has the PDF as a source. Small, self-contained.
+### ✅ Phase 2 — Fix `findIncRemFast` source verification *(done)*
+It resolved "the IncRem for this PDF" from the known-rems index without confirming the candidate still had the PDF as a source, so a detached chapter could be returned — and would beat a correctly-sourced rem sitting later in the same list. Now verifies with `findPDFinRem`, the same predicate `getInstantRemsForPDF` uses, after the cheap `hasPowerup` filter. Stale ids are skipped and counted in a log line (a useful measure of how polluted a PDF's index is), not deleted: this is a read path, and pruning stays owned by the self-heal.
 
-### ⏸ Phase 3 — PDF reading state onto the rem
+### ✅ Phase 3 — PDF reading state onto the rem *(done)*
 **Removes ~464 keys, ~161 KB.** Also delivers history durability for detached chapters.
 
-One hidden slot on the Incremental powerup: `{v:1, bySource: {[pdfRemId]: {page, range, history}}}` — collapsing current page, page range, page history and active PDF into a single versioned property. Keep the existing history cap. **Debounce the writes**: a page turn currently costs a plugin-storage write; on a rem it becomes a KB edit, so writing per turn trades a storage problem for sync churn.
+State lives in [`pdf_state.ts`](src/lib/pdf_state.ts) as `{v:1, active?, bySource: {[pdfRemId]: {page, range, history}}}` in one hidden, `onlyProgrammaticModifying` slot — collapsing current page, page range, page history *and* active PDF into a single property per Rem, however many PDFs it draws on. History keeps its 100-entry cap per source.
 
-Needs first: a small helper module — `getRemJson` / `setRemJson` over hidden, `onlyProgrammaticModifying` slots with JSON serialized to string, plus `readWithLegacyFallback(remGetter, syncedGetter)` for read-through migration. No bulk migration passes anywhere.
+**The slot is registered on BOTH the Incremental and Dismissed powerups**, same code, same shape. Dismissal removes the Incremental powerup, which would take the property with it, so `transferToDismissed` copies the serialized string across — after the Dismissed powerup is attached, before the caller removes the Incremental one. `initIncrementalRem` reads it back off the Dismissed powerup *before* `mergeHistoryFromDismissed` deletes that powerup, then writes it once the Incremental powerup is attached. Because both sides share a shape, transfer is a string copy; re-dismissal merges per source with the newer value winning.
+
+A separate slot rather than folding into the history slot: that slot holds `IncrementalRep[]`, read by ~8 modules that all do `tryParseJson(raw) || []` and assume every element is a rep. Wrapping or polluting it would break all of them, for no gain.
+
+Reads migrate per (Rem, PDF) pair on the way past — the legacy key names cannot be enumerated without knowing both ids, so migration is necessarily lazy. Legacy keys are blanked (not deleted — no API) by `clearIncrementalPDFData` and `clearIncrementalPageRange`, so a clear cannot be undone by the fallback resurrecting the old value.
+
+All call sites now route through the accessors in `pdfUtils`, whose signatures are unchanged: three widgets and two libs that wrote the legacy keys directly were converted, and `setPageHistory` / `clearIncrementalPageRange` were added for the two operations that had no accessor. The debug inflation tool's "no key present → skip" check became "empty history → skip", since a migrated Rem legitimately has no legacy key.
+
+**Not done: write debouncing.** A page turn is still one write, now a Rem edit rather than a storage write. Debouncing needs a cross-iframe-safe pending buffer — each widget iframe holds its own module instance, so a naive module-level buffer would make the Reader and the Page Range panel disagree. Revisit if sync churn shows up in practice.
+
+**Known gap:** a Rem dismissed with *no* review history returns early from `transferToDismissed` and never gains the Dismissed powerup, so its reading state is not preserved. Matches how history itself behaves.
 
 ### ⏸ Phase 4 — Small per-rem families
 Parent-selector destinations (114 IncRem + 47 PDF), list-break snapshots (42), debug backups (3), video positions (4). **~210 keys.** The PDF-keyed parent-selector variant needs a home on the PDF rem.
 
-### ⏸ Phase 5 — Review-graph snapshot onto its graph rem
-**13 keys.** The graph rem is plugin-created, so tagging it is invisible, and the data would then die with the document instead of leaking. This family is the purest orphan case: the synced index is empty, so every key ever written is unnameable.
+### ✅ Phase 5 — Review-graph snapshot onto its graph rem *(done)*
+The snapshot now lives in a hidden, programmatic-only `graphData` slot on the **existing** Priority Review Graph powerup the graph Rem already carries — so no new powerup and no extra tagging. Deleting the review document now takes its graph data with it, which is the point: the orphan problem disappears rather than being swept up afterwards.
+
+Reads go property-first, fall back to the legacy `priority_review_graph_data_*` key, and migrate it onto the Rem on the way past — no bulk pass, so pre-existing documents move themselves the first time they are opened. Both historical value shapes (bare bin array, and the later object) are normalized in one place. A malformed property falls back to the legacy key rather than blanking a graph the user can still see.
+
+New code in [`graph_data.ts`](src/lib/priority_review_document/graph_data.ts). `registerReviewGraphKey` is deleted (nothing registers new entries now); `cleanupOrphanedReviewGraphs` stays as a legacy sweep and is documented as such — it can only blank values, never free slots.
+
+Legacy keys are left in place: there is still no deletion API, so they wait for Phase 7.
 
 ### ⏸ Phase 6 — Retention, not migration
 The two doc-level shield keys have **no pruning at all** — add a retention window. Plus the daily-aggregate rollup (daily for ~2 years, monthly before that).

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -2,6 +2,29 @@
 
 This page documents the major changes and improvements for each version of the Incremental Everything (Plus) plugin.
 
+## v1.0.34 - August 5th, 2026
+
+### 🐛 Fixed: a PDF could open the wrong chapter
+
+When a chapter Incremental Rem had its PDF source removed, it could linger in the plugin's index of "rems that use this PDF". Opening that PDF then resolved the *detached* chapter as the one to read — and it did so in preference to a correctly-linked chapter sitting further down the same list, because the lookup took the first entry it found without checking the PDF was still one of that rem's sources. It now checks.
+
+### ♻️ Changed: reading state is stored on the Rem itself
+
+Your **current page, page range, page history, active PDF and read points** used to live in the plugin's own storage, filed under keys built from the Rem's id. They now live on the Rem, in a hidden property.
+
+Nothing changes in how you use any of it, and nothing needs migrating by hand — each item moves itself the first time it is opened. What changes is what happens to it afterwards:
+
+- **Reading history now survives dismissal.** Dismissing a chapter and later making it Incremental again (`Alt+X`) used to leave its reading position behind; the state now travels with the Rem in both directions. This applies to read points on outline-style Rems too, which were similarly lost before.
+- **Reading history now survives losing the PDF source.** If you detach a chapter from its PDF — a common step once a section is processed, since the source pulls every one of the book's highlights into that chapter's scoped queue — the reading history stays on the chapter rather than becoming unreachable.
+- **Deleting a chapter now deletes its reading data.** Previously the plugin had no way to remove those entries, so every deleted chapter left its page position and history behind permanently.
+
+The same move applies to the distribution graph inside a **Priority Review Document**: its data now lives on the graph Rem, so deleting the document takes the graph data with it instead of stranding it.
+
+> [!NOTE]
+> This is the second instalment of a broader cleanup, prompted by the storage limits RemNote introduced in 1.27.16 (see [v1.0.29](#v1029-august-1st-2026)). Around 480 of the plugin's storage entries move onto the Rems they describe. Existing data is read and migrated as you go — there is no upgrade step and nothing to click.
+
+📖 See [PDF Incremental Reading Workflow](PDF-Incremental-Reading-Workflow.md#multiple-pdf-sources-active-pdf-switcher-and-preferthispdf) for how the active PDF is resolved, and [Read Points](Reviewing-Items-in-the-Editor.md#read-points-for-rem-type-incremental-rems) for outline reading positions.
+
 ## v1.0.33 - August 5th, 2026
 
 ### ✨ New: a settings popup of the plugin's own

--- a/docs/PDF-Incremental-Reading-Workflow.md
+++ b/docs/PDF-Incremental-Reading-Workflow.md
@@ -178,7 +178,7 @@ Toggle behavior simply by adding or removing the `extractviewer` tag:
 
 ### Multiple PDF Sources — Active PDF, Switcher, and `#preferthispdf`
 
-An Incremental Rem can now have **as many PDF sources as you like**, and you can switch between them on the fly. The plugin tracks an **active PDF** per Inc Rem (a synced-storage pin under `active_pdf_for_<remId>`) and applies the same resolution chain everywhere a PDF is opened or displayed.
+An Incremental Rem can now have **as many PDF sources as you like**, and you can switch between them on the fly. The plugin tracks an **active PDF** per Inc Rem — pinned in the Rem's own hidden *Reading State* property, alongside its page position, page range and page history — and applies the same resolution chain everywhere a PDF is opened or displayed.
 
 **Resolution chain (applied uniformly across queue Reader, PDF Control Panel, Priority Editor, Editor Review Timer, Execute Repetition popup, bookmark popup, etc.):**
 

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -493,7 +493,7 @@ The visible symptom was that the **Total Time** on the [PDF Control panel](PDF-I
 
 ### When to Use
 
-- **Page History Dump** — anytime you want to inspect the raw per-entry contents of `incremental_page_history_<remId>_<pdfRemId>` storage for a given Incremental (or Dismissed) Rem, e.g. to investigate a discrepancy between PDF Control and Repetition History totals, or to confirm that recent reviews were recorded correctly.
+- **Page History Dump** — anytime you want to inspect the per-entry reading history of a given Incremental (or Dismissed) Rem, e.g. to investigate a discrepancy between PDF Control and Repetition History totals, or to confirm that recent reviews were recorded correctly.
 - **Clean Inflated Page-History Durations** — when the dump (or PDF Control vs Repetition History) shows that this rem has inflated entries to strip.
 - **Clean Inflated Page-History — Global Scan** — once, after upgrading to v0.2.258, to clean up every IncRem and Dismissed rem in the knowledge base in a single pass.
 
@@ -507,15 +507,18 @@ The visible symptom was that the **Total Time** on the [PDF Control panel](PDF-I
 
 Click **Dump Page History**. For every PDF source on the focused rem, the widget will:
 
-- Print the raw storage value and the parsed `PageHistoryEntry[]` to the console (F12 → Console).
+- Print the parsed `PageHistoryEntry[]` to the console (F12 → Console), along with the legacy synced value for that pair — see the note below on reading it.
 - Render a per-PDF summary card in the widget showing:
   - **Total entries** vs **entries with `sessionDuration > 0`**.
   - **Sum of durations** vs **`getReadingStatistics` total** (these should always match; mismatch indicates a parsing bug).
   - **Min/Max** duration and **count of entries hitting the 4h cap** (14400 s).
-  - The exact storage key (`incremental_page_history_<remId>_<pdfRemId>`).
+  - The legacy storage key for the pair (`incremental_page_history_<remId>_<pdfRemId>`), shown for reference.
 - A `<details>` toggle exposes the full raw JSON of every entry.
 
 This is purely diagnostic — nothing is mutated.
+
+> [!NOTE]
+> **Since v1.0.34, reading history lives on the Rem** (a hidden *Reading State* property) rather than in plugin storage. The dump still reports the old synced value so you can tell whether a given (Rem, PDF) pair has moved across yet: `none — migrated to the Rem` next to a populated history means the migration has happened, **not** that data was lost. Pairs migrate individually, the first time each is opened.
 
 ### 🧹 Clean Inflated Page-History Durations (per rem)
 

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -10,7 +10,7 @@
   "version": {
     "major": 1,
     "minor": 0,
-    "patch": 33
+    "patch": 34
   },
   "unlisted": false,
   "theme": [],

--- a/src/components/reader/usePdfPageControls.ts
+++ b/src/components/reader/usePdfPageControls.ts
@@ -2,6 +2,7 @@ import React, { useState, useCallback, useEffect, useMemo } from 'react';
 import { RNPlugin } from '@remnote/plugin-sdk';
 import {
     getIncrementalReadingPosition,
+    setIncrementalReadingPosition,
     getIncrementalPageRange,
     clearIncrementalPDFData,
     PageRangeContext
@@ -22,8 +23,10 @@ export function usePdfPageControls(
 
     const saveCurrentPage = useCallback(async (page: number) => {
         if (!incrementalRemId || !pdfRemId) return;
-        const pageKey = `incremental_current_page_${incrementalRemId}_${pdfRemId}`;
-        await plugin.storage.setSynced(pageKey, page);
+        // Must go through the accessor: reading state lives on the Rem now, and
+        // writing the legacy key directly would be ignored by every reader once
+        // that Rem has migrated.
+        await setIncrementalReadingPosition(plugin, incrementalRemId, pdfRemId, page);
     }, [incrementalRemId, pdfRemId, plugin]);
 
     const incrementPage = useCallback(() => {

--- a/src/lib/consts.ts
+++ b/src/lib/consts.ts
@@ -5,6 +5,13 @@ export const nextRepDateSlotCode = 'nextRepDate';
 export const repHistorySlotCode = 'repHist';
 export const originalIncrementalDateSlotCode = 'originalIncDate';
 
+// PDF reading state (page, page range, page history, active PDF) as serialized
+// JSON, replacing four per-(Rem, PDF) synced-key families. Registered on BOTH
+// the Incremental and Dismissed powerups under the same code and shape:
+// dismissing a Rem removes the Incremental powerup, so the state is copied
+// across as an opaque string rather than being lost. See lib/pdf_state.ts.
+export const pdfStateSlotCode = 'pdfState';
+
 // Dismissed Powerup
 export const dismissedPowerupCode = 'dismissed';
 export const dismissedHistorySlotCode = 'dismissedHistory';
@@ -266,6 +273,12 @@ export const pendingScrollRequestKey = 'pending-scroll-request';
 
 // Priority Review Graph
 export const priorityGraphPowerupCode = 'priority_review_graph';
+// Hidden slot on the graph Rem holding that graph's data as serialized JSON.
+// Replaces the per-graph synced key `priority_review_graph_data_<remId>`: the
+// snapshot belongs to the graph Rem, so storing it there means it is deleted
+// with the Priority Review Document instead of being orphaned in plugin storage
+// (which has no deletion API — orphans were unreclaimable).
+export const priorityGraphDataSlotCode = 'graphData';
 export const GRAPH_DATA_KEY_PREFIX = 'priority_review_graph_data_';
 // Synced index of every graph Rem ID we've written graph data for. Used to find
 // orphaned `GRAPH_DATA_KEY_PREFIX + remId` entries on startup so they can be cleared.

--- a/src/lib/dismissed/index.ts
+++ b/src/lib/dismissed/index.ts
@@ -1,9 +1,11 @@
 import { RNPlugin, PluginRem } from '@remnote/plugin-sdk';
 import {
+    powerupCode,
     dismissedPowerupCode,
     dismissedHistorySlotCode,
     dismissedDateSlotCode,
 } from '../consts';
+import { transferPdfState } from '../pdf_state';
 import { IncrementalRep } from '../incremental_rem/types';
 import { tryParseJson, getDailyDocReferenceForDate } from '../utils';
 import { stampNoteAndContext } from '../history_notes';
@@ -99,6 +101,22 @@ export async function transferToDismissed(
         if (dateRef) {
             await rem.setPowerupProperty(dismissedPowerupCode, dismissedDateSlotCode, dateRef);
         }
+    }
+
+    // Carry the PDF reading state (page, range, page history, active PDF) from
+    // the Incremental powerup to the Dismissed one. This must run AFTER the
+    // Dismissed powerup exists — you cannot set a property for a powerup the Rem
+    // does not have — and BEFORE the caller removes the Incremental powerup,
+    // which would take the source property with it. Both powerups declare the
+    // same slot with the same shape, so this is a string copy.
+    //
+    // A Rem dismissed with no history returns early above and never gains the
+    // Dismissed powerup, so its reading state is not preserved either. That
+    // matches how history itself behaves: nothing was recorded, nothing is kept.
+    try {
+        await transferPdfState(rem, powerupCode, dismissedPowerupCode);
+    } catch (err) {
+        console.warn('[Dismissed] Could not carry PDF reading state across', err);
     }
 }
 

--- a/src/lib/incremental_rem/index.ts
+++ b/src/lib/incremental_rem/index.ts
@@ -17,7 +17,9 @@ import {
   currentIncRemKey,
   incremReviewStartTimeKey,
   pendingQueueDashboardRefocusKey,
+  dismissedPowerupCode,
 } from '../consts';
+import { readRawPdfState, writeRawPdfState } from '../pdf_state';
 import { getNextSpacingDateForRem, updateSRSDataForRem } from '../scheduler';
 import { IncrementalRem, IncrementalRep } from './types';
 import { tryParseJson, getDailyDocReferenceForDate, sleep } from '../utils';
@@ -451,6 +453,12 @@ export async function initIncrementalRem(plugin: ReactRNPlugin, rem: PluginRem, 
 
     let triggeredCascade = false;
     try {
+      // Read any PDF reading state parked on the Dismissed powerup BEFORE the
+      // merge below, which removes that powerup and would take the property with
+      // it. It is written back after the Incremental powerup is attached — a
+      // property cannot be set for a powerup the Rem does not yet carry.
+      const carriedPdfState = await readRawPdfState(rem, dismissedPowerupCode);
+
       // Independent reads — run concurrently instead of serially. The dismissed-history
       // merge and the two settings lookups don't depend on one another.
       const [dismissedHistory, initialIntervalSetting, defaultPrioritySetting] = await Promise.all([
@@ -519,6 +527,12 @@ export async function initIncrementalRem(plugin: ReactRNPlugin, rem: PluginRem, 
           rem.setPowerupProperty(powerupCode, originalIncrementalDateSlotCode, todayRef)
         );
       }
+      // Restore the reading state carried over from a previous dismissal, so a
+      // Rem revived with Opt+X resumes at the page it was left on.
+      if (carriedPdfState) {
+        slotWrites.push(writeRawPdfState(rem, powerupCode, carriedPdfState));
+      }
+
       await Promise.all(slotWrites);
 
       // Band sync for the initial priority. Deliberately NOT routed through

--- a/src/lib/pdfUtils.ts
+++ b/src/lib/pdfUtils.ts
@@ -3,6 +3,17 @@ import { RNPlugin, PluginRem, RemId, BuiltInPowerupCodes } from '@remnote/plugin
 import { powerupCode, allIncrementalRemKey } from './consts';
 import { IncrementalRem } from './incremental_rem/types';
 import { resolveRemTextToString, resolveRemTextForBreadcrumb } from './richTextRemRefs';
+import {
+  loadPdfState,
+  savePdfState,
+  updateSourceState,
+  normalizeHistory,
+  PAGE_HISTORY_LIMIT,
+  getCurrentPageKey,
+  getPageRangeKey,
+  getPageHistoryKey,
+  type PageHistoryEntry,
+} from './pdf_state';
 
 export interface PageRangeContext {
   incrementalRemId: RemId | null;
@@ -19,15 +30,11 @@ export interface PageRangeContext {
 }
 
 /**
- * Enhanced structure for page history entries with duration tracking
+ * Enhanced structure for page history entries with duration tracking.
+ * Defined by the state module that persists it; re-exported here because most
+ * callers reach it through this file.
  */
-export interface PageHistoryEntry {
-  // Optional: HTML articles and PDF Text Reader highlights have no page number.
-  page?: number;
-  timestamp: number;
-  sessionDuration?: number;   // Duration in seconds for this reading session
-  highlightId?: string;       // Rem ID of the specific highlight mapped to this bookmark
-}
+export type { PageHistoryEntry } from './pdf_state';
 
 /**
  * Safely convert rem text to string, handling all edge cases
@@ -131,23 +138,15 @@ const extractTextManually = (richText: any): string => {
   return text.trim();
 };
 
-/**
- * Generate key for storing current page position per incremental rem
- */
-export const getCurrentPageKey = (incrementalRemId: string, pdfRemId: string) =>
-  `incremental_current_page_${incrementalRemId}_${pdfRemId}`;
-
-/**
- * Generate key for storing page range per incremental rem  
- */
-export const getPageRangeKey = (incrementalRemId: string, pdfRemId: string) =>
-  `incremental_page_range_${incrementalRemId}_${pdfRemId}`;
-
-/**
- * Generate key for storing page history per incremental rem
- */
-export const getPageHistoryKey = (incrementalRemId: string, pdfRemId: string) =>
-  `incremental_page_history_${incrementalRemId}_${pdfRemId}`;
+// The legacy synced-key builders now live alongside the state module that
+// migrates away from them. Re-exported here so existing importers — and the
+// storage audit, which still probes for these keys — keep working unchanged.
+export {
+  getCurrentPageKey,
+  getPageRangeKey,
+  getPageHistoryKey,
+  getActivePdfKey,
+} from './pdf_state';
 
 /**
  * Get the current reading position for an incremental rem
@@ -157,9 +156,9 @@ export const getIncrementalReadingPosition = async (
   incrementalRemId: string,
   pdfRemId: string
 ): Promise<number | null> => {
-  const pageKey = getCurrentPageKey(incrementalRemId, pdfRemId);
-  const savedPage = await plugin.storage.getSynced(pageKey);
-  return typeof savedPage === 'number' ? savedPage : null;
+  const { state } = await loadPdfState(plugin, incrementalRemId, pdfRemId);
+  const page = state.bySource[pdfRemId]?.page;
+  return typeof page === 'number' ? page : null;
 };
 
 /**
@@ -171,8 +170,7 @@ export const setIncrementalReadingPosition = async (
   pdfRemId: string,
   page: number
 ): Promise<void> => {
-  const pageKey = getCurrentPageKey(incrementalRemId, pdfRemId);
-  await plugin.storage.setSynced(pageKey, page);
+  await updateSourceState(plugin, incrementalRemId, pdfRemId, (s) => ({ ...s, page }));
 };
 
 /**
@@ -183,11 +181,9 @@ export const getIncrementalPageRange = async (
   incrementalRemId: string,
   pdfRemId: string
 ): Promise<{ start: number, end: number } | null> => {
-  const rangeKey = getPageRangeKey(incrementalRemId, pdfRemId);
-  const savedRange = await plugin.storage.getSynced(rangeKey);
-  return savedRange && typeof savedRange === 'object' && 'start' in savedRange
-    ? savedRange as { start: number, end: number }
-    : null;
+  const { state } = await loadPdfState(plugin, incrementalRemId, pdfRemId);
+  const range = state.bySource[pdfRemId]?.range;
+  return range && typeof range === 'object' && 'start' in range ? range : null;
 };
 
 /**
@@ -200,8 +196,43 @@ export const setIncrementalPageRange = async (
   start: number,
   end: number
 ): Promise<void> => {
-  const rangeKey = getPageRangeKey(incrementalRemId, pdfRemId);
-  await plugin.storage.setSynced(rangeKey, { start, end });
+  await updateSourceState(plugin, incrementalRemId, pdfRemId, (s) => ({
+    ...s,
+    range: { start, end },
+  }));
+};
+
+/**
+ * Replace the whole page history for one source. Used by the diagnostic tools
+ * that rewrite history (e.g. stripping inflated session durations); ordinary
+ * recording goes through addPageToHistory.
+ */
+export const setPageHistory = async (
+  plugin: RNPlugin,
+  incrementalRemId: string,
+  pdfRemId: string,
+  entries: PageHistoryEntry[]
+): Promise<void> => {
+  await updateSourceState(plugin, incrementalRemId, pdfRemId, (s) => ({
+    ...s,
+    history: entries.slice(-PAGE_HISTORY_LIMIT),
+  }));
+};
+
+/**
+ * Clear the page range for an incremental rem, leaving its position and history
+ * untouched. Callers used to write `null` to the range key directly; with the
+ * state on the Rem, "no range" means the field is absent.
+ */
+export const clearIncrementalPageRange = async (
+  plugin: RNPlugin,
+  incrementalRemId: string,
+  pdfRemId: string
+): Promise<void> => {
+  await updateSourceState(plugin, incrementalRemId, pdfRemId, ({ range, ...rest }) => rest);
+  // Also blank the legacy key, or the migration fallback could restore the range
+  // the user just cleared.
+  await plugin.storage.setSynced(getPageRangeKey(incrementalRemId, pdfRemId), null);
 };
 
 /**
@@ -212,32 +243,10 @@ export const getPageHistory = async (
   incrementalRemId: string,
   pdfRemId: string
 ): Promise<PageHistoryEntry[]> => {
-  const historyKey = getPageHistoryKey(incrementalRemId, pdfRemId);
-  const history = await plugin.storage.getSynced(historyKey);
-
-  // Handle both old format (just numbers) and new format (with timestamps)
-  if (Array.isArray(history)) {
-    return history.map(entry => {
-      if (typeof entry === 'number') {
-        // Old format: just page number, no timestamp
-        return { page: entry, timestamp: 0 };
-      } else if (entry && (typeof entry.page === 'number' || entry.highlightId)) {
-        // Accept entries with a real page number (PDF Reader) OR with a
-        // highlightId but no page (HTML / PDF Text Reader bookmarks).
-        return {
-          page: typeof entry.page === 'number' ? entry.page : undefined,
-          timestamp: entry.timestamp || 0,
-          sessionDuration: entry.sessionDuration,
-          highlightId: entry.highlightId
-        };
-      } else {
-        // Invalid entry
-        return null;
-      }
-    }).filter(Boolean) as PageHistoryEntry[];
-  }
-
-  return [];
+  const { state } = await loadPdfState(plugin, incrementalRemId, pdfRemId);
+  // normalizeHistory handles both historical shapes — a bare array of page
+  // numbers, and the later entry objects.
+  return normalizeHistory(state.bySource[pdfRemId]?.history);
 };
 
 /**
@@ -261,7 +270,11 @@ export const addPageToHistory = async (
 ): Promise<void> => {
   console.log(`[addPageToHistory] Triggered for Rem: ${incrementalRemId}`);
 
-  const historyKey = getPageHistoryKey(incrementalRemId, pdfRemId);
+  // One load, one save: position, history and the write all come from the same
+  // property, so reading each through its own accessor would cost three round
+  // trips to build a single entry.
+  const loaded = await loadPdfState(plugin, incrementalRemId, pdfRemId);
+  const source = loaded.state.bySource[pdfRemId] || {};
 
   // Get the page to record. `null` = explicit "no page" (HTML/text reader).
   let page: number | undefined;
@@ -271,7 +284,7 @@ export const addPageToHistory = async (
     page = pageToRecord;
   } else {
     // Get the actual current reading position instead of defaulting to 1
-    const currentPage = await getIncrementalReadingPosition(plugin, incrementalRemId, pdfRemId);
+    const currentPage = typeof source.page === 'number' ? source.page : null;
     page = currentPage || 1;
   }
 
@@ -287,7 +300,7 @@ export const addPageToHistory = async (
     sessionDuration = sessionDurationOverride;
   }
 
-  const history = await getPageHistory(plugin, incrementalRemId, pdfRemId);
+  const history = normalizeHistory(source.history);
 
   // Bookmark preservation: when no highlightId is supplied (e.g. queue "Next",
   // session-end timers, manual page save) but the most-recent same-page entry
@@ -317,10 +330,12 @@ export const addPageToHistory = async (
 
   history.push(entry);
 
-  // Keep only last 100 entries to avoid storage bloat
-  const trimmedHistory = history.slice(-100);
-
-  await plugin.storage.setSynced(historyKey, trimmedHistory);
+  // Keep only the last N entries to avoid unbounded growth
+  loaded.state.bySource[pdfRemId] = {
+    ...source,
+    history: history.slice(-PAGE_HISTORY_LIMIT),
+  };
+  await savePdfState(loaded);
 };
 
 /**
@@ -456,16 +471,41 @@ export const findIncrementalRemForPDFFast = async (
     } catch (e) { /* ignore */ }
   }
 
-  // 3. Known-rems cache — check if any stored rem is incremental and has this PDF
+  // 3. Known-rems cache — check if any stored rem is incremental AND still has
+  //    this PDF as a source.
+  //
+  //    The source check is not optional. The index is a cache of past
+  //    associations and goes stale: a chapter IncRem whose PDF source was removed
+  //    stays listed until some other path happens to trim it. Trusting the entry
+  //    on `hasPowerup` alone would resolve that detached rem as "the IncRem for
+  //    this PDF" and open the wrong chapter — silently, and preferentially, since
+  //    this is the fast path that runs before any fuller search.
+  //
+  //    `findPDFinRem` is the same predicate getInstantRemsForPDF verifies with, so
+  //    the two agree on what "associated" means. It is the more expensive call, so
+  //    the cheap hasPowerup filter runs first. Stale ids are skipped, not deleted:
+  //    this is a read path, and the self-heal in getInstantRemsForPDF owns pruning.
   const knownRemsKey = getKnownPdfRemsKey(pdfRem._id);
   const knownRemIds = (await plugin.storage.getSynced<string[]>(knownRemsKey)) || [];
+  let staleSkipped = 0;
   for (const remId of knownRemIds) {
     const rem = await plugin.rem.findOne(remId);
     if (!rem) continue;
-    if (await rem.hasPowerup(powerupCode)) {
-      console.log(`[findIncRemFast] Found via known-rems cache (${remId})`);
-      return rem;
+    if (!(await rem.hasPowerup(powerupCode))) continue;
+
+    const stillHasPdf = await findPDFinRem(plugin, rem, pdfRem._id);
+    if (!stillHasPdf) {
+      staleSkipped++;
+      continue;
     }
+
+    console.log(`[findIncRemFast] Found via known-rems cache (${remId})`);
+    return rem;
+  }
+  if (staleSkipped > 0) {
+    console.log(
+      `[findIncRemFast] Skipped ${staleSkipped} stale known-rems entr(ies) — incremental, but this PDF is no longer one of their sources.`
+    );
   }
 
   // 4. Expensive full scan as last resort
@@ -663,7 +703,6 @@ export const getAllPDFsInRem = async (
  * Lets the user pin a non-preferred PDF as the focus of their work without
  * editing tags.
  */
-export const getActivePdfKey = (incRemId: string) => `active_pdf_for_${incRemId}`;
 
 /**
  * Pin a PDF as the active one for an IncRem. Pass `null` to clear the pin.
@@ -673,7 +712,9 @@ export const setActivePdfForIncRem = async (
   incRemId: string,
   pdfRemId: string | null
 ): Promise<void> => {
-  await plugin.storage.setSynced(getActivePdfKey(incRemId), pdfRemId);
+  const loaded = await loadPdfState(plugin, incRemId);
+  loaded.state.active = pdfRemId ?? undefined;
+  await savePdfState(loaded);
 };
 
 /**
@@ -700,12 +741,14 @@ export const getActivePdfForIncRem = async (
   if (allPdfs.length === 1) return allPdfs[0].rem;
 
   // 1. Explicit active PDF
-  const activeId = await plugin.storage.getSynced<string>(getActivePdfKey(rem._id));
+  const loaded = await loadPdfState(plugin, rem._id);
+  const activeId = loaded.state.active;
   if (activeId) {
     const match = allPdfs.find(p => p.rem._id === activeId);
     if (match) return match.rem;
     // Stored PDF is no longer a source — clear the stale pin.
-    await plugin.storage.setSynced(getActivePdfKey(rem._id), null);
+    loaded.state.active = undefined;
+    await savePdfState(loaded);
   }
 
   // 2. Preferred PDF (#preferthispdf)
@@ -1279,13 +1322,19 @@ export const clearIncrementalPDFData = async (
   incrementalRemId: string,
   pdfRemId: string
 ): Promise<void> => {
-  const pageKey = getCurrentPageKey(incrementalRemId, pdfRemId);
-  const rangeKey = getPageRangeKey(incrementalRemId, pdfRemId);
-  const historyKey = getPageHistoryKey(incrementalRemId, pdfRemId);
+  // Drop this source's slice from the property. The legacy keys are also blanked
+  // so a later read cannot resurrect what the user just cleared through the
+  // migration fallback — blanking does not free the key, but it does clear the
+  // value, which is what matters here.
+  const loaded = await loadPdfState(plugin, incrementalRemId);
+  if (loaded.state.bySource[pdfRemId]) {
+    delete loaded.state.bySource[pdfRemId];
+    await savePdfState(loaded);
+  }
 
-  await plugin.storage.setSynced(pageKey, null);
-  await plugin.storage.setSynced(rangeKey, null);
-  await plugin.storage.setSynced(historyKey, null);
+  await plugin.storage.setSynced(getCurrentPageKey(incrementalRemId, pdfRemId), null);
+  await plugin.storage.setSynced(getPageRangeKey(incrementalRemId, pdfRemId), null);
+  await plugin.storage.setSynced(getPageHistoryKey(incrementalRemId, pdfRemId), null);
 };
 
 /**

--- a/src/lib/pdf_state.ts
+++ b/src/lib/pdf_state.ts
@@ -1,0 +1,310 @@
+import { RNPlugin, PluginRem } from '@remnote/plugin-sdk';
+import { powerupCode, dismissedPowerupCode, pdfStateSlotCode } from './consts';
+
+// --- legacy synced keys ----------------------------------------------------
+// Defined here rather than in pdfUtils so this module has no dependency on it
+// (pdfUtils imports this one). pdfUtils re-exports them for existing callers,
+// notably the storage audit, which still needs to probe for them.
+
+export const getCurrentPageKey = (incrementalRemId: string, pdfRemId: string) =>
+  `incremental_current_page_${incrementalRemId}_${pdfRemId}`;
+
+export const getPageRangeKey = (incrementalRemId: string, pdfRemId: string) =>
+  `incremental_page_range_${incrementalRemId}_${pdfRemId}`;
+
+export const getPageHistoryKey = (incrementalRemId: string, pdfRemId: string) =>
+  `incremental_page_history_${incrementalRemId}_${pdfRemId}`;
+
+export const getActivePdfKey = (incRemId: string) => `active_pdf_for_${incRemId}`;
+
+// ---------------------------------------------------------------------------
+// PDF reading state — stored on the Rem, not in plugin storage
+//
+// Four synced-key families used to hold this, one key per (IncRem, PDF) pair
+// plus one per IncRem:
+//
+//   incremental_current_page_<incRemId>_<pdfRemId>
+//   incremental_page_range_<incRemId>_<pdfRemId>
+//   incremental_page_history_<incRemId>_<pdfRemId>
+//   active_pdf_for_<incRemId>
+//
+// That is the family that scales fastest with use — three keys for every chapter
+// of every book — and plugin storage has no deletion API, so deleting a chapter
+// left its keys behind permanently. The state is also, plainly, about the Rem.
+//
+// It now lives in one hidden slot as versioned JSON:
+//
+//   { v: 1, active?: pdfRemId, bySource: { [pdfRemId]: { page, range, history } } }
+//
+// One property per Rem regardless of how many PDFs it draws on, deleted with the
+// Rem, and carried through dismissal (see transferPdfState). Reads fall back to
+// the legacy keys and migrate that pair on the way past — no bulk pass.
+//
+// The slot exists on BOTH the Incremental and Dismissed powerups. Dismissing a
+// Rem removes the Incremental powerup, which would take the state with it, so
+// the dismissal path copies the serialized string across and the re-activation
+// path copies it back. Same shape on both sides makes that a string copy rather
+// than a parse/transform.
+// ---------------------------------------------------------------------------
+
+export interface PageHistoryEntry {
+  page?: number;
+  timestamp: number;
+  sessionDuration?: number;
+  highlightId?: string;
+}
+
+export interface PdfSourceState {
+  page?: number;
+  range?: { start: number; end: number };
+  history?: PageHistoryEntry[];
+}
+
+export interface PdfState {
+  v: 1;
+  /** The PDF pinned as active for this Rem, when it has several sources. */
+  active?: string;
+  bySource: Record<string, PdfSourceState>;
+}
+
+const EMPTY: PdfState = { v: 1, bySource: {} };
+
+/** Page history is capped at this many entries per source, as it was under the
+ *  old per-pair key. A Rem reading several PDFs holds one capped list each. */
+export const PAGE_HISTORY_LIMIT = 100;
+
+// --- powerup resolution ----------------------------------------------------
+
+/** Which powerup currently carries this Rem's state. A Rem is Incremental or
+ *  Dismissed, never both in normal operation; Incremental wins if both are
+ *  somehow present, since that is the live one. */
+async function resolveStateHost(rem: PluginRem): Promise<string | null> {
+  try {
+    if (await rem.hasPowerup(powerupCode)) return powerupCode;
+    if (await rem.hasPowerup(dismissedPowerupCode)) return dismissedPowerupCode;
+  } catch {
+    /* fall through */
+  }
+  return null;
+}
+
+// --- serialization ---------------------------------------------------------
+
+function parseState(raw: unknown): PdfState | null {
+  if (!raw || typeof raw !== 'string' || raw.trim() === '') return null;
+  try {
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object') return null;
+    return { v: 1, active: parsed.active, bySource: parsed.bySource || {} };
+  } catch {
+    return null;
+  }
+}
+
+/** Reads the raw serialized state string, or null. Used by the dismissal
+ *  transfer, which moves the value without needing to understand it. */
+export async function readRawPdfState(
+  rem: PluginRem,
+  powerup: string
+): Promise<string | null> {
+  try {
+    const raw = await rem.getPowerupProperty(powerup, pdfStateSlotCode);
+    return typeof raw === 'string' && raw.trim() !== '' ? raw : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function writeRawPdfState(
+  rem: PluginRem,
+  powerup: string,
+  raw: string
+): Promise<void> {
+  await rem.setPowerupProperty(powerup, pdfStateSlotCode, [raw]);
+}
+
+// --- legacy migration ------------------------------------------------------
+
+/**
+ * Pulls whatever the legacy synced keys hold for one (Rem, PDF) pair.
+ *
+ * Returns null when there is nothing stored, so a Rem that never had legacy data
+ * is not written back for no reason. The legacy keys are left in place: plugin
+ * storage cannot delete a key, and writing null does not free the slot, so they
+ * wait for the ledger sweep (STORAGE_PLAN.md Phase 7).
+ */
+async function readLegacyPair(
+  plugin: RNPlugin,
+  remId: string,
+  pdfRemId: string
+): Promise<PdfSourceState | null> {
+  const [page, range, history] = await Promise.all([
+    plugin.storage.getSynced(getCurrentPageKey(remId, pdfRemId)),
+    plugin.storage.getSynced(getPageRangeKey(remId, pdfRemId)),
+    plugin.storage.getSynced(getPageHistoryKey(remId, pdfRemId)),
+  ]);
+
+  const state: PdfSourceState = {};
+  if (typeof page === 'number') state.page = page;
+  if (range && typeof range === 'object' && 'start' in (range as any)) {
+    state.range = range as { start: number; end: number };
+  }
+  if (Array.isArray(history)) {
+    const normalized = normalizeHistory(history);
+    if (normalized.length > 0) state.history = normalized;
+  }
+
+  return Object.keys(state).length > 0 ? state : null;
+}
+
+/** Accepts both historical history shapes: a bare array of page numbers, and
+ *  the later entry objects. Entries with neither a page nor a highlightId are
+ *  dropped, matching the previous reader's behaviour. */
+export function normalizeHistory(raw: unknown): PageHistoryEntry[] {
+  if (!Array.isArray(raw)) return [];
+  return raw
+    .map((entry: any) => {
+      if (typeof entry === 'number') return { page: entry, timestamp: 0 };
+      if (entry && (typeof entry.page === 'number' || entry.highlightId)) {
+        return {
+          page: typeof entry.page === 'number' ? entry.page : undefined,
+          timestamp: entry.timestamp || 0,
+          sessionDuration: entry.sessionDuration,
+          highlightId: entry.highlightId,
+        };
+      }
+      return null;
+    })
+    .filter(Boolean) as PageHistoryEntry[];
+}
+
+// --- load / save -----------------------------------------------------------
+
+export interface LoadedPdfState {
+  rem: PluginRem | null;
+  powerup: string | null;
+  state: PdfState;
+}
+
+/**
+ * Loads a Rem's PDF state, migrating the legacy keys for `pdfRemId` if the
+ * property does not cover that source yet.
+ *
+ * Pass `pdfRemId` when the caller is working with a specific source — migration
+ * is per-pair, because the legacy key names cannot be enumerated without knowing
+ * both ids. Omit it to read whatever the property already holds.
+ */
+export async function loadPdfState(
+  plugin: RNPlugin,
+  remId: string,
+  pdfRemId?: string
+): Promise<LoadedPdfState> {
+  let rem: PluginRem | null = null;
+  try {
+    rem = (await plugin.rem.findOne(remId)) ?? null;
+  } catch {
+    rem = null;
+  }
+
+  const powerup = rem ? await resolveStateHost(rem) : null;
+  let state: PdfState = { v: 1, bySource: {} };
+
+  if (rem && powerup) {
+    const parsed = parseState(await readRawPdfState(rem, powerup));
+    if (parsed) state = parsed;
+  }
+
+  // Legacy fallback, for this source only.
+  if (pdfRemId && !state.bySource[pdfRemId]) {
+    const legacy = await readLegacyPair(plugin, remId, pdfRemId);
+    if (legacy) {
+      state.bySource[pdfRemId] = legacy;
+      if (rem && powerup) {
+        try {
+          await writeRawPdfState(rem, powerup, JSON.stringify(state));
+          console.log(`[PdfState] Migrated legacy reading state for ${remId} / ${pdfRemId} onto the Rem.`);
+        } catch (err) {
+          console.warn('[PdfState] Migration write failed; using the legacy value', err);
+        }
+      }
+    }
+  }
+
+  // The active PDF lived in its own per-Rem key.
+  if (state.active === undefined) {
+    try {
+      const legacyActive = await plugin.storage.getSynced<string>(getActivePdfKey(remId));
+      if (typeof legacyActive === 'string' && legacyActive) state.active = legacyActive;
+    } catch {
+      /* ignore */
+    }
+  }
+
+  return { rem, powerup, state };
+}
+
+/** Persists a state object. A Rem with neither powerup cannot hold it — that
+ *  happens transiently while a Rem is being converted, and losing a page
+ *  position there is preferable to writing a property onto an untagged Rem. */
+export async function savePdfState(loaded: LoadedPdfState): Promise<boolean> {
+  const { rem, powerup, state } = loaded;
+  if (!rem || !powerup) return false;
+  try {
+    await writeRawPdfState(rem, powerup, JSON.stringify(state));
+    return true;
+  } catch (err) {
+    console.warn('[PdfState] Write failed', err);
+    return false;
+  }
+}
+
+/** Read-modify-write for one source's slice of the state. */
+export async function updateSourceState(
+  plugin: RNPlugin,
+  remId: string,
+  pdfRemId: string,
+  mutate: (current: PdfSourceState) => PdfSourceState
+): Promise<void> {
+  const loaded = await loadPdfState(plugin, remId, pdfRemId);
+  const current = loaded.state.bySource[pdfRemId] || {};
+  loaded.state.bySource[pdfRemId] = mutate({ ...current });
+  await savePdfState(loaded);
+}
+
+// --- dismissal transfer ----------------------------------------------------
+
+/**
+ * Moves the serialized state between the Incremental and Dismissed powerups.
+ *
+ * Dismissal removes the Incremental powerup, so this must run BEFORE that
+ * removal; re-activation adds the Incremental powerup, so it must run AFTER.
+ * Both powerups use the same slot code and the same shape, so nothing is parsed.
+ *
+ * When the target already holds state (a Rem dismissed, revived and dismissed
+ * again), the two are merged per source with the incoming — more recent —
+ * value winning, rather than one silently replacing the other.
+ */
+export async function transferPdfState(
+  rem: PluginRem,
+  fromPowerup: string,
+  toPowerup: string
+): Promise<boolean> {
+  const incoming = await readRawPdfState(rem, fromPowerup);
+  if (!incoming) return false;
+
+  const existing = await readRawPdfState(rem, toPowerup);
+  if (!existing) {
+    await writeRawPdfState(rem, toPowerup, incoming);
+    return true;
+  }
+
+  const a = parseState(existing) ?? EMPTY;
+  const b = parseState(incoming) ?? EMPTY;
+  const merged: PdfState = {
+    v: 1,
+    active: b.active ?? a.active,
+    bySource: { ...a.bySource, ...b.bySource },
+  };
+  await writeRawPdfState(rem, toPowerup, JSON.stringify(merged));
+  return true;
+}

--- a/src/lib/priority_review_document/cleanup.ts
+++ b/src/lib/priority_review_document/cleanup.ts
@@ -1,29 +1,19 @@
 import { RNPlugin } from '@remnote/plugin-sdk';
 import { GRAPH_DATA_KEY_PREFIX, REVIEW_GRAPH_INDEX_KEY } from '../consts';
 
+// LEGACY. Graph data now lives on the graph Rem itself (see ./graph_data.ts), so
+// nothing registers new entries here any more and no new orphans are created —
+// deleting a Priority Review Document now takes its graph data with it.
+//
+// What remains is a sweep over the entries written BEFORE that change. It can
+// only blank their values, not delete the keys (plugin storage has no deletion
+// API and writing null does not release the slot), so its benefit is limited to
+// reclaiming the bytes of graphs whose Rem is gone. Retire this once RemNote
+// ships deletion and the ledger sweep in STORAGE_PLAN.md Phase 7 can run.
+
 interface ReviewGraphIndexEntry {
   remId: string;
   createdAt: number;
-}
-
-/**
- * Registers a newly-written review-graph data entry in the synced index.
- * Call this immediately after `setSynced(GRAPH_DATA_KEY_PREFIX + graphRemId, ...)`.
- * The index is what allows the startup sweep to find orphaned keys later —
- * the SDK has no way to enumerate synced storage keys.
- */
-export async function registerReviewGraphKey(
-  plugin: RNPlugin,
-  graphRemId: string,
-): Promise<void> {
-  try {
-    const list = (await plugin.storage.getSynced<ReviewGraphIndexEntry[]>(REVIEW_GRAPH_INDEX_KEY)) || [];
-    const without = list.filter((e) => e.remId !== graphRemId);
-    without.push({ remId: graphRemId, createdAt: Date.now() });
-    await plugin.storage.setSynced(REVIEW_GRAPH_INDEX_KEY, without);
-  } catch (err) {
-    console.warn('[ReviewGraphCleanup] Failed to register key', graphRemId, err);
-  }
 }
 
 /**

--- a/src/lib/priority_review_document/graph_data.ts
+++ b/src/lib/priority_review_document/graph_data.ts
@@ -1,0 +1,126 @@
+import { RNPlugin, PluginRem } from '@remnote/plugin-sdk';
+import {
+  GRAPH_DATA_KEY_PREFIX,
+  priorityGraphPowerupCode,
+  priorityGraphDataSlotCode,
+} from '../consts';
+
+// ---------------------------------------------------------------------------
+// Priority Review Document — graph data storage
+//
+// The graph is a snapshot of the priority distribution at the moment the review
+// document was created; it is never recomputed (recomputing later would give
+// different numbers, since priorities move and items get reviewed). So it is the
+// only copy of that data and has to persist.
+//
+// It used to live under a synced key per graph Rem, `priority_review_graph_data_
+// <remId>`. That was the worst-behaved family the storage audit found: plugin
+// storage has no deletion API, so when the user deleted a Priority Review
+// Document its key stayed behind forever, unnameable and unreclaimable — writing
+// null does not release the slot. A synced index existed to let a startup sweep
+// find those orphans, but it could only ever null them, and the index was empty
+// in practice anyway.
+//
+// The data now lives on the graph Rem itself, in a hidden powerup slot. The Rem
+// is created by the plugin (it already carries the Priority Review Graph
+// powerup), so this costs no extra tagging, and deleting the review document
+// takes the graph data with it. That is the whole point: the lifetime problem
+// disappears rather than being swept up afterwards.
+//
+// Reads fall back to the legacy key and migrate on the way past, per RemNote's
+// recommended pattern — no bulk migration pass. Documents created before this
+// change keep working and move themselves across the first time they are opened.
+// ---------------------------------------------------------------------------
+
+export interface PriorityGraphBin {
+  [key: string]: any;
+}
+
+export interface ReviewGraphData {
+  bins: PriorityGraphBin[];
+  binsRelative?: PriorityGraphBin[];
+  stats: { incRem: number; card: number } | null;
+}
+
+/** Normalizes the two historical shapes into one. The oldest documents stored a
+ *  bare array of bins; later ones an object with bins/binsRelative/stats. */
+function normalize(stored: any): ReviewGraphData | null {
+  if (!stored) return null;
+  if (Array.isArray(stored)) return { bins: stored, binsRelative: undefined, stats: null };
+  return {
+    bins: stored.bins || [],
+    binsRelative: stored.binsRelative,
+    stats: stored.stats || null,
+  };
+}
+
+/** Writes the snapshot onto the graph Rem. Values are RichText, so the JSON is
+ *  serialized to a string. */
+export async function saveReviewGraphData(
+  plugin: RNPlugin,
+  graphRem: PluginRem,
+  data: ReviewGraphData
+): Promise<void> {
+  await graphRem.setPowerupProperty(priorityGraphPowerupCode, priorityGraphDataSlotCode, [
+    JSON.stringify(data),
+  ]);
+}
+
+/**
+ * Reads the snapshot for a graph Rem.
+ *
+ * Order: the Rem's own property first, then the legacy synced key — and when the
+ * legacy key is the one that answers, its value is copied onto the Rem so the
+ * next read comes from the property. The legacy key itself cannot be removed
+ * until RemNote provides a deletion API; it is recorded in STORAGE_PLAN.md's
+ * ledger phase for that day.
+ */
+export async function loadReviewGraphData(
+  plugin: RNPlugin,
+  remId: string
+): Promise<ReviewGraphData | null> {
+  let rem: PluginRem | undefined;
+  try {
+    rem = (await plugin.rem.findOne(remId)) ?? undefined;
+  } catch {
+    rem = undefined;
+  }
+
+  if (rem) {
+    try {
+      const raw = await rem.getPowerupProperty(
+        priorityGraphPowerupCode,
+        priorityGraphDataSlotCode
+      );
+      if (raw && typeof raw === 'string' && raw.trim() !== '') {
+        const parsed = normalize(JSON.parse(raw));
+        if (parsed) return parsed;
+      }
+    } catch (err) {
+      // A malformed property should fall through to the legacy key rather than
+      // blanking a graph the user can still see data for.
+      console.warn('[ReviewGraph] Could not read graph data property, trying legacy key', err);
+    }
+  }
+
+  let legacy: unknown;
+  try {
+    legacy = await plugin.storage.getSynced(GRAPH_DATA_KEY_PREFIX + remId);
+  } catch {
+    return null;
+  }
+
+  const parsed = normalize(legacy);
+  if (!parsed) return null;
+
+  if (rem) {
+    try {
+      await saveReviewGraphData(plugin, rem, parsed);
+      console.log(`[ReviewGraph] Migrated graph data for ${remId} from synced storage onto the Rem.`);
+    } catch (err) {
+      console.warn('[ReviewGraph] Migration write failed; continuing from the legacy value', err);
+    }
+  }
+
+  return parsed;
+}

--- a/src/lib/priority_review_document/index.ts
+++ b/src/lib/priority_review_document/index.ts
@@ -5,13 +5,12 @@ import { getDueCardsWithPriorities } from '../card_priority';
 import {
   allIncrementalRemKey,
   priorityGraphPowerupCode,
-  GRAPH_DATA_KEY_PREFIX,
   allCardPriorityInfoKey
 } from '../consts';
 import { CardPriorityInfo, calculateCardRemPercentilesFromCards } from '../card_priority';
 import { calculateAllPercentiles } from '../utils';
 import { buildComprehensiveScope } from '../scope_helpers';
-import { registerReviewGraphKey } from './cleanup';
+import { saveReviewGraphData } from './graph_data';
 import { safeRemTextToString } from '../pdfUtils';
 import * as _ from 'remeda'; // Ensure remeda is imported for uniqBy if available, or use custom
 
@@ -561,10 +560,10 @@ Created: ${timestamp}`;
       }
     };
 
-    await plugin.storage.setSynced(GRAPH_DATA_KEY_PREFIX + graphRem._id, graphData);
-    // Track this graph Rem so the startup sweep can clear its data later
-    // if the user deletes the Priority Review Document.
-    await registerReviewGraphKey(plugin, graphRem._id);
+    // Stored on the graph Rem itself rather than under a synced key, so it is
+    // deleted along with the review document. Plugin storage has no deletion
+    // API, so the old per-graph keys could only ever be orphaned.
+    await saveReviewGraphData(plugin, graphRem, graphData);
   }
 
 

--- a/src/lib/review_actions.ts
+++ b/src/lib/review_actions.ts
@@ -1,5 +1,5 @@
 import { RNPlugin, PluginRem } from '@remnote/plugin-sdk';
-import { getActivePdfForIncRem, getCurrentPageKey, addPageToHistory, safeRemTextToString } from './pdfUtils';
+import { getActivePdfForIncRem, getIncrementalReadingPosition, addPageToHistory, safeRemTextToString } from './pdfUtils';
 import { getIncrementalRemFromRem, updateReviewRemData } from './incremental_rem';
 import { incremReviewStartTimeKey } from './consts';
 import { determineIncRemType } from './incRemHelpers';
@@ -19,8 +19,7 @@ export const handleReviewInEditorRem = async (
     if (remType === 'pdf') {
         const pdfRem = await getActivePdfForIncRem(plugin, rem);
         if (pdfRem) {
-            const pageKey = getCurrentPageKey(rem._id, pdfRem._id);
-            const currentPage = await plugin.storage.getSynced<number>(pageKey);
+            const currentPage = await getIncrementalReadingPosition(plugin, rem._id, pdfRem._id);
 
             if (currentPage) {
                 await addPageToHistory(plugin, rem._id, pdfRem._id, currentPage);

--- a/src/register/commands.ts
+++ b/src/register/commands.ts
@@ -50,7 +50,7 @@ import { initIncrementalRem } from './powerups';
 import { getIncrementalRemFromRem, handleNextRepetitionClick, getCurrentIncrementalRem, requestQueueDashboardRefocus } from '../lib/incremental_rem';
 import { removeIncrementalRemCache } from '../lib/incremental_rem/cache';
 import { IncrementalRep } from '../lib/incremental_rem/types';
-import { safeRemTextToString, getCurrentPageKey, addPageToHistory, registerRemsAsPdfKnown, getActivePdfForIncRem, getAllPDFsInRem, getDescendantsToDepth, getRemCardContent, resolveSourcePopupTarget } from '../lib/pdfUtils';
+import { safeRemTextToString, getIncrementalReadingPosition, addPageToHistory, registerRemsAsPdfKnown, getActivePdfForIncRem, getAllPDFsInRem, getDescendantsToDepth, getRemCardContent, resolveSourcePopupTarget } from '../lib/pdfUtils';
 import { getHoveredReference } from './events';
 import { transferToDismissed } from '../lib/dismissed';
 import { addToIncrementalHistory, addDismissalToIncrementalHistory } from '../lib/history_utils';
@@ -2499,8 +2499,7 @@ export async function registerCommands(plugin: ReactRNPlugin) {
       if (remType === 'pdf') {
         const pdfRem = await getActivePdfForIncRem(plugin, rem);
         if (pdfRem) {
-          const pageKey = getCurrentPageKey(rem._id, pdfRem._id);
-          const currentPage = await plugin.storage.getSynced<number>(pageKey);
+          const currentPage = await getIncrementalReadingPosition(plugin, rem._id, pdfRem._id);
           if (currentPage) {
             await addPageToHistory(plugin, rem._id, pdfRem._id, currentPage);
           }

--- a/src/register/powerups.tsx
+++ b/src/register/powerups.tsx
@@ -10,6 +10,8 @@ import {
   repHistorySlotCode,
   originalIncrementalDateSlotCode,
   priorityGraphPowerupCode,
+  priorityGraphDataSlotCode,
+  pdfStateSlotCode,
   dismissedPowerupCode,
   dismissedHistorySlotCode,
   dismissedDateSlotCode,
@@ -69,6 +71,15 @@ export async function registerPluginPowerups(plugin: ReactRNPlugin) {
           hidden: true,
         },
         {
+          // PDF reading state — page, range, page history and active PDF, as
+          // serialized JSON. Machine state, so hidden and programmatic-only.
+          code: pdfStateSlotCode,
+          name: 'Reading State',
+          propertyType: PropertyType.TEXT,
+          hidden: true,
+          onlyProgrammaticModifying: true,
+        },
+        {
           code: originalIncrementalDateSlotCode,
           name: 'Created',
           propertyType: PropertyType.DATE,
@@ -112,7 +123,17 @@ export async function registerPluginPowerups(plugin: ReactRNPlugin) {
     code: priorityGraphPowerupCode,
     description: 'Displays a distribution graph of priorities for items in this document.',
     options: {
-      slots: [] // No special slots needed, we just use the tag as a trigger
+      slots: [
+        {
+          // The graph's own data, as serialized JSON. Hidden and
+          // programmatic-only: it is machine state, not something to edit by hand.
+          code: priorityGraphDataSlotCode,
+          name: 'Graph Data',
+          propertyType: PropertyType.TEXT,
+          hidden: true,
+          onlyProgrammaticModifying: true,
+        },
+      ],
     }
   });
 
@@ -135,6 +156,16 @@ export async function registerPluginPowerups(plugin: ReactRNPlugin) {
           name: 'Dismissed Date',
           propertyType: PropertyType.DATE,
           hidden: true,
+        },
+        {
+          // Mirror of the Incremental powerup's slot, same code and same shape.
+          // Dismissal removes the Incremental powerup, so the reading state is
+          // copied here to survive it and copied back on re-activation.
+          code: pdfStateSlotCode,
+          name: 'Reading State',
+          propertyType: PropertyType.TEXT,
+          hidden: true,
+          onlyProgrammaticModifying: true,
         },
       ],
     },

--- a/src/widgets/answer_buttons.tsx
+++ b/src/widgets/answer_buttons.tsx
@@ -32,7 +32,7 @@ import { getIncrementalRemFromRem, handleNextRepetitionClick, handleNextRepetiti
 import { removeIncrementalRemCache } from '../lib/incremental_rem/cache';
 import { IncrementalRem } from '../lib/incremental_rem';
 import { percentileToHslColor, calculateRelativePercentile, calculateVolumeBasedPercentile, calculateWeightedShield, PERFORMANCE_MODE_LIGHT } from '../lib/utils';
-import { safeRemTextToString, getActivePdfForIncRem, findHTMLinRem, addPageToHistory, getPageHistory, getCurrentPageKey, getDescendantsToDepth, resolveSessionBookmarkCarry } from '../lib/pdfUtils';
+import { safeRemTextToString, getActivePdfForIncRem, findHTMLinRem, addPageToHistory, getPageHistory, getIncrementalReadingPosition, getDescendantsToDepth, resolveSessionBookmarkCarry } from '../lib/pdfUtils';
 import { getRemReadPoint } from '../lib/remReadPoint';
 import { resolveRemTextForBreadcrumb } from '../lib/richTextRemRefs';
 import { QueueSessionCache, setCardPriority } from '../lib/card_priority';
@@ -345,8 +345,7 @@ export function AnswerButtons() {
     if (remType === 'pdf') {
       const pdfRem = await getActivePdfForIncRem(plugin, rem);
       if (pdfRem) {
-        const pageKey = getCurrentPageKey(rem._id, pdfRem._id);
-        const currentPage = await plugin.storage.getSynced<number>(pageKey);
+        const currentPage = await getIncrementalReadingPosition(plugin, rem._id, pdfRem._id);
 
         if (currentPage) {
           // Carry a session bookmark forward so this reading-time entry does

--- a/src/widgets/debug.tsx
+++ b/src/widgets/debug.tsx
@@ -23,6 +23,7 @@ import {
   getAllPDFsInRem,
   getPageHistory,
   getPageHistoryKey,
+  setPageHistory,
   getReadingStatistics,
 } from '../lib/pdfUtils';
 import { formatDuration } from '../lib/utils';
@@ -1496,10 +1497,12 @@ function Debug() {
     pdfName: string,
     repHistory: Array<{ date: number; reviewTimeSeconds?: number }>
   ): Promise<InflationPdfEntry | null> => {
+    // Page history now lives on the Rem, so a missing legacy key no longer means
+    // "nothing recorded" — read through the accessor and treat an empty history
+    // as nothing to analyse. storageKey is kept for display only.
     const storageKey = getPageHistoryKey(rId, pdfRem._id);
-    const rawStored = await plugin.storage.getSynced(storageKey);
-    if (rawStored == null) return null; // no key present
     const history = await getPageHistory(plugin, rId, pdfRem._id);
+    if (history.length === 0) return null;
 
     const matchesRep = (entry: { timestamp: number; sessionDuration?: number }) => {
       const dur = entry.sessionDuration;
@@ -1628,8 +1631,8 @@ function Debug() {
     try {
       for (const p of inflationPreview.perPdf) {
         if (p.stripCount === 0) continue;
-        await plugin.storage.setSynced(p.storageKey, p.patched);
-        console.log(`[InflationCleanup] Rewrote ${p.storageKey} — stripped ${p.stripCount} entr(ies).`);
+        await setPageHistory(plugin, remId!, p.pdfRemId, p.patched);
+        console.log(`[InflationCleanup] Rewrote page history for ${remId}/${p.pdfRemId} — stripped ${p.stripCount} entr(ies).`);
       }
       await plugin.app.toast(`Cleanup applied. Stripped ${totalStrip} entr(ies).`);
       setInflationPreview(null);
@@ -1746,9 +1749,9 @@ function Debug() {
       let rewritten = 0;
       for (const r of globalInflationPreview.perRem) {
         for (const p of r.perPdf) {
-          await plugin.storage.setSynced(p.storageKey, p.patched);
+          await setPageHistory(plugin, r.remId, p.pdfRemId, p.patched);
           rewritten++;
-          console.log(`[GlobalInflationCleanup] Rewrote ${p.storageKey} — stripped ${p.stripCount} entr(ies).`);
+          console.log(`[GlobalInflationCleanup] Rewrote page history for ${r.remId}/${p.pdfRemId} — stripped ${p.stripCount} entr(ies).`);
         }
       }
       await plugin.app.toast(`Global cleanup applied. Rewrote ${rewritten} key(s), stripped ${globalInflationPreview.totalStripCount} entr(ies).`);

--- a/src/widgets/debug.tsx
+++ b/src/widgets/debug.tsx
@@ -1388,8 +1388,11 @@ function Debug() {
       console.log(`\n========== PAGE HISTORY DUMP: ${remId} ==========`);
       for (const { rem: pdfRem } of pdfs) {
         const pdfName = await safeRemTextToString(plugin, pdfRem.text);
+        // Reading state lives on the Rem now; the legacy key is only still read
+        // here to show whether this pair has migrated. `null` next to a populated
+        // parsed history means "migrated", not "data lost".
         const storageKey = getPageHistoryKey(remId, pdfRem._id);
-        const raw = await plugin.storage.getSynced(storageKey);
+        const legacyRaw = await plugin.storage.getSynced(storageKey);
         const parsed = await getPageHistory(plugin, remId, pdfRem._id);
         const stats = await getReadingStatistics(plugin, remId, pdfRem._id);
 
@@ -1408,7 +1411,10 @@ function Debug() {
         console.log(`Sum of sessionDurations: ${durationsSum}s = ${formatDuration(durationsSum)}`);
         console.log(`getReadingStatistics().totalTimeSeconds: ${stats.totalTimeSeconds}s = ${formatDuration(stats.totalTimeSeconds)}`);
         console.log(`Min duration: ${durationsMin}s   Max duration: ${durationsMax}s   Capped(>=14400): ${capped14400Count}`);
-        console.log(`Raw storage value:`, raw);
+        console.log(
+          `Legacy synced value (${legacyRaw == null ? 'none — migrated to the Rem' : 'still present'}):`,
+          legacyRaw
+        );
         console.log(`Parsed history (JSON):`);
         console.log(JSON.stringify(parsed, null, 2));
 

--- a/src/widgets/page-range.tsx
+++ b/src/widgets/page-range.tsx
@@ -7,7 +7,8 @@ import {
 } from '@remnote/plugin-sdk';
 import React, { useState, useEffect } from 'react';
 import {
-  getPageRangeKey,
+  setIncrementalPageRange,
+  clearIncrementalPageRange,
   getPageHistory,
   getAllIncrementsForPDF,
   getInstantRemsForPDF,
@@ -283,17 +284,15 @@ function PageRangeWidget() {
     if (!contextData?.pdfRemId || editingState.type !== 'range') return;
 
     const { start, end } = editingState;
-    const rangeKey = getPageRangeKey(remId, contextData.pdfRemId);
-
     if (start > 1 || end > 0) {
-      await plugin.storage.setSynced(rangeKey, { start, end });
+      await setIncrementalPageRange(plugin, remId, contextData.pdfRemId, start, end);
       // Patch the range for this rem in the local list in-place
       setRelatedRems(prev => prev.map(r =>
         r.remId === remId ? { ...r, range: { start, end } } : r
       ));
       await plugin.app.toast(`Saved page range: ${start}-${end || '∞'}`);
     } else {
-      await plugin.storage.setSynced(rangeKey, null);
+      await clearIncrementalPageRange(plugin, remId, contextData.pdfRemId);
       setRelatedRems(prev => prev.map(r =>
         r.remId === remId ? { ...r, range: null } : r
       ));
@@ -506,14 +505,11 @@ function PageRangeWidget() {
 
     try {
       const { incrementalRemId, pdfRemId } = contextData;
-      const rangeKey = getPageRangeKey(incrementalRemId, pdfRemId);
-
       if (pageRangeStart > 1 || pageRangeEnd > 0) {
-        const range = { start: pageRangeStart, end: pageRangeEnd };
-        await plugin.storage.setSynced(rangeKey, range);
+        await setIncrementalPageRange(plugin, incrementalRemId, pdfRemId, pageRangeStart, pageRangeEnd);
         await plugin.app.toast(`Saved page range: ${pageRangeStart}-${pageRangeEnd || '∞'}`);
       } else {
-        await plugin.storage.setSynced(rangeKey, null);
+        await clearIncrementalPageRange(plugin, incrementalRemId, pdfRemId);
         await plugin.app.toast('Cleared page range');
       }
 

--- a/src/widgets/priority_editor.tsx
+++ b/src/widgets/priority_editor.tsx
@@ -23,7 +23,8 @@ import {
   getReadingStatistics,
   setIncrementalReadingPosition,
   addPageToHistory,
-  getPageRangeKey,
+  setIncrementalPageRange,
+  clearIncrementalPageRange,
   safeRemTextToString,
   PageHistoryEntry,
 } from '../lib/pdfUtils';
@@ -307,12 +308,11 @@ export function PriorityEditor() {
   const pdfSaveRange = useCallback(async () => {
     if (pdfEdit.mode !== 'range' || !remId || !hostPdfRemId) return;
     const { start, end } = pdfEdit;
-    const rangeKey = getPageRangeKey(remId, hostPdfRemId);
     if (start > 1 || end > 0) {
-      await plugin.storage.setSynced(rangeKey, { start, end });
+      await setIncrementalPageRange(plugin, remId, hostPdfRemId, start, end);
       await plugin.app.toast(`Saved page range: ${start}–${end || '∞'}`);
     } else {
-      await plugin.storage.setSynced(rangeKey, null);
+      await clearIncrementalPageRange(plugin, remId, hostPdfRemId);
       await plugin.app.toast('Cleared page range');
     }
     setPdfEdit({ mode: 'none' });

--- a/src/widgets/priority_review_graph.tsx
+++ b/src/widgets/priority_review_graph.tsx
@@ -10,7 +10,7 @@ import {
   Legend,
   ResponsiveContainer,
 } from 'recharts';
-import { GRAPH_DATA_KEY_PREFIX } from '../lib/consts';
+import { loadReviewGraphData } from '../lib/priority_review_document/graph_data';
 
 interface GraphDataPoint {
   range: string;
@@ -40,24 +40,12 @@ function PriorityReviewGraph() {
 
   const remId = context?.remId;
 
-  // Fetch the data and parse it
+  // Reads the graph Rem's own property, falling back to the legacy synced key
+  // (and migrating it across) for documents created before the move. Both
+  // historical value shapes are normalized inside the loader.
   const graphData = useRunAsync(async () => {
     if (!remId) return null;
-    const stored = await plugin.storage.getSynced(GRAPH_DATA_KEY_PREFIX + remId) as any;
-
-    if (!stored) return null;
-
-    // Handle legacy format (just array)
-    if (Array.isArray(stored)) {
-      return { bins: stored, binsRelative: undefined, stats: null };
-    }
-
-    // Handle new format
-    return {
-      bins: stored.bins || [],
-      binsRelative: stored.binsRelative, // May be undefined for older docs created before this update
-      stats: stored.stats || null
-    };
+    return await loadReviewGraphData(plugin, remId);
   }, [remId]);
 
   if (!graphData || !graphData.bins || graphData.bins.length === 0) {


### PR DESCRIPTION
## v1.0.34 - August 5th, 2026

### 🐛 Fixed: a PDF could open the wrong chapter

When a chapter Incremental Rem had its PDF source removed, it could linger in the plugin's index of "rems that use this PDF". Opening that PDF then resolved the *detached* chapter as the one to read — and it did so in preference to a correctly-linked chapter sitting further down the same list, because the lookup took the first entry it found without checking the PDF was still one of that rem's sources. It now checks.

### ♻️ Changed: reading state is stored on the Rem itself

Your **current page, page range, page history, active PDF and read points** used to live in the plugin's own storage, filed under keys built from the Rem's id. They now live on the Rem, in a hidden property.

Nothing changes in how you use any of it, and nothing needs migrating by hand — each item moves itself the first time it is opened. What changes is what happens to it afterwards:

- **Reading history now survives dismissal.** Dismissing a chapter and later making it Incremental again (`Alt+X`) used to leave its reading position behind; the state now travels with the Rem in both directions. This applies to read points on outline-style Rems too, which were similarly lost before.
- **Reading history now survives losing the PDF source.** If you detach a chapter from its PDF — a common step once a section is processed, since the source pulls every one of the book's highlights into that chapter's scoped queue — the reading history stays on the chapter rather than becoming unreachable.
- **Deleting a chapter now deletes its reading data.** Previously the plugin had no way to remove those entries, so every deleted chapter left its page position and history behind permanently.

The same move applies to the distribution graph inside a **Priority Review Document**: its data now lives on the graph Rem, so deleting the document takes the graph data with it instead of stranding it.

> [!NOTE]
> This is the second instalment of a broader cleanup, prompted by the storage limits RemNote introduced in 1.27.16 (see [v1.0.29](#v1029-august-1st-2026)). Around 480 of the plugin's storage entries move onto the Rems they describe. Existing data is read and migrated as you go — there is no upgrade step and nothing to click.
