### PR TITLE
Fixed priority slots failure after RemNote update

### DIFF
--- a/REMNOTE_SUPPORT_FOLLOWUP_1.27.24.md
+++ b/REMNOTE_SUPPORT_FOLLOWUP_1.27.24.md
@@ -1,0 +1,131 @@
+# Follow-up: verification of the 1.27.24 fix, and what remains
+
+**Reporter:** Hugo Marins — *Incremental Everything* plugin (`incremental-everything`, v1.0.35)
+**Date:** 2026-08-07
+**Re:** previous report — *Powerup property references re-pointed to orphaned slot Rems after the storage/sync overhaul*
+
+This is a follow-up. It covers only what is new since that report: what 1.27.24 fixed, what it did not, and what we have since resolved on our own side. Everything below is measured across the same knowledge base (5,434 Incremental Rems, 45,078 CardPriority Rems).
+
+---
+
+## 1. Confirmed fixed by 1.27.24
+
+| Defect | Before | After |
+|---|---|---|
+| Detached `Incremental` priority | 5,390 / 5,434 (99.2%) | **0** |
+| Detached `CardPriority` priority | 3,001 / 45,078 (6.7%) | **0** |
+| `Next Rep Date` slot references | ~2,231 unresolvable | **0** |
+
+The migration re-pointed roughly 8,400 property→slot references, including the date properties. Thank you — this was the bulk of the problem.
+
+The `getPowerupSlotByCode` message was also amended to "…although legacy slot Rem may still exist", which resolves the inaccuracy raised in §6 of the previous report.
+
+---
+
+## 2. Residual A — collapsed property pairs (2 Rems, now fixed by us)
+
+Two Rems carrying **both** powerups had their two same-named `Priority` properties **merged into one**. The survivor was correctly linked to one powerup; the other powerup had no priority property at all.
+
+| Rem | Surviving property links to | Powerup left with nothing |
+|---|---|---|
+| `gJiSum4KOK8YRaCmU` | `6eUpUKWrfZdU4nrgc` (CardPriority) | Incremental |
+| `741rSQQHCazbKrttP` | `76Pb95h0XktNfDO7Y` (Incremental) | CardPriority |
+
+In both cases the two priorities were **numerically identical** before the merge — necessarily so for `gJiSum4KOK8YRaCmU`, whose card priority was derived from its incremental priority (`Source: incremental`). That points at a de-duplication step that collapsed two properties judged equivalent by name *and* value.
+
+Only 2 remain, and we have repaired both by rewriting the priority. **The concern is not the count but the rule:** the same de-duplication would silently destroy one of two *differing* priorities wherever the values were not equal.
+
+---
+
+## 3. Residual B — 376 properties referencing a DELETED slot Rem
+
+This is the significant one, and it was not addressed by 1.27.24.
+
+376 property Rems reference slot Rem **`JF0lnO7kCGbDrHRrt`**, which **does not exist** — `findOne` returns nothing. It is not a child of either powerup definition and is not one of the orphan slots identified previously.
+
+The 1.27.24 migration repaired properties pointing at the *surviving* orphan slot (`VLmEpU417yLnZEMWf`). Properties pointing at a **deleted** slot were left as they were.
+
+The consequence was that 376 CardPriority values remained unreadable. They did not appear as "detached" in any check keyed on known slot definitions — they were simply reported as **missing**, indistinguishable from a Rem that never had a priority set:
+
+```
+CardPriority: total 45,078 · ok 44,702 · detached 0 · missing 376
+```
+
+Of those 376: **21 had `prioritySource: manual`** — user-set values that nothing else held — and 354 were `inherited`.
+
+We note this predates the fix: the same slot id was already unresolvable in a dump taken 2026-08-06, before 1.27.24 was installed.
+
+---
+
+## 4. OUTSTANDING — 2,033 dangling Daily Document references
+
+**This is the one issue we cannot resolve and would like an answer on.**
+
+`Next Rep Date` stores its value as a reference to a Daily Document. The property Rems and their slot links are now healthy, but the documents they point at are gone:
+
+**2,033 of 5,394 (37.7%)** reference a Rem that no longer exists. RemNote's own property row renders as `Loading` indefinitely.
+
+Broken down by the scheduling interval recorded in each Rem's history — i.e. how far ahead of the write date the reference pointed:
+
+| Interval | Resolves | Dangling | Dangling |
+|---|---|---|---|
+| 0–1 days | 1,362 | 961 | 41.4% |
+| 2–7 days | 204 | 109 | 34.8% |
+| 8–30 days | 161 | 107 | 39.9% |
+| 31–90 days | 50 | 72 | 59.0% |
+| 90+ days | 7 | 146 | **95.4%** |
+| (not recorded) | 1,553 | 636 | 29.1% |
+
+The gradient is steep at the far end but the baseline is already ~41%, so "far-future documents were pruned" does not by itself account for it. A single mechanism that fits the whole curve: **empty Daily Documents did not survive, and survival tracks the probability that the document had content.** A document one day ahead is very likely a day the user actually opened RemNote; one ninety days ahead is almost certainly an auto-created, never-visited placeholder — and 95.4% of those are gone.
+
+Supporting this, the missing targets are heavily **shared** rather than unique per Rem: `SiSUgRPP4AmE6VtYN` is referenced by 6 different Rems in our sample, `e7EeGUq2xn4AhdFsa` by 4, `RJX52l8YddImAH0UT` by 3. Whole dates disappeared, not individual references.
+
+**Impact is limited only because our plugin independently stamps the next-repetition timestamp into its own history slot**, so the schedule survives and the affected Rems still come due correctly. 1,768 of the 2,033 (87%) are rebuildable from that stamp; 265 are not, because they predate the field. Any other plugin storing a date in a powerup slot, and any RemNote feature doing the same, would have no equivalent fallback.
+
+### Questions
+
+1. Were Daily Documents deleted as part of the migration — specifically empty, auto-created, future-dated ones?
+2. **Can it recur?** This is what matters most to us. If empty daily documents are pruned again, every future-dated reference breaks again, and we would need to stop storing dates as Daily Document references altogether.
+3. Is there any way to recover the deleted documents, or should we rebuild the references from our own history?
+
+---
+
+## 5. Also outstanding — orphan slot Rems on the powerup definitions
+
+Unchanged since the previous report. The powerup definitions still carry slot children that this plugin never registered:
+
+| Powerup | Slot Rem | Name |
+|---|---|---|
+| `Incremental` (`jhWSM9ZVkEx6uzLL4`) | `fAnEFqDe2zJwECi5N` | `Missing Name` |
+| `Incremental` | `2q46PZilKAtrhRwGP` | `Missing Name` |
+| `Incremental` | `YzfWfdh46cRFzlCOd` | `Missing Name` |
+| `CardPriority` (`PAbc0mEVTzOTk5118`) | `VLmEpU417yLnZEMWf` | *(empty text)* |
+
+Nothing points at them any longer, so they are inert. We would still like to know what they are and whether it is safe for a plugin to delete them.
+
+---
+
+## 6. What we resolved on our own side
+
+Recorded here so you know the current state of this knowledge base, and in case it is useful for other affected users.
+
+1. **Recovered the 21 manual CardPriority values** by reading the value from the mis-pointed property Rem and rewriting it through the normal write path, preserving the original `prioritySource` and `lastUpdated`. Each write was verified to read back. 21/21 succeeded.
+2. **Re-materialised the 354 inherited values** using our own "Update all inherited Card Priorities" command, which recomputes from the ancestor cascade and skips manual values. This also cleared the remaining `missing` count: 376 → **0**.
+3. **Deleted the 370 orphaned property Rems**, in stages — 3 first, verified, then the rest. Each deletion was individually guarded (refused unless the owner's priority already read back) and recorded the owner's state either side. Result: **370 deleted, 0 disturbed**. Deleting a mis-pointed property does not affect the correctly-linked one.
+
+Final state:
+
+```
+Incremental    5,434 total · detached 0 · missing 40
+CardPriority  45,078 total · detached 0 · missing 0
+Leftover priority properties: 0
+Next Rep Date: 2,033 dangling  ← the only outstanding data issue
+```
+
+---
+
+## Summary
+
+1.27.24 resolved the reference detachment. Two classes of residue remained — collapsed property pairs, and properties pointing at a deleted slot Rem — and we have repaired both locally; they are reported here because the underlying rules could affect other users.
+
+The dangling Daily Document references are the one outstanding problem, and the only one where data is genuinely unrecoverable from the property itself. Whether it can recur is the question that determines whether we change how this plugin stores dates.

--- a/REMNOTE_SUPPORT_REPORT_priority_slot_detachment.md
+++ b/REMNOTE_SUPPORT_REPORT_priority_slot_detachment.md
@@ -4,7 +4,7 @@
 **SDK:** `@remnote/plugin-sdk` ^0.0.46
 **RemNote build:** _(to be filled in — desktop build on which the dump below was taken)_
 **Date of evidence:** 2026-08-06
-**Severity:** Data is intact but unreadable through the plugin API. No data loss; silent wrong values presented to the user.
+**Severity:** Widespread. A full scan of this knowledge base finds **99.2% of Incremental Rems (5,390 / 5,434)** with a detached priority slot, **6.7% of CardPriority Rems (3,001 / 45,078)**, and **59.8% of scheduled dates (1,893 / 3,163)** pointing at Daily Documents that no longer exist. Values are recoverable in every category; none are silently correct.
 
 ---
 
@@ -156,6 +156,21 @@ Every pre-overhaul Incremental Rem examined shows the same defect, and every one
 
 In all three damaged cases the stored value agrees with the last priority recorded in the Rem's own history, which independently corroborates that these are the correct values and that nothing rewrote them.
 
+### 3.7 Scale — a full scan of the knowledge base
+
+| Powerup | Rems | OK | Detached | No value | Detached |
+|---|---|---|---|---|---|
+| `Incremental` | 5,434 | **4** | **5,390** | 40 | **99.2%** |
+| `CardPriority` | 45,078 | 41,701 | **3,001** | 376 | 6.7% |
+
+**Every single detached property in both populations points at the same orphan slot `VLmEpU417yLnZEMWf`** (5,389 + 3,001), with exactly one exception: one `Incremental` property points at `6eUpUKWrfZdU4nrgc`, which is `CardPriority`'s *registered* Priority slot. That single case is direct evidence of cross-powerup mixing of slots that share the display name "Priority".
+
+The four healthy `Incremental` Rems are the ones touched by hand during the repair testing above. In other words, **before those manual writes, the detachment rate for `Incremental` was effectively 100%.**
+
+The contrast with `CardPriority` is explained by write frequency rather than by a different fault. Card priorities are rewritten constantly by the plugin (inheritance cascades, new cards, batch operations), and — as §3.6 shows — any rewrite heals the reference. Incremental priority is written only when a user deliberately sets one, which is rare. On that reading both powerups were hit at ~100%, and `CardPriority` has been quietly self-healing ever since; the 6.7% is the residue that has not been rewritten yet.
+
+That inference matters for the remedy: it means the damage is repairable through ordinary writes, and is already repairing itself where writes happen.
+
 **Rewriting the property repairs the Rem.** Writing a new priority through the normal `setPowerupProperty` path was tested on two Rems, with dumps taken immediately before and after:
 
 ```
@@ -217,9 +232,32 @@ Here the property Rem and its slot link are both **healthy** — it correctly re
 
 This is materially different from §3. There the value survives on the Rem and can be recovered; here the referenced Rem is simply gone, and the scheduled date is unrecoverable from the property itself. (Our plugin survives it only because it independently stamps the next-repetition timestamp into its own history slot and falls back to that.)
 
-The correlation across the sample is suggestive but not conclusive at n=1 for the failing case: the two references that resolve point at a daily document **one day** ahead of when they were written, while the one that fails pointed **30 days** ahead, to a date that was still in the future at the time. A plausible mechanism is that empty, programmatically-created future daily documents did not survive the migration, orphaning every reference to them. If that is what happened, the scope would be considerably wider than §3, since it would affect any Rem scheduled far enough ahead — for this plugin, that is a large fraction of a mature knowledge base.
+### 5.1 Scale, and what the distribution shows
+
+A full scan of the knowledge base found **1,893 of 3,163 Rems with a Next Rep Date property (59.8%) pointing at a Daily Document that no longer exists.** Broken down by the scheduling interval recorded in each Rem's history — i.e. how far ahead of the write date the reference pointed:
+
+| Interval | Resolves | Dangling | Dangling |
+|---|---|---|---|
+| 0–1 days | 986 | 935 | 48.7% |
+| 2–7 days | 67 | 93 | 58.1% |
+| 8–30 days | 43 | 90 | 67.7% |
+| 31–90 days | 20 | 49 | 71.0% |
+| 90+ days | 3 | 139 | **97.9%** |
+| (interval not recorded) | 143 | 586 | 80.4% |
+
+The gradient is monotonic and steep — from roughly half at one day out to virtually total beyond ninety. But the baseline is already ~49%, so "far-future documents were pruned" does not by itself account for it.
+
+A single mechanism that fits the whole curve: **empty Daily Documents did not survive, and survival tracks the probability that the document had content.** A daily document one day ahead is very likely to be a day the user actually opened RemNote, so it accumulated content and survived. One ninety days ahead is almost certainly an auto-created, never-visited placeholder, and 97.9% of those are gone.
+
+Supporting this, the missing targets are heavily shared rather than unique per Rem: in the sample, `AE7yLF6exeF8tC1nS` is referenced by 5 different Rems and `uiFt628ESp1W6mcxq` by 6. Whole dates disappeared, not individual references.
 
 We would rather RemNote confirm or rule this out than guess at it.
+
+### 5.2 Recoverable, but not from the property
+
+Unlike §3, the value on the property cannot be recovered — the referenced Rem is gone. However, this plugin independently stamps the next-repetition timestamp into its own `History` slot on every scheduling write, so the *intended date* survives for these Rems and the schedule is not lost. Reading falls back to that stamp, which is why the affected Rems still appear in the queue on the correct day despite RemNote's own property row rendering as `Loading` indefinitely.
+
+This is a plugin-specific safety net. Any other plugin storing a date in a powerup slot, and any RemNote feature doing the same, would have no equivalent fallback.
 
 ---
 
@@ -291,7 +329,8 @@ The control Rem in §3.5 shows the identical layout (`childCount: 2`, no propert
 
 - Priority is the plugin's core scheduling input. An unreadable slot silently substitutes a default, which changes queue ordering and review weighting for every affected Rem.
 - The value presented to the user is wrong while the correct value remains on the Rem, so the fault is not visible as data loss and is easy to mistake for a plugin defect.
-- The reporting user observes this across Rems created before the overhaul; Rems created after it are unaffected. The evidence in this report is a full trace of one representative Rem.
+- Measured across this knowledge base: 5,390 Incremental Rems, 3,001 CardPriority Rems and 1,893 scheduled dates are affected (§3.7, §5.1). Rems created after the overhaul are unaffected.
+- **CardPriority is the most acute case.** `getCardPriority` has no history to fall back on — it silently resolves an inherited value or the default — so those 3,001 flashcard priorities are simply wrong in the app today, with no mitigation, even though the correct values are still present on the Rems.
 - Any plugin reading a **visible** powerup slot on pre-overhaul Rems is potentially exposed to the same failure, not only this one.
 
 ---

--- a/REMNOTE_SUPPORT_REPORT_priority_slot_detachment.md
+++ b/REMNOTE_SUPPORT_REPORT_priority_slot_detachment.md
@@ -1,0 +1,343 @@
+# Powerup property references re-pointed to orphaned slot Rems after the storage/sync overhaul
+
+**Reporter:** Hugo Marins — *Incremental Everything* plugin (`incremental-everything`, v1.0.34)
+**SDK:** `@remnote/plugin-sdk` ^0.0.46
+**RemNote build:** _(to be filled in — desktop build on which the dump below was taken)_
+**Date of evidence:** 2026-08-06
+**Severity:** Data is intact but unreadable through the plugin API. No data loss; silent wrong values presented to the user.
+
+---
+
+## 1. Summary
+
+On Rems that carried the plugin's `Incremental` powerup **before** RemNote's storage/sync overhaul, the `Priority` property is no longer readable via `getPowerupProperty('incremental', 'priority')`, which returns empty.
+
+The value has **not** been lost. It is still stored on the Rem, in the `backText` of its property Rem. What changed is the *link*: that property Rem's slot reference now points at a **nameless slot Rem that is a child of a different powerup definition** (`CardPriority`) instead of the registered `Incremental` → `Priority` slot.
+
+Because the plugin resolves the property by walking the registered slot, it finds nothing and falls back to a default — so the user sees a fabricated priority (P10 under the old code) while the real value sits on the Rem unread.
+
+Rems created *after* the overhaul are unaffected, and rewriting the priority on an affected Rem restores it (§3.6) — both consistent with a migration artifact rather than a live write-path defect.
+
+Three further findings are included below:
+
+- orphaned slot Rems present on the powerup definitions themselves (§4);
+- **dangling Daily Document references on `Next Rep Date` (§5)** — a separate fault where, unlike the above, the value is genuinely unrecoverable from the property;
+- the current `getPowerupSlotByCode` error message not matching observed behaviour (§6).
+
+---
+
+## 2. Symptom as seen by the user
+
+A Rem whose priority was set to **17** displays as **P10**, and RemNote's own outliner renders its property row under an **unnamed** slot:
+
+```
+• ARPA, que consiste em um radar de navegação comum, …          [P10]
+    📅 July 8th, 2026
+    • Unnamed — 17
+```
+
+The `17` in that row is the correct value. The `10` is the plugin's read fallback for an unreadable slot.
+
+---
+
+## 3. Primary finding — the property reference points at another powerup's orphan slot
+
+Diagnostic Rem: `I4pm1fkBWzvgCdI5n`
+
+### 3.1 The stored value is intact
+
+```json
+{
+  "propertyRemId":      "vAwvSXgSc3pUNGTxO",
+  "rawValue":           "17",
+  "slotReferenceLabel": "[Untitled]",
+  "slotDefIds":         ["VLmEpU417yLnZEMWf"],
+  "slotDefNames":       ["Untitled"],
+  "matchedPowerup":     null,
+  "matchedSlotCode":    null,
+  "apiValue":           null,
+  "verdict":            "DETACHED"
+}
+```
+
+- `rawValue` is read directly from the property Rem's `backText` — this is the stored value: **17**.
+- `apiValue` is what `getPowerupProperty('incremental', 'priority')` returns: **empty**.
+
+### 3.2 The slot it references belongs to a different powerup
+
+`VLmEpU417yLnZEMWf` is **not** the registered `Incremental` → `Priority` slot. The registered one is `76Pb95h0XktNfDO7Y`. `VLmEpU417yLnZEMWf` appears as a slot child of the **`CardPriority`** powerup (`PAbc0mEVTzOTk5118`):
+
+```json
+"CardPriority": {
+  "powerupRemId": "PAbc0mEVTzOTk5118",
+  "actualSlotChildren": [
+    { "id": "hgwNbXh4gypyUH5uR", "name": "Priority Source" },
+    { "id": "we4WQ5lsyor2D1j08", "name": "Last Updated" },
+    { "id": "VLmEpU417yLnZEMWf", "name": "" },          ← referenced by the Incremental property above
+    { "id": "6eUpUKWrfZdU4nrgc", "name": "Priority" }
+  ]
+}
+```
+
+So an `Incremental` property on a user Rem now resolves through a nameless slot Rem parented under `CardPriority`.
+
+Both powerups declare a slot displayed as **"Priority"** (`incremental:priority` and `cardPriority:priority`). A migration step that keyed on slot display name rather than on the owning powerup would produce exactly this result. This is a hypothesis, not a claim — the observation is the mis-pointed reference.
+
+### 3.3 A sibling property on the same Rem is undamaged
+
+The `Next Rep Date` property on the same Rem resolved correctly, which isolates the fault to the `Priority` reference rather than to the Rem as a whole:
+
+```json
+{
+  "propertyRemId":      "RtpNKSweZbmiP4bsS",
+  "rawValue":           "July 8th, 2026",
+  "slotReferenceLabel": "[Next Rep Date]",
+  "slotDefIds":         ["o9GwvFHCn3AH6MAFB"],
+  "matchedPowerup":     "Incremental",
+  "matchedSlotCode":    "nextRepDate",
+  "apiValue":           "July 8th, 2026",
+  "verdict":            "OK"
+}
+```
+
+### 3.4 Independent corroboration that 17 is the correct value
+
+The Rem's `History` slot is readable and records the priority at each repetition. Its last entry confirms 17:
+
+```json
+[
+  { "date": 1783414230669, "eventType": "madeIncremental",     "priority": 20, "nextRepMs": 1783500630637 },
+  { "date": 1783414237796, "eventType": "rescheduledInEditor", "priority": 17, "nextRepMs": 1783500637796 }
+]
+```
+
+Value in `backText` (17) and value in history (17) agree. The API read (empty) is the outlier.
+
+---
+
+### 3.5 Control — a Rem created after the overhaul is structurally identical and healthy
+
+Rem `IDWpFTp6pC8mkoqro` ("New Inc Rem for test"), created 2026-08-06, dumped from the same knowledge base under the same powerup definitions:
+
+```json
+{
+  "propertyRemId":      "6LkzHevmU1TUN8lZJ",
+  "rawValue":           "26",
+  "slotReferenceLabel": "[Priority]",
+  "slotDefIds":         ["76Pb95h0XktNfDO7Y"],
+  "matchedPowerup":     "Incremental",
+  "matchedSlotCode":    "priority",
+  "apiValue":           "26",
+  "verdict":            "OK"
+}
+```
+
+This is the same shape as the damaged Rem — one property Rem per visible slot, value in `backText` — differing only in which slot definition the reference points at: `76Pb95h0XktNfDO7Y` (registered, correct) versus `VLmEpU417yLnZEMWf` (nameless orphan under another powerup).
+
+Both Rems report `childCount: 2`. Nothing is missing from the damaged Rem, and its property Rem is not malformed. **The only defect is the target of the reference.**
+
+Two conclusions follow:
+
+1. **The current write path is healthy.** `setPowerupProperty` resolves the registered slot correctly today. The defect is confined to references written before or rewritten during the migration; it is not being reproduced on new writes.
+2. **The orphaned slot Rems in §4 are not, by themselves, sufficient to cause the fault.** They were present in the definitions when this Rem was created, and it was written correctly anyway. The orphans and the mis-pointed reference are related but distinct findings.
+
+---
+
+### 3.6 Population, and a confirmed repair
+
+Every pre-overhaul Incremental Rem examined shows the same defect, and every one of them points at the **same** orphan slot `VLmEpU417yLnZEMWf`:
+
+| Rem | Property Rem | Stored value | API read | Last priority in history |
+|---|---|---|---|---|
+| `I4pm1fkBWzvgCdI5n` | `vAwvSXgSc3pUNGTxO` | `17` | empty | 17 |
+| `kPXiWgXG9wzR3oSJZ` | `HAphrUvpVO1Q3PP1r` | `12` | empty | 12 |
+| `zO8KahzIJYeAEbqjj` | `j6shjpLjE3O4PDNQ0` | `20` | empty | 20 |
+| `IDWpFTp6pC8mkoqro` (post-overhaul) | `6LkzHevmU1TUN8lZJ` | `26` | `26` ✓ | 26 |
+
+In all three damaged cases the stored value agrees with the last priority recorded in the Rem's own history, which independently corroborates that these are the correct values and that nothing rewrote them.
+
+**Rewriting the property repairs the Rem.** Writing a new priority through the normal `setPowerupProperty` path was tested on two Rems, with dumps taken immediately before and after:
+
+```
+BEFORE  childCount: 2
+  j6shjpLjE3O4PDNQ0  "20"  [Untitled] -> VLmEpU417yLnZEMWf   apiValue null   DETACHED
+
+AFTER (priority set to 21)   childCount: 3
+  Zme22i7Jrns88LQkA  "21"  [Priority] -> 76Pb95h0XktNfDO7Y   apiValue "21"   OK
+  j6shjpLjE3O4PDNQ0  "20"  [Untitled] -> VLmEpU417yLnZEMWf   apiValue null   DETACHED
+```
+
+The write creates a **new**, correctly-referenced property Rem rather than repairing or replacing the mis-pointed one, which is then **left behind**. The user sees it in the outliner as a stray `Unnamed — 20` row, and `childCount` grows permanently by one per repaired Rem.
+
+---
+
+## 4. Secondary finding — orphaned slot Rems on the powerup definitions
+
+The plugin declares each slot exactly once, in a single `registerPowerup` call per powerup, and has no code path that creates a second slot. The live powerup definitions nevertheless carry more slot children than were registered.
+
+### `Incremental` (`jhWSM9ZVkEx6uzLL4`) — 5 registered, **7 present**
+
+| Slot Rem id | Name | Matches a registered slot? |
+|---|---|---|
+| `76Pb95h0XktNfDO7Y` | `Priority` | yes |
+| `o9GwvFHCn3AH6MAFB` | `Next Rep Date` | yes |
+| `rY5dBJhTFnZVEkD90` | `History` | yes |
+| `eyPosVf8lYEfAr18t` | `Created` | yes |
+| `fAnEFqDe2zJwECi5N` | `Missing Name` | no |
+| `2q46PZilKAtrhRwGP` | `Missing Name` | no |
+| `YzfWfdh46cRFzlCOd` | `Missing Name` | no |
+
+`"Missing Name"` is the literal text stored in those Rems, not a placeholder introduced by our diagnostic — the diagnostic reports genuinely empty text as `""`.
+
+The fifth registered slot, `Reading State` (code `pdfState`), does **not** appear under its registered name and could not be resolved by name. It is hidden, and it was registered on 2026-08-06 — i.e. after the overhaul — so its absence as a named Rem is consistent with the new model described in §6, where hidden slots are not represented as Rems. On that reading it accounts for none of the three `Missing Name` entries.
+
+Even allowing generously that one of the three is `Reading State`, **at least two slot Rems under `Incremental` correspond to nothing this plugin has ever registered.** We verified against the full git history of `register/powerups.tsx` that the Incremental powerup has only ever declared these five slot codes — `priority`, `nextRepDate`, `repHist`, `originalIncDate`, `pdfState` — so these are not the residue of slots we registered and later removed.
+
+### `CardPriority` (`PAbc0mEVTzOTk5118`) — 3 registered, **4 present**
+
+All three registered slots are present and correctly named. The extra one is `VLmEpU417yLnZEMWf`, with empty text — the same Rem the damaged `Incremental` property in §3 points at.
+
+### `Dismissed` (`kllsK59tpaXG19XFI`) — 2 registered, 2 present, both correct
+
+Undamaged, and included as a control.
+
+---
+
+## 5. Third finding — dangling Daily Document references on `Next Rep Date`
+
+A separate and independent fault appears on the same class of Rems. `Next Rep Date` stores its value as a **reference to a Daily Document**. On one of the three pre-overhaul Rems that reference no longer resolves:
+
+| Rem | Scheduled for | Reference target | Resolves? |
+|---|---|---|---|
+| `zO8KahzIJYeAEbqjj` | 2026-07-08 (interval 1) | `AN9vCK2NGI8P23AZO` | yes — daily doc, `Date` = `2026-07-08` |
+| `I4pm1fkBWzvgCdI5n` | 2026-07-08 (interval 1) | resolves | yes |
+| `kPXiWgXG9wzR3oSJZ` | 2026-08-06 (interval 30) | `oaxQNwxWzYTrzRI3o` | **no — target not found** |
+
+Here the property Rem and its slot link are both **healthy** — it correctly references the registered `Next Rep Date` slot `o9GwvFHCn3AH6MAFB`. The failure is in the value: the Daily Document it points at cannot be resolved, so `getPowerupProperty` returns empty and RemNote's own property row renders as `Loading` indefinitely.
+
+This is materially different from §3. There the value survives on the Rem and can be recovered; here the referenced Rem is simply gone, and the scheduled date is unrecoverable from the property itself. (Our plugin survives it only because it independently stamps the next-repetition timestamp into its own history slot and falls back to that.)
+
+The correlation across the sample is suggestive but not conclusive at n=1 for the failing case: the two references that resolve point at a daily document **one day** ahead of when they were written, while the one that fails pointed **30 days** ahead, to a date that was still in the future at the time. A plausible mechanism is that empty, programmatically-created future daily documents did not survive the migration, orphaning every reference to them. If that is what happened, the scope would be considerably wider than §3, since it would affect any Rem scheduled far enough ahead — for this plugin, that is a large fraction of a mature knowledge base.
+
+We would rather RemNote confirm or rule this out than guess at it.
+
+---
+
+## 6. Fourth finding — `getPowerupSlotByCode` behaviour and error text
+
+`getPowerupSlotByCode` now rejects for a subset of slots with:
+
+> `Plugin Error: Internal API Error: Error: getPowerupSlotByCode only supports visible plugin powerup slots: built-in and hidden slots are not represented as Rem. Use getPowerupProperty or getPowerupPropertyAsRichText to read slot values instead.`
+
+Measured behaviour matches the visible/hidden split precisely, against the plugin's own `hidden: true` registration flags:
+
+| Powerup | Slot | Registered `hidden` | `getPowerupSlotByCode` |
+|---|---|---|---|
+| Incremental | `priority` (Priority) | — | resolves `76Pb95h0XktNfDO7Y` |
+| Incremental | `nextRepDate` (Next Rep Date) | — | resolves `o9GwvFHCn3AH6MAFB` |
+| Incremental | `repHist` (History) | `true` | throws |
+| Incremental | `originalIncDate` (Created) | `true` | throws |
+| Incremental | `pdfState` (Reading State) | `true` | throws |
+| CardPriority | `priority` (Priority) | — | resolves `6eUpUKWrfZdU4nrgc` |
+| CardPriority | `prioritySource` | `true` | throws |
+| CardPriority | `lastUpdated` | `true` | throws |
+| Dismissed | `dismissedHistory`, `dismissedDate` | `true` | throws |
+
+**The message's premise does not match the current data, though the discrepancy may be transitional.** It states that hidden slots "are not represented as Rem". Walking the powerup Rem's children and filtering on `isPowerupSlot()` nevertheless returns every one of them, with correct names and ids —
+
+- `repHist` → `rY5dBJhTFnZVEkD90` (`History`)
+- `originalIncDate` → `eyPosVf8lYEfAr18t` (`Created`)
+- `cardPriority:prioritySource` → `hgwNbXh4gypyUH5uR` (`Priority Source`)
+- `cardPriority:lastUpdated` → `we4WQ5lsyor2D1j08` (`Last Updated`)
+- `dismissed:*` → `vPe7uIq5I5BG1GCv7`, `vji3juTs0R47PS8DA`
+
+Only this accessor declines to return them.
+
+A consistent explanation is that these are **legacy artifacts**: hidden slots registered *before* the overhaul still have their Rems, while hidden slots registered *after* it no longer materialise one. Our `Reading State` slot (§4), registered 2026-08-06, has no Rem under any name — exactly what the new model predicts, and in contrast to `History` and `Created`, which predate the change and still do.
+
+If that is right, the message describes the intended end state while the transitional reality differs, and plugin authors reading it would wrongly conclude these Rems are already gone. Confirmation either way would be useful: whether the surviving hidden-slot Rems are scheduled for cleanup, and whether resolving them via the children walk is a supported path in the meantime or one that will stop working.
+
+---
+
+## 7. Why only the `Priority` property was affected
+
+The dump shows a structural asymmetry between visible and hidden slots that explains the blast radius.
+
+For the diagnostic Rem, `childCount` is **2** — it has exactly two property child Rems, for the two **visible** slots (`Priority`, `Next Rep Date`). The **hidden** slots (`History`, `Created`) read back correctly through `getPowerupProperty` while having **no property child Rem at all**:
+
+| Slot | Visibility | Property child Rem | API read |
+|---|---|---|---|
+| `priority` | visible | `vAwvSXgSc3pUNGTxO` | **empty (broken)** |
+| `nextRepDate` | visible | `RtpNKSweZbmiP4bsS` | OK |
+| `repHist` | hidden | none | OK |
+| `originalIncDate` | hidden | none | OK |
+| `pdfState` | hidden | none | empty (never set) |
+
+Hidden-slot values migrated off the Rem entirely and are unaffected. Visible-slot values still live in a property child Rem whose reference must resolve to the right slot definition — and it is precisely one of those references that was re-pointed.
+
+The control Rem in §3.5 shows the identical layout (`childCount: 2`, no property Rem for the hidden slots), confirming this is the normal post-overhaul structure rather than a symptom. Only visible slots carry a reference that can be mis-pointed, which bounds the exposure to `Priority` and `Next Rep Date`.
+
+---
+
+## 8. Ruled out on the plugin side
+
+- **No write path can produce this.** The plugin writes the Priority slot at exactly three call sites, each with an explicit value, all via `setPowerupProperty(powerupCode, prioritySlotCode, …)`. None can emit an incorrect value, and none can alter a property Rem's slot reference.
+- **The plugin never creates duplicate or nameless slot Rems.** Slots are declared once per powerup in `registerPowerup`.
+- **The displayed `10` was our own read fallback**, not stored data — confirmed by `apiValue: null` against `rawValue: "17"`. It was never written back to the slot. (We have since replaced that silent fallback with an explicit provenance flag, and now recover the value from the Rem's history when the slot is unreadable, so affected users see the correct number again. This is a workaround for the symptom; the underlying reference is still mis-pointed and we have not written to it.)
+
+---
+
+## 9. Impact
+
+- Priority is the plugin's core scheduling input. An unreadable slot silently substitutes a default, which changes queue ordering and review weighting for every affected Rem.
+- The value presented to the user is wrong while the correct value remains on the Rem, so the fault is not visible as data loss and is easy to mistake for a plugin defect.
+- The reporting user observes this across Rems created before the overhaul; Rems created after it are unaffected. The evidence in this report is a full trace of one representative Rem.
+- Any plugin reading a **visible** powerup slot on pre-overhaul Rems is potentially exposed to the same failure, not only this one.
+
+---
+
+## 10. Reproducing the diagnostic
+
+The dump is produced read-only by the plugin's own tooling (`src/lib/raw_slot_dump.ts`), which bypasses `getPowerupProperty` and reads the property Rems directly:
+
+1. Focus an affected Rem.
+2. Run the command **"Debug: Dump Raw Powerup Slots (console)"**, or use **Dump Raw Slots** in the plugin's debug widget.
+3. It emits JSON containing, per property Rem: the value from `backText`, the slot definition its `text` references (id and name), whether that id matches the registered slot, and the corresponding `getPowerupProperty` result.
+
+Full JSON dumps for Rem `I4pm1fkBWzvgCdI5n` are attached.
+
+---
+
+## 11. Questions for RemNote
+
+1. Can the storage/sync migration re-point a powerup property's slot reference to a slot Rem belonging to a **different** powerup? The two powerups here share the display name "Priority", which would be consistent with name-keyed matching during migration.
+2. What are the nameless / `Missing Name` slot Rems now attached to these powerup definitions, and is it safe for a plugin to delete them?
+3. Rewriting the priority repairs the read but leaves the mis-pointed property Rem behind (§3.6). Is it safe for the plugin to delete those orphaned property Rems outright as part of a repair pass, or is there a supported way to re-point an existing property Rem at the correct slot definition so no debris is created?
+
+4. Are the dangling Daily Document references in §5 a known consequence of the migration, and specifically were empty future-dated daily documents pruned? This determines whether affected users have lost scheduled dates at scale or only in isolated cases.
+5. Is the `getPowerupSlotByCode` restriction to visible slots intended to be permanent? If so, the message's claim that hidden slots "are not represented as Rem" should be corrected, since they remain reachable and resolvable via the powerup's children.
+6. Is a corrective migration planned on RemNote's side? If so we will hold off on any repair pass of our own to avoid conflicting writes.
+
+---
+
+## Appendix — identifier reference
+
+| Id | What it is |
+|---|---|
+| `I4pm1fkBWzvgCdI5n` | Diagnostic user Rem (pre-overhaul) |
+| `vAwvSXgSc3pUNGTxO` | Its `Priority` property Rem — `backText` = `17`, reference broken |
+| `RtpNKSweZbmiP4bsS` | Its `Next Rep Date` property Rem — intact |
+| `IDWpFTp6pC8mkoqro` | Control Rem, created post-overhaul — fully healthy |
+| `6LkzHevmU1TUN8lZJ` | Its `Priority` property Rem — correctly references `76Pb95h0XktNfDO7Y` |
+| `kPXiWgXG9wzR3oSJZ` | Second affected Rem — `Priority` detached (`12`) **and** dangling date reference |
+| `oaxQNwxWzYTrzRI3o` | Its `Next Rep Date` target — **does not exist** (was 2026-08-06, 30 days ahead) |
+| `zO8KahzIJYeAEbqjj` | Third affected Rem — repair test subject (before/after dumps) |
+| `j6shjpLjE3O4PDNQ0` | Its original detached `Priority` property (`20`) — left behind after repair |
+| `Zme22i7Jrns88LQkA` | The new, correctly-referenced `Priority` property (`21`) created by the repair |
+| `AN9vCK2NGI8P23AZO` | Its `Next Rep Date` target — exists, daily doc `2026-07-08`, resolves fine |
+| `jhWSM9ZVkEx6uzLL4` | `Incremental` powerup definition (7 slot children, 5 registered) |
+| `76Pb95h0XktNfDO7Y` | Registered `Incremental` → `Priority` slot (**expected** target) |
+| `PAbc0mEVTzOTk5118` | `CardPriority` powerup definition (4 slot children, 3 registered) |
+| `VLmEpU417yLnZEMWf` | Nameless orphan slot under `CardPriority` (**actual** target) |
+| `fAnEFqDe2zJwECi5N`, `2q46PZilKAtrhRwGP`, `YzfWfdh46cRFzlCOd` | `Missing Name` orphan slots under `Incremental` |
+| `kllsK59tpaXG19XFI` | `Dismissed` powerup definition — undamaged control |

--- a/REMNOTE_SUPPORT_REPORT_priority_slot_detachment.md
+++ b/REMNOTE_SUPPORT_REPORT_priority_slot_detachment.md
@@ -4,7 +4,67 @@
 **SDK:** `@remnote/plugin-sdk` ^0.0.46
 **RemNote build:** _(to be filled in — desktop build on which the dump below was taken)_
 **Date of evidence:** 2026-08-06
-**Severity:** Widespread. A full scan of this knowledge base finds **99.2% of Incremental Rems (5,390 / 5,434)** with a detached priority slot, **6.7% of CardPriority Rems (3,001 / 45,078)**, and **59.8% of scheduled dates (1,893 / 3,163)** pointing at Daily Documents that no longer exist. Values are recoverable in every category; none are silently correct.
+**Status:** Priority detachment **fixed in 1.27.24** and fully remediated on 2026-08-07; missing Daily Documents **outstanding**. See §0, and the follow-up `REMNOTE_SUPPORT_FOLLOWUP_1.27.24.md`.
+**Severity (as originally reported):** Widespread. A full scan of this knowledge base finds **99.2% of Incremental Rems (5,390 / 5,434)** with a detached priority slot, **6.7% of CardPriority Rems (3,001 / 45,078)**, and **59.8% of scheduled dates (1,893 / 3,163)** pointing at Daily Documents that no longer exist. Values are recoverable in every category; none are silently correct.
+
+---
+
+## 0. STATUS AFTER RemNote 1.27.24 — partially fixed
+
+Re-scanned on 2026-08-07 against the same knowledge base.
+
+| Defect | Before | After 1.27.24 | After remediation | Status |
+|---|---|---|---|---|
+| §3 Detached `Incremental` priority | 5,390 / 5,434 (99.2%) | 1 | **0** | ✅ resolved |
+| §3 Detached `CardPriority` priority | 3,001 / 45,078 (6.7%) | 1 | **0** | ✅ resolved |
+| §5 `Next Rep Date` slot reference | ~2,231 unresolvable | **0** | 0 | ✅ fixed by 1.27.24 |
+| CardPriority values unreadable (`missing`) | — | 376 | **0** | ✅ resolved by us |
+| Orphaned property Rems (litter) | — | 370 | **0** | ✅ deleted by us |
+| §5 Missing Daily Documents | 1,893 dangling | 2,033 dangling | **2,033 dangling** | ❌ **outstanding** |
+| §4 Orphan slot Rems on the definitions | 4 | 4 | **4** | ❌ not cleaned (inert) |
+| §6 Error message wording | — | corrected | corrected | ✅ fixed |
+
+**What the fix did:** it re-pointed the property→slot references, and it did so for `Next Rep Date` as well as for priority. The date figure needs care: before the fix only 3,163 Incremental Rems had a *findable* Next Rep Date property, because ~2,231 of them referenced something other than the registered slot and were invisible to the scan. All 5,394 are now correctly linked. So the reference-level defect is resolved across the board.
+
+**What remains:** the Daily Documents those date properties point at are still gone. **2,033 of 5,394 (37.7%)** reference a Rem that does not exist. This is now the only substantive defect, and it is unaffected by the fix because it is not a reference problem — the target was deleted.
+
+**Two residual cases, and they identify the mechanism precisely.** Both are Rems carrying **both** powerups, and on each one the two same-named `Priority` properties have been **collapsed into a single property**. The survivor is correctly linked to one powerup; the other powerup has no priority property at all:
+
+| Rem | Surviving property links to | Reads correctly | Has no property |
+|---|---|---|---|
+| `gJiSum4KOK8YRaCmU` | `6eUpUKWrfZdU4nrgc` (CardPriority) | CardPriority = 10 | **Incremental** → falls back to 50 |
+| `741rSQQHCazbKrttP` | `76Pb95h0XktNfDO7Y` (Incremental) | Incremental = 10 | **CardPriority** → resolves as inherited |
+
+Confirmed in the UI: `gJiSum4KOK8YRaCmU` shows Flashcard Priority **10** with `Source: incremental` while Incremental Rem shows **50** — the plugin's fallback, not a stored value; the outliner shows a single `# 10` row. `741rSQQHCazbKrttP` is the mirror image: Incremental **10**, Flashcard Priority **10** with `Source: inherited`.
+
+In both cases the two priorities were **numerically identical** before the merge — necessarily so for `gJiSum4KOK8YRaCmU`, whose card priority was derived from its incremental priority (`Source: incremental`). That points at a de-duplication step that collapsed two properties judged equivalent by name *and* value, on Rems where both powerups were present.
+
+This is the clearest confirmation of the mechanism proposed in §3.2: slots were matched by the display name "Priority" across powerup boundaries. The 1.27.24 migration repaired every property pointing at an *orphan* slot, but a collapsed pair looks entirely healthy from the surviving powerup's side, so nothing flags it.
+
+Only 2 remain (down from 250 Rems carrying both powerups with a detached property before the fix), and the practical damage is small — one Rem is showing 50 where 10 is correct — but the same de-duplication would silently destroy one of two *differing* priorities wherever the values were not equal.
+
+The four orphan slot Rems in §4 are still attached to the powerup definitions.
+
+The `getPowerupSlotByCode` message has been amended to "…although legacy slot Rem may still exist", which resolves the inaccuracy raised in §6.
+
+### Remediation completed 2026-08-07
+
+A further defect surfaced after the fix and is documented in the follow-up: **376 property Rems referencing slot Rem `JF0lnO7kCGbDrHRrt`, which does not exist.** Because that slot is not a child of either powerup definition, these did not register as "detached" — they were reported as `missing`, indistinguishable from a Rem that never had a priority. 21 of them carried `prioritySource: manual`.
+
+All of it is now resolved on this knowledge base:
+
+- 21 manual values recovered from their mis-pointed property Rems (verified read-back, 21/21);
+- 354 inherited values re-materialised via the plugin's own inheritance command (`missing` 376 → **0**);
+- 370 orphaned property Rems deleted in stages, each individually guarded — **370 deleted, 0 values disturbed**.
+
+```
+Incremental    5,434 total · detached 0 · missing 40
+CardPriority  45,078 total · detached 0 · missing 0
+Leftover priority properties: 0
+Next Rep Date: 2,033 dangling   ← the only outstanding data issue
+```
+
+Full detail, and the questions still open for RemNote, are in **`REMNOTE_SUPPORT_FOLLOWUP_1.27.24.md`**.
 
 ---
 

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -2,6 +2,25 @@
 
 This page documents the major changes and improvements for each version of the Incremental Everything (Plus) plugin.
 
+## v1.0.35 - August 7th, 2026
+
+### 🐛 Fixed: priorities showing the wrong number after a RemNote update
+
+RemNote's storage/sync overhaul re-pointed some powerup properties at the wrong slot definition — unnamed ones, the *other* priority powerup's, or ones that had since been deleted. **No value was ever lost**: it stayed on the Rem, in a property the plugin could no longer reach. What you saw instead was the fallback. Because both priority powerups use a slot displayed as "Priority", they got crossed with each other.
+
+RemNote fixed the bulk of it in **1.27.24**. This release deals with what survived that fix, and with the reporting that hid it:
+
+- **Incremental priorities are recovered from the Rem's own history** when the slot cannot be read, instead of silently substituting a default. The displayed number now also says where it came from, so a recovered or placeholder value can never pass for a stored one.
+- **A repair for Card Priority**, which has no history to fall back on and so was the only case genuinely showing wrong values. It reads the value off the unreachable property and rewrites it through the normal path, keeping the original source and timestamp.
+- **Diagnostics to check your own knowledge base** — a raw dump for one Rem and a whole-KB scan — plus a guarded cleanup for the stray `Unnamed — 42` rows the repair leaves behind.
+
+> [!NOTE]
+> **If your priorities look wrong after a RemNote update, please get in touch.** The tools above will tell you whether your knowledge base is affected and by how much, and they write nothing. Reports are especially valuable if the damage appears on a RemNote version **after 1.27.24**, or looks different in shape from what is documented — that would point at a path not yet seen. Open an issue on the [plugin's issue tracker](https://github.com/bjsi/incremental-everything/issues) with the scan output.
+
+One related fault is still outstanding on RemNote's side: some **Next Rep Date** properties reference a Daily Document that no longer exists, so RemNote's date row shows `Loading` indefinitely. Scheduling is unaffected — the plugin keeps its own copy of the next-repetition date and reads that — but the date chip cannot be edited by hand until it is rebuilt.
+
+📖 See [Priorities Wrong or Empty After a RemNote Update](Troubleshooting.md#priorities-wrong-or-empty-after-a-remnote-update) for how to check your own knowledge base and what the repair does.
+
 ## v1.0.34 - August 5th, 2026
 
 ### 🐛 Fixed: a PDF could open the wrong chapter

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -647,3 +647,52 @@ There is also a **Diagnose Read Path** button in the debug widget's Card Priorit
 - **Reapply in bulk instead.** Note the priorities before transferring (a [Priority Review Document](Priority-Review-Document.md) is a convenient snapshot) and use **[Batch Assign Card Priority](Priorities-for-Flashcards.md#assigning-priorities-in-bulk)** in the target knowledge base afterwards.
 - **Incremental Rem data is safe** to move as-is.
 - If you hit this, it is worth reporting to RemNote: the same export file succeeding in one knowledge base and failing in another, with the plugin disabled, is a precise reproduction.
+
+---
+
+## 🔧 Priorities Wrong or Empty After a RemNote Update
+
+**Symptom:** after a RemNote update, priorities you never touched show the wrong number — often the same number everywhere — or the priority row reads **Empty** while a stray `Unnamed — 42` line sits under the Rem.
+
+### What Happened
+
+Every powerup property is a small child Rem that points at its slot definition. RemNote's storage/sync overhaul re-pointed some of those references at slot definitions that were unnamed, belonged to the *other* powerup, or had been deleted outright. **The values were never lost** — they stayed on the Rem, in a property the plugin could no longer reach. What you saw instead was whatever the plugin falls back to.
+
+Both priority powerups use a slot displayed as "Priority", which is why they got crossed.
+
+RemNote fixed the bulk of this in **1.27.24**. Two kinds of residue could survive that fix:
+
+- properties pointing at a slot definition that had since been **deleted** — these read as though no priority was ever set;
+- on Rems carrying *both* Incremental and Card Priority, the two "Priority" properties **collapsed into one**, leaving the other powerup with nothing.
+
+### How To Check Your Own Knowledge Base
+
+The debug widget's **Raw Slot Diagnostics** section (at the bottom) has two read-only tools:
+
+- **Dump Raw Slots** — for the focused Rem and its descendants, reads the value stored on each property directly, bypassing the normal lookup, and shows it next to what the plugin actually reads. A value present in one column and empty in the other is the signature.
+- **Scan Whole KB** — counts how many Rems are affected across both priority powerups, and separately checks whether each `Next Rep Date` still points at a Daily Document that exists.
+
+Both are safe to run at any time and write nothing.
+
+### How It Was Fixed Here
+
+On the knowledge base where this was diagnosed, the sequence was:
+
+1. **Recover deliberate values.** The CardPriority repair reads the value off the unreachable property and rewrites it through the normal path, preserving the original source and timestamp. It skips inherited values, which are derived rather than authored.
+2. **Re-materialise inherited values** with **Update all inherited Card Priorities**, which recomputes them from the ancestor cascade and leaves manual priorities alone.
+3. **Delete the abandoned properties** — the stray `Unnamed — N` rows — once, and only once, the value is confirmed readable in its correct place. Each deletion is individually refused if the Rem's priority is not already restored.
+
+Incremental Rem priorities needed none of this: the plugin recovers them from the Rem's own repetition history, so they kept showing the right number throughout.
+
+### Still Outstanding
+
+A separate fault affects **Next Rep Date**: the property is healthy, but the Daily Document it references no longer exists, so RemNote's date row shows `Loading` forever. Scheduling is unaffected — the plugin stamps the next-repetition date into its own history and reads that instead — but the date chip cannot be edited by hand until it is rebuilt.
+
+### If You See This In Your Knowledge Base
+
+Please get in touch, via the [plugin's issue tracker](https://github.com/bjsi/incremental-everything/issues), with the JSON that **Scan Whole KB** produces. Two things make a report especially useful:
+
+- **it happened on a RemNote version after 1.27.24** — that would mean a path we have not seen;
+- **the numbers differ in shape from the ones above** — a different slot id, or a Rem where a *manual* priority disagrees with what is displayed.
+
+The diagnostic tools were built for exactly this, and the more knowledge bases they are run against, the more precisely the remaining cases can be described to RemNote.

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -10,7 +10,7 @@
   "version": {
     "major": 1,
     "minor": 0,
-    "patch": 34
+    "patch": 35
   },
   "unlisted": false,
   "theme": [],

--- a/src/lib/incremental_rem/index.ts
+++ b/src/lib/incremental_rem/index.ts
@@ -21,7 +21,7 @@ import {
 } from '../consts';
 import { readRawPdfState, writeRawPdfState } from '../pdf_state';
 import { getNextSpacingDateForRem, updateSRSDataForRem } from '../scheduler';
-import { IncrementalRem, IncrementalRep } from './types';
+import { IncrementalRem, IncrementalRep, UNREADABLE_PRIORITY_FALLBACK } from './types';
 import { tryParseJson, getDailyDocReferenceForDate, sleep } from '../utils';
 import { getInitialPriority } from '../priority_inheritance';
 import { stampNoteAndContext } from '../history_notes';
@@ -322,8 +322,27 @@ export const getIncrementalRemFromRem = async (
 
   const resolvedNextRepDate = await resolveDailyDocSlot(nextRepDateSlotCode);
 
+  // Read the original incremental date slot (Daily Document reference)
+  let createdAt = await resolveDailyDocSlot(originalIncrementalDateSlotCode);
+
+  const history = tryParseJson(await r.getPowerupProperty(powerupCode, repHistorySlotCode));
+
+  // Priority resolution. The slot is authoritative, but it is not always
+  // readable: RemNote's storage/sync overhaul left some Rems with a Priority
+  // property whose slot definition no longer resolves, so getPowerupProperty
+  // returns nothing while the value is still sitting on the Rem.
+  //
+  // This used to fall straight through to a bare `let priority = 10`, which was
+  // indistinguishable from a genuinely stored 10 — a Rem whose history proved a
+  // priority of 17 displayed as P10 with nothing to say it was a guess. Worse,
+  // that fabricated number was then stamped into the next history entry
+  // (see scheduler.ts), turning a display glitch into permanent data.
+  //
+  // So: read the slot; failing that, recover the last priority the Rem itself
+  // recorded in its history; and only if there is nothing to go on at all fall
+  // back to a constant — flagged, never silent.
   const priorityRichText = await r.getPowerupPropertyAsRichText(powerupCode, prioritySlotCode);
-  let priority = 10;
+  let priority: number | undefined;
   if (priorityRichText && priorityRichText.length > 0) {
     const priorityString = await plugin.richText.toString(priorityRichText);
     const parsedPriority = parseInt(priorityString, 10);
@@ -332,10 +351,23 @@ export const getIncrementalRemFromRem = async (
     }
   }
 
-  // Read the original incremental date slot (Daily Document reference)
-  let createdAt = await resolveDailyDocSlot(originalIncrementalDateSlotCode);
-
-  const history = tryParseJson(await r.getPowerupProperty(powerupCode, repHistorySlotCode));
+  let prioritySource: IncrementalRem['prioritySource'] = 'slot';
+  if (priority === undefined && Array.isArray(history)) {
+    // Walk backwards to the most recent rep that recorded a priority.
+    for (let i = history.length - 1; i >= 0; i--) {
+      const recorded = history[i]?.priority;
+      if (typeof recorded === 'number' && !isNaN(recorded)) {
+        priority = recorded;
+        prioritySource = 'history';
+        break;
+      }
+    }
+  }
+  if (priority === undefined) {
+    priority = UNREADABLE_PRIORITY_FALLBACK;
+    prioritySource = 'fallback';
+  }
+  priority = Math.min(100, Math.max(0, priority));
 
   // Fallback: derive createdAt from the 'madeIncremental' history marker when the
   // originalIncDate slot is empty/unresolvable. This repairs rems whose Daily Doc
@@ -378,6 +410,7 @@ export const getIncrementalRemFromRem = async (
     remId: r._id,
     nextRepDate,
     priority: priority,
+    prioritySource,
     history,
     createdAt,
   };

--- a/src/lib/incremental_rem/types.ts
+++ b/src/lib/incremental_rem/types.ts
@@ -193,10 +193,39 @@ export function repCountsForScheduling(eventType: IncrementalRep['eventType']): 
   );
 }
 
+/**
+ * Priority used when a Rem's Priority slot cannot be read AND its history holds
+ * no recorded priority either — i.e. when nothing is actually known about it.
+ *
+ * This is deliberately a named constant rather than a literal inside the read
+ * path. It used to be a bare `let priority = 10` in `getIncrementalRemFromRem`,
+ * which made a fabricated value indistinguishable from a stored one: after
+ * RemNote's storage/sync overhaul detached some Priority slots, Rems whose real
+ * priority was still on them displayed as P10 with nothing marking it a guess.
+ * Anything reaching for this value must also honour `prioritySource`.
+ */
+export const UNREADABLE_PRIORITY_FALLBACK = 50;
+
+/**
+ * Where a resolved `priority` actually came from.
+ *
+ * - `slot`     — read from the Priority powerup slot. Trustworthy.
+ * - `history`  — the slot was unreadable; this is the last priority the Rem
+ *                recorded in its own repetition history. Trustworthy as a value,
+ *                but the slot needs repairing.
+ * - `fallback` — nothing was readable. The number is
+ *                {@link UNREADABLE_PRIORITY_FALLBACK} and means nothing; it must
+ *                not be written back or stamped into history.
+ */
+export const PrioritySource = z.enum(['slot', 'history', 'fallback']);
+export type PrioritySource = z.infer<typeof PrioritySource>;
+
 export const IncrementalRem = z.object({
   remId: z.string(),
   nextRepDate: z.number(),
   priority: z.number().min(0).max(100),
+  /** Provenance of `priority`. Absent on cached objects written before this existed. */
+  prioritySource: PrioritySource.optional(),
   history: z.array(IncrementalRep).optional(),
   /**
    * Timestamp (ms) when the Rem was first made Incremental.

--- a/src/lib/powerup_slot_compat.ts
+++ b/src/lib/powerup_slot_compat.ts
@@ -2,11 +2,34 @@
 //
 // Compatibility shim for `plugin.powerup.getPowerupSlotByCode`.
 //
-// Recent RemNote desktop builds (post storage/sync overhaul) deprecated the
-// runtime implementation of `getPowerupSlotByCode`: every call now rejects with
-//   "Plugin Error: Internal API Error: Error: getPowerupSlotByCode is deprecated"
-// even though the method is still declared in @remnote/plugin-sdk@0.0.46 and in
-// the public API docs. The sibling `getPowerupByCode` still works.
+// Recent RemNote desktop builds (post storage/sync overhaul) narrowed the
+// runtime implementation of `getPowerupSlotByCode`, even though the method is
+// still declared in @remnote/plugin-sdk@0.0.46 and in the public API docs. The
+// sibling `getPowerupByCode` still works.
+//
+// The failure is NOT blanket deprecation, as an earlier reading of this had it.
+// A raw-slot dump (lib/raw_slot_dump.ts) captured the actual rejection:
+//
+//   "getPowerupSlotByCode only supports visible plugin powerup slots: built-in
+//    and hidden slots are not represented as Rem. Use getPowerupProperty or
+//    getPowerupPropertyAsRichText to read slot values instead."
+//
+// So it is selective, and the split is visible-vs-hidden:
+//
+//   VISIBLE slots (Priority, Next Rep Date)   -> still resolve natively.
+//   HIDDEN  slots (History, Created, pdfState,
+//                  Priority Source, Last Updated,
+//                  the Dismissed slots)        -> throw the above.
+//
+// Note the error's premise is wrong in one respect, which is worth keeping in
+// mind: hidden slots ARE still present as Rems — the fallback below finds them
+// by walking the powerup's children and checking `isPowerupSlot()`, and it
+// resolves every one of them. Only this accessor refuses to return them.
+//
+// The practical consequence is that hidden-slot VALUES no longer live in a child
+// Rem of the tagged rem (a rem with History and Created set can have zero
+// property children), while visible-slot values still do. Anything reasoning
+// about property children must not assume the two behave alike.
 //
 // This helper is a drop-in replacement that:
 //   1. Tries the native method first (so it self-heals if RemNote restores it,

--- a/src/lib/raw_slot_dump.ts
+++ b/src/lib/raw_slot_dump.ts
@@ -1,0 +1,610 @@
+// RAW powerup-slot dump — evidence collector for RemNote support.
+//
+// WHY THIS EXISTS
+// ---------------
+// After RemNote's storage/sync overhaul, IncRems created before the change began
+// reporting the wrong priority: the plugin shows 10 while the rem's own repetition
+// history proves the last written value was something else (17 in the reported
+// case), and the RemNote outliner renders the value under an *Unnamed* slot row.
+//
+// Every number the plugin displays for priority comes from
+// getIncrementalRemFromRem, which reads the Priority slot and falls back to
+// `let priority = 10` when the read comes back empty (lib/incremental_rem/index.ts).
+// So a display of 10 is ambiguous on its own — it means either "10 is stored" or
+// "nothing could be read". Same ambiguity the powerup READ-PATH diagnostic already
+// documents for imported rems (see powerup_read_diagnostic.ts).
+//
+// The debug widget's "Priority" row shows that same post-fallback number, so it
+// CANNOT settle the question either. This dump answers it, by ignoring
+// getPowerupProperty entirely and reading the property rems directly:
+//
+//   * every child rem of the target that is a powerup property, with its text
+//     verbatim — that text IS the stored value, fallbacks cannot reach it;
+//   * which slot-definition rem each property is tagged with, by id AND name;
+//   * whether that slot definition is the one getPowerupByCode() resolves to.
+//
+// A property holding "17" whose slot definition is unnamed and/or is not the
+// registered Priority slot is exactly the "value is intact, the plugin can no
+// longer reach it" case, stated in terms RemNote support can verify against their
+// own storage.
+//
+// READ-ONLY. Every call is a getter; nothing here writes.
+
+import { RNPlugin, PluginRem, BuiltInPowerupCodes } from '@remnote/plugin-sdk';
+import {
+  powerupCode,
+  prioritySlotCode,
+  nextRepDateSlotCode,
+  repHistorySlotCode,
+  originalIncrementalDateSlotCode,
+  pdfStateSlotCode,
+  dismissedPowerupCode,
+  dismissedHistorySlotCode,
+  dismissedDateSlotCode,
+} from './consts';
+import {
+  CARD_PRIORITY_CODE,
+  PRIORITY_SLOT,
+  SOURCE_SLOT,
+  LAST_UPDATED_SLOT,
+} from './card_priority/types';
+import { safeRemTextToString } from './pdfUtils';
+import { getPowerupSlotByCodeSafe } from './powerup_slot_compat';
+import { resolveRemTextToString } from './richTextRemRefs';
+
+/** The powerups whose slots this dump covers, with the slot codes to probe. */
+const SPECS = [
+  {
+    code: powerupCode,
+    label: 'Incremental',
+    slots: [
+      prioritySlotCode,
+      nextRepDateSlotCode,
+      repHistorySlotCode,
+      originalIncrementalDateSlotCode,
+      pdfStateSlotCode,
+    ],
+  },
+  {
+    code: CARD_PRIORITY_CODE,
+    label: 'CardPriority',
+    slots: [PRIORITY_SLOT, SOURCE_SLOT, LAST_UPDATED_SLOT],
+  },
+  {
+    code: dismissedPowerupCode,
+    label: 'Dismissed',
+    slots: [dismissedHistorySlotCode, dismissedDateSlotCode],
+  },
+] as const;
+
+/** A slot definition rem belonging to a registered powerup. */
+interface RegisteredSlot {
+  slotCode: string;
+  /** Resolved via getPowerupSlotByCodeSafe — what the plugin actually uses. */
+  slotDefId: string | null;
+  slotDefName: string;
+  /** What the native (deprecated) getPowerupSlotByCode returned, for comparison. */
+  nativeSlotDefId: string | null;
+  nativeError: string | null;
+}
+
+interface RegisteredPowerup {
+  label: string;
+  code: string;
+  powerupRemId: string | null;
+  slots: RegisteredSlot[];
+  /** Every slot child found on the powerup rem, whether or not we asked for it. */
+  actualSlotChildren: Array<{ id: string; name: string }>;
+}
+
+/** One property rem hanging off the target — the raw stored value. */
+export interface RawPropertyRow {
+  /** Owning rem. */
+  remId: string;
+  remText: string;
+  depth: number;
+  /** The property rem itself. */
+  propertyRemId: string;
+  /** Its backText, verbatim — this is the stored value. */
+  rawValue: string;
+  rawValueLength: number;
+  /** Raw element count of the backText, before any rendering. 0 = genuinely nothing stored. */
+  rawElementCount: number;
+  /**
+   * Rem-reference ids inside the value. Date slots store a Daily Document
+   * reference, so a non-empty list here with an empty `rawValue` means the
+   * reference exists but its target could not be resolved — which is a very
+   * different fault from the value having been lost.
+   */
+  rawValueRefIds: string[];
+  /**
+   * What each of those references actually points at. A date slot's value is a
+   * Daily Document reference; if the target Rem no longer exists (or has lost its
+   * text / its Date property) the value is unreachable even though the property
+   * and its slot link are both healthy. That is a different fault from the
+   * detached-slot one and needs reporting as such.
+   */
+  refTargets: Array<{
+    id: string;
+    exists: boolean;
+    text: string | null;
+    isDailyDoc: boolean;
+    dailyDocDate: string | null;
+  }>;
+  /**
+   * How the property's `text` renders — i.e. the slot reference. A healthy one
+   * reads "[Priority]"; "[Untitled]" means the slot definition it points at has
+   * lost its name, which is exactly the detached case.
+   */
+  slotReferenceLabel: string;
+  isPowerupProperty: boolean;
+  isProperty: boolean;
+  /** Slot-definition rems this property is tagged with. */
+  slotDefIds: string[];
+  slotDefNames: string[];
+  /** Which registered powerup+slot this property resolves to, if any. */
+  matchedPowerup: string | null;
+  matchedSlotCode: string | null;
+  /** What getPowerupProperty returns for that slot — the plugin's actual read. */
+  apiValue: string | null;
+  /**
+   * DETACHED   — a value is stored but its slot definition is not the registered
+   *              one (or has no name), so the plugin cannot reach it.
+   * API_BLIND  — the slot definition matches, the property holds a value, yet
+   *              getPowerupProperty returns nothing. An SDK read bug.
+   * OK         — stored value and API read agree.
+   * EMPTY      — the property rem carries no value at all (zero elements).
+   * UNRESOLVED_REF
+   *            — the value IS present as a rem reference (e.g. a Daily Document
+   *              for a date slot) but the target could not be resolved. Not the
+   *              same as empty: something is stored, it just won't render.
+   * UNKNOWN    — not attributable to any powerup this dump covers.
+   */
+  verdict: 'OK' | 'DETACHED' | 'API_BLIND' | 'EMPTY' | 'UNRESOLVED_REF' | 'UNKNOWN';
+}
+
+/** Per-rem summary of what the plugin reads vs. what is stored. */
+export interface RawSlotRemRow {
+  remId: string;
+  remText: string;
+  depth: number;
+  powerups: string[];
+  /** Total children walked. If slots read via the API but no property rem is
+   *  listed for them, the value is not stored as a child rem at all. */
+  childCount: number;
+  /** Slot-by-slot: the API read next to the raw property value. */
+  slots: Array<{
+    powerup: string;
+    slotCode: string;
+    apiValue: string | null;
+    rawValue: string | null;
+    rawPropertyRemId: string | null;
+    slotDefLinked: boolean | null;
+    verdict: RawPropertyRow['verdict'];
+  }>;
+}
+
+export interface RawSlotDumpReport {
+  exportedAt: string;
+  rootRemId: string;
+  rootRemText: string;
+  scannedRems: number;
+  registered: RegisteredPowerup[];
+  rems: RawSlotRemRow[];
+  properties: RawPropertyRow[];
+  /** Rems where a value is physically stored but the plugin reads nothing. */
+  unreachable: RawPropertyRow[];
+}
+
+/** Rem-reference elements carried by a rich-text value, by id. */
+function refIdsIn(richText: unknown): string[] {
+  if (!Array.isArray(richText)) return [];
+  return (richText as any[])
+    .filter((el) => el != null && typeof el === 'object' && el.i === 'q' && el._id)
+    .map((el) => String(el._id));
+}
+
+/**
+ * Plain text of a rich-text field, with EMPTY reported as empty.
+ *
+ * Two traps this avoids, both of which would make the dump lie about whether a
+ * value is stored — the one question it exists to answer:
+ *
+ * 1. `safeRemTextToString` substitutes 'Untitled' for a null/empty field. Right
+ *    for display, wrong here: it erases "nothing is stored".
+ * 2. `plugin.richText.toString()` DROPS rem-reference elements (see
+ *    lib/richTextRemRefs.ts). Date slots store a Daily Document *reference*, so
+ *    a perfectly healthy `Next Rep Date` would come back as "" and be reported
+ *    as EMPTY. References are resolved via `resolveRemTextToString` instead.
+ */
+async function readRawText(plugin: RNPlugin, richText: unknown): Promise<string> {
+  if (richText == null || !Array.isArray(richText) || richText.length === 0) return '';
+  if (refIdsIn(richText).length > 0) {
+    try {
+      const resolved = await resolveRemTextToString(plugin, richText);
+      // resolveRemTextToString returns 'Untitled' only when genuinely empty, but
+      // it also returns it for a reference whose target has no text — so keep the
+      // reference ids alongside (reported separately) rather than collapsing here.
+      return resolved;
+    } catch {
+      /* fall through to the plain read */
+    }
+  }
+  try {
+    return (await plugin.richText.toString(richText as any)) ?? '';
+  } catch {
+    // Malformed rich text — report the shape rather than pretending it is empty.
+    return `(unreadable rich text, ${richText.length} element(s))`;
+  }
+}
+
+/** Resolve the registered powerup rems and their slot children, by id and name. */
+async function readRegisteredPowerups(plugin: RNPlugin): Promise<RegisteredPowerup[]> {
+  const out: RegisteredPowerup[] = [];
+
+  for (const spec of SPECS) {
+    const powerup = await plugin.powerup.getPowerupByCode(spec.code).catch(() => undefined);
+
+    // Walk the powerup's slot children once and match by name — the same tolerant
+    // matching getPowerupSlotByCodeSafe uses, since getPowerupSlotByCode itself is
+    // deprecated at runtime on affected builds (see powerup_slot_compat.ts).
+    const actualSlotChildren: Array<{ id: string; name: string }> = [];
+    if (powerup) {
+      const children = await powerup.getChildrenRem().catch(() => []);
+      for (const child of children || []) {
+        if (!(await child.isPowerupSlot().catch(() => false))) continue;
+        actualSlotChildren.push({
+          id: child._id,
+          name: await safeRemTextToString(plugin, child.text),
+        });
+      }
+    }
+
+    const slots: RegisteredSlot[] = [];
+    for (const slotCode of spec.slots) {
+      // getPowerupSlotByCode resolves VISIBLE slots only; hidden ones throw
+      // "only supports visible plugin powerup slots" (see powerup_slot_compat.ts).
+      // So a null here is NOT evidence the slot is missing — getPowerupSlotByCodeSafe
+      // is what the plugin actually uses, and its children-walk resolves hidden
+      // slots fine. Record both, plus the error text, so the split is visible.
+      let nativeSlotDefId: string | null = null;
+      let nativeError: string | null = null;
+      try {
+        const slot = await plugin.powerup.getPowerupSlotByCode(spec.code, slotCode);
+        nativeSlotDefId = slot?._id ?? null;
+      } catch (e) {
+        nativeError = String(e);
+      }
+
+      const resolved = await getPowerupSlotByCodeSafe(plugin, spec.code, slotCode);
+      slots.push({
+        slotCode,
+        slotDefId: resolved?._id ?? null,
+        slotDefName: resolved ? await safeRemTextToString(plugin, resolved.text) : '',
+        nativeSlotDefId,
+        nativeError,
+      });
+    }
+
+    out.push({
+      label: spec.label,
+      code: spec.code,
+      powerupRemId: powerup?._id ?? null,
+      slots,
+      actualSlotChildren,
+    });
+  }
+
+  return out;
+}
+
+/**
+ * Dumps the RAW stored value of every powerup property on `root` and its
+ * descendants, alongside what the plugin's own read path returns for the same
+ * slot. Read-only.
+ *
+ * @param maxRems Safety cap on how many rems are walked (large subtrees).
+ */
+export async function dumpRawPowerupSlots(
+  plugin: RNPlugin,
+  root: PluginRem,
+  maxRems = 2000
+): Promise<RawSlotDumpReport> {
+  const registered = await readRegisteredPowerups(plugin);
+
+  // slotDefId -> which powerup/slot it belongs to, for attributing a property rem.
+  const slotDefIndex = new Map<string, { powerup: string; slotCode: string }>();
+  for (const p of registered) {
+    for (const s of p.slots) {
+      if (s.slotDefId) slotDefIndex.set(s.slotDefId, { powerup: p.label, slotCode: s.slotCode });
+    }
+  }
+
+  const rootText = await safeRemTextToString(plugin, root.text);
+  const descendants = ((await root.getDescendants().catch(() => [])) || []) as PluginRem[];
+  const targets = [root, ...descendants].slice(0, maxRems);
+
+  // Depth relative to the root, so the dump reads like the outliner.
+  const depthById = new Map<string, number>([[root._id, 0]]);
+
+  const properties: RawPropertyRow[] = [];
+  const rems: RawSlotRemRow[] = [];
+
+  for (const node of targets) {
+    // Only rems carrying one of the covered powerups are interesting.
+    const carried: string[] = [];
+    for (const spec of SPECS) {
+      if (await node.hasPowerup(spec.code).catch(() => false)) carried.push(spec.label);
+    }
+    if (carried.length === 0) continue;
+
+    if (!depthById.has(node._id)) {
+      const parent = await node.getParentRem().catch(() => undefined);
+      depthById.set(node._id, (parent && depthById.get(parent._id)) != null
+        ? (depthById.get(parent!._id) as number) + 1
+        : 1);
+    }
+    const depth = depthById.get(node._id) ?? 0;
+    const remText = await safeRemTextToString(plugin, node.text);
+
+    // ── The API read, per slot: what the plugin actually sees. ────────────────
+    const apiByKey = new Map<string, string | null>();
+    for (const spec of SPECS) {
+      if (!carried.includes(spec.label)) continue;
+      for (const slotCode of spec.slots) {
+        let value: string | null = null;
+        try {
+          const raw = await node.getPowerupProperty(spec.code, slotCode);
+          value = raw == null || raw === '' ? null : String(raw);
+        } catch {
+          value = null;
+        }
+        apiByKey.set(`${spec.label}:${slotCode}`, value);
+      }
+    }
+
+    // ── The raw read: the property rems themselves. ───────────────────────────
+    const children = ((await node.getChildrenRem().catch(() => [])) || []) as PluginRem[];
+    const rawByKey = new Map<string, RawPropertyRow>();
+
+    for (const child of children) {
+      // isPowerupProperty is deprecated at runtime on affected builds (it throws;
+      // see powerupSlotFilter.ts), so it must not be the gate — a property whose
+      // flags don't answer would silently vanish from the dump, and "no property
+      // rem found" is a conclusion we'd then draw from our own filter rather than
+      // from the data. Every child is reported; the flags are just columns.
+      const isPowerupProperty = await (child as any).isPowerupProperty?.().catch(() => false) ?? false;
+      const isProperty = await (child as any).isProperty?.().catch(() => false) ?? false;
+
+      // A powerup property rem's TEXT is a single reference to its slot
+      // DEFINITION, and its BACKTEXT holds the value. (Same structure
+      // powerupSlotFilter.ts relies on for slot detection.) So the reference id
+      // in `text` is the link the plugin follows — when it points at a slot rem
+      // that is not the registered definition, the value in `backText` becomes
+      // unreachable while remaining perfectly intact on the Rem.
+      const refIds = Array.isArray(child.text)
+        ? (child.text as any[])
+            .filter((el) => el != null && typeof el === 'object' && el.i === 'q' && el._id)
+            .map((el) => String(el._id))
+        : [];
+      // Tags are a secondary link (CardPriority slot instances use them).
+      const tags = ((await child.getTagRems().catch(() => [])) || []) as PluginRem[];
+      const slotDefIds = Array.from(new Set([...refIds, ...tags.map((t) => t._id)]));
+
+      const slotDefNames: string[] = [];
+      for (const id of slotDefIds) {
+        const defRem = await plugin.rem.findOne(id).catch(() => undefined);
+        const name = defRem ? await safeRemTextToString(plugin, defRem.text) : '';
+        slotDefNames.push(name === '' ? '(unnamed)' : name);
+      }
+
+      // THE VALUE. Not child.text — that resolves to the slot reference (which
+      // is why an earlier revision of this dump reported "[Untitled]" and
+      // "[Next Rep Date]" as though they were stored data).
+      const rawValue = await readRawText(plugin, (child as any).backText);
+      const match = slotDefIds.map((id) => slotDefIndex.get(id)).find((m) => !!m) || null;
+      const apiValue = match ? apiByKey.get(`${match.powerup}:${match.slotCode}`) ?? null : null;
+
+      // Follow each reference in the VALUE to its target. For a date slot this is
+      // the Daily Document; a missing or textless target is why an otherwise
+      // healthy property reads back as nothing.
+      const valueRefIds = refIdsIn((child as any).backText);
+      const refTargets: RawPropertyRow['refTargets'] = [];
+      for (const id of valueRefIds) {
+        const target = await plugin.rem.findOne(id).catch(() => undefined);
+        if (!target) {
+          refTargets.push({ id, exists: false, text: null, isDailyDoc: false, dailyDocDate: null });
+          continue;
+        }
+        const text = await readRawText(plugin, target.text);
+        let isDailyDoc = false;
+        let dailyDocDate: string | null = null;
+        try {
+          isDailyDoc = await target.hasPowerup(BuiltInPowerupCodes.DailyDocument);
+          if (isDailyDoc) {
+            dailyDocDate =
+              (await target.getPowerupProperty<BuiltInPowerupCodes.DailyDocument>(
+                BuiltInPowerupCodes.DailyDocument,
+                'Date'
+              )) || null;
+          }
+        } catch {
+          /* leave as not-a-daily-doc */
+        }
+        refTargets.push({ id, exists: true, text: text || null, isDailyDoc, dailyDocDate });
+      }
+      // A value made only of references that resolve to nothing usable.
+      const allRefsDead =
+        valueRefIds.length > 0 &&
+        refTargets.every((t) => !t.exists || (!t.dailyDocDate && !t.text));
+
+      // Is this child a powerup property at all? Either flag says so, and so does
+      // a slot reference in its text — which is the one signal that survives the
+      // deprecated flags. Ordinary content children are reported as UNKNOWN and
+      // kept out of the unreachable list, so a note with back text is never
+      // mistaken for a stranded slot value.
+      const looksLikeProperty = isPowerupProperty || isProperty || refIds.length > 0;
+
+      // "Rendered empty" and "nothing stored" are different. A date slot holds a
+      // Daily Document reference; if that reference cannot be resolved the value
+      // renders as "" while the elements are still there. Only zero elements is
+      // genuinely empty.
+      const backElements = Array.isArray((child as any).backText)
+        ? (child as any).backText.length
+        : 0;
+      const renderedEmpty = rawValue.trim() === '';
+      const genuinelyEmpty = backElements === 0;
+
+      let verdict: RawPropertyRow['verdict'];
+      if (!looksLikeProperty) {
+        verdict = 'UNKNOWN';
+      } else if (!match) {
+        // Its slot reference points at a rem that is NOT one of the registered
+        // slot definitions. If it still holds a value, that value is stranded.
+        verdict = genuinelyEmpty ? 'EMPTY' : 'DETACHED';
+      } else if (genuinelyEmpty) {
+        verdict = 'EMPTY';
+      } else if ((renderedEmpty || allRefsDead) && apiValue == null) {
+        // The property and its slot link are both fine; the VALUE is a reference
+        // whose target is gone or unusable.
+        verdict = 'UNRESOLVED_REF';
+      } else if (apiValue == null) {
+        verdict = 'API_BLIND';
+      } else {
+        verdict = 'OK';
+      }
+
+      const row: RawPropertyRow = {
+        remId: node._id,
+        remText,
+        depth,
+        propertyRemId: child._id,
+        rawValue,
+        rawValueLength: rawValue.length,
+        rawElementCount: Array.isArray((child as any).backText) ? (child as any).backText.length : 0,
+        rawValueRefIds: valueRefIds,
+        refTargets,
+        slotReferenceLabel: await safeRemTextToString(plugin, child.text),
+        isPowerupProperty,
+        isProperty,
+        slotDefIds,
+        slotDefNames,
+        matchedPowerup: match?.powerup ?? null,
+        matchedSlotCode: match?.slotCode ?? null,
+        apiValue,
+        verdict,
+      };
+      properties.push(row);
+      if (match) rawByKey.set(`${match.powerup}:${match.slotCode}`, row);
+    }
+
+    // ── Per-rem slot table: API value beside raw value. ───────────────────────
+    const slots: RawSlotRemRow['slots'] = [];
+    for (const spec of SPECS) {
+      if (!carried.includes(spec.label)) continue;
+      for (const slotCode of spec.slots) {
+        const key = `${spec.label}:${slotCode}`;
+        const apiValue = apiByKey.get(key) ?? null;
+        const raw = rawByKey.get(key) ?? null;
+        // No property rem carries this slot definition. If the API is also empty
+        // the slot was simply never written; if the API has a value, the property
+        // lives somewhere this walk didn't look.
+        const verdict: RawPropertyRow['verdict'] = raw
+          ? raw.verdict
+          : apiValue == null
+          ? 'EMPTY'
+          : 'OK';
+        slots.push({
+          powerup: spec.label,
+          slotCode,
+          apiValue,
+          rawValue: raw?.rawValue ?? null,
+          rawPropertyRemId: raw?.propertyRemId ?? null,
+          slotDefLinked: raw ? raw.matchedPowerup !== null : null,
+          verdict,
+        });
+      }
+    }
+
+    rems.push({ remId: node._id, remText, depth, powerups: carried, childCount: children.length, slots });
+  }
+
+  // Values that are stored but the plugin cannot read — the whole point.
+  const unreachable = properties.filter(
+    (p) => p.verdict === 'DETACHED' || p.verdict === 'API_BLIND'
+  );
+
+  const report: RawSlotDumpReport = {
+    exportedAt: new Date().toISOString(),
+    rootRemId: root._id,
+    rootRemText: rootText,
+    scannedRems: rems.length,
+    registered,
+    rems,
+    properties,
+    unreachable,
+  };
+
+  logRawSlotDump(report);
+  return report;
+}
+
+/** Console report, formatted for pasting into a support ticket. */
+export function logRawSlotDump(report: RawSlotDumpReport): void {
+  console.log('\n========== RAW POWERUP SLOT DUMP ==========');
+  console.log(`Root: "${report.rootRemText}" [${report.rootRemId}]`);
+  console.log(`Rems carrying a covered powerup: ${report.scannedRems}`);
+
+  console.log('\n--- Registered powerups (what getPowerupByCode resolves to) ---');
+  for (const p of report.registered) {
+    console.log(`${p.label} (code: ${p.code}) -> powerup rem ${p.powerupRemId ?? '(none)'}`);
+    console.table(p.slots.map((s) => ({
+      slotCode: s.slotCode,
+      slotDefId: s.slotDefId ?? '(unresolved)',
+      slotDefName: s.slotDefName || '(unnamed)',
+      nativeSlotDefId: s.nativeSlotDefId ?? '(none)',
+      nativeError: s.nativeError ?? '',
+    })));
+    console.log('  slot children actually on the powerup rem:');
+    console.table(p.actualSlotChildren.map((c) => ({ id: c.id, name: c.name || '(unnamed)' })));
+  }
+
+  console.log('\n--- Every stored property, raw ---');
+  console.table(report.properties.map((p) => ({
+    rem: p.remText.slice(0, 40),
+    remId: p.remId,
+    propertyRemId: p.propertyRemId,
+    slotDefNames: p.slotDefNames.join(' | ') || '(untagged)',
+    slotDefIds: p.slotDefIds.join(' | ') || '(none)',
+    slotRef: p.slotReferenceLabel,
+    matched: p.matchedPowerup ? `${p.matchedPowerup}:${p.matchedSlotCode}` : '(NO MATCH)',
+    RAW: p.rawValue.slice(0, 60),
+    API: p.apiValue === null ? '(empty)' : p.apiValue.slice(0, 60),
+    verdict: p.verdict,
+  })));
+
+  if (report.unreachable.length === 0) {
+    console.log('\nNo unreachable values: every stored property matched a registered slot');
+    console.log('and read back through getPowerupProperty. Priorities the plugin shows');
+    console.log('are the priorities that are stored.');
+  } else {
+    console.log(`\n*** ${report.unreachable.length} STORED VALUE(S) THE PLUGIN CANNOT READ ***`);
+    console.table(report.unreachable.map((p) => ({
+      rem: p.remText.slice(0, 40),
+      remId: p.remId,
+      propertyRemId: p.propertyRemId,
+      slotDefNames: p.slotDefNames.join(' | ') || '(untagged)',
+      slotRef: p.slotReferenceLabel,
+      storedValue: p.rawValue.slice(0, 60),
+      apiReturns: p.apiValue === null ? '(empty)' : p.apiValue,
+      verdict: p.verdict,
+    })));
+    console.log('DETACHED  = the property is tagged with a slot rem that is NOT the');
+    console.log('            registered slot definition. The value is intact in storage;');
+    console.log('            getPowerupProperty walks the registered slot and finds');
+    console.log('            nothing, so the plugin displays its read fallback instead.');
+    console.log('API_BLIND = the slot definition IS the registered one and the property');
+    console.log('            holds a value, yet getPowerupProperty returns nothing.');
+  }
+  console.log('===========================================\n');
+}

--- a/src/lib/raw_slot_dump.ts
+++ b/src/lib/raw_slot_dump.ts
@@ -197,7 +197,7 @@ export interface RawSlotDumpReport {
 }
 
 /** Rem-reference elements carried by a rich-text value, by id. */
-function refIdsIn(richText: unknown): string[] {
+export function refIdsIn(richText: unknown): string[] {
   if (!Array.isArray(richText)) return [];
   return (richText as any[])
     .filter((el) => el != null && typeof el === 'object' && el.i === 'q' && el._id)
@@ -217,7 +217,7 @@ function refIdsIn(richText: unknown): string[] {
  *    a perfectly healthy `Next Rep Date` would come back as "" and be reported
  *    as EMPTY. References are resolved via `resolveRemTextToString` instead.
  */
-async function readRawText(plugin: RNPlugin, richText: unknown): Promise<string> {
+export async function readRawText(plugin: RNPlugin, richText: unknown): Promise<string> {
   if (richText == null || !Array.isArray(richText) || richText.length === 0) return '';
   if (refIdsIn(richText).length > 0) {
     try {

--- a/src/lib/raw_slot_repair.ts
+++ b/src/lib/raw_slot_repair.ts
@@ -32,10 +32,10 @@
 
 import { RNPlugin, PluginRem } from '@remnote/plugin-sdk';
 import { CARD_PRIORITY_CODE, PRIORITY_SLOT, SOURCE_SLOT, LAST_UPDATED_SLOT, PrioritySource } from './card_priority/types';
-import { setCardPriority } from './card_priority';
-import { getPowerupSlotByCodeSafe } from './powerup_slot_compat';
+import { setCardPriority, getCardPriority } from './card_priority';
 import { safeRemTextToString } from './pdfUtils';
-import { refIdsIn, readRawText } from './raw_slot_dump';
+import { readRawText } from './raw_slot_dump';
+import { scanKbForDetachedSlots, LeftoverProperty } from './raw_slot_scan';
 import { getIESetting } from './settings';
 import { enableFlashcardPrioritisationId } from './consts';
 
@@ -72,11 +72,16 @@ export interface RepairReport {
    * `testDeleteOrphanProperties` — keep it; it is the only record of what to clean.
    */
   orphanPropertyRemIds: string[];
+  /**
+   * Orphan property Rems belonging to the SKIPPED derivable Rems. Also litter,
+   * but their values are reconstructible, which makes them the safe population to
+   * try the first deletions on — unlike the recovered manual values above.
+   */
+  derivableOrphanPropertyRemIds: string[];
   samples: RepairCandidate[];
   notes: string[];
 }
 
-const BATCH_SIZE = 50;
 const SAMPLE_CAP = 25;
 
 export interface RepairOptions {
@@ -107,182 +112,153 @@ export async function repairDetachedCardPriorities(
   const started = Date.now();
   const notes: string[] = [];
 
-  const registeredSlot = await getPowerupSlotByCodeSafe(plugin, CARD_PRIORITY_CODE, PRIORITY_SLOT);
-  const registeredId = registeredSlot?._id ?? null;
-  if (!registeredId) {
-    throw new Error(
-      'Could not resolve the registered CardPriority priority slot — refusing to run. ' +
-      'Without it, a healthy property is indistinguishable from a detached one.'
-    );
-  }
+  // ── Work list ─────────────────────────────────────────────────────────────
+  //
+  // The candidates come from the KB scan, NOT from a second walk of the Rem tree.
+  //
+  // This function used to re-derive "is this a stranded priority" itself, and its
+  // answer disagreed with the scan three times running (324 vs 375). Each round
+  // produced a plausible-looking cause — an early `break`, an empty linked
+  // property, an incomplete `taggedRem()` index — and each fix left the numbers
+  // unchanged, because the real problem was having two implementations of one
+  // predicate at all. The scan is the authority; this consumes its output.
+  //
+  // Cost: the scan runs first (~25s, read-only). Worth it for a one-shot repair.
+  const scan = await scanKbForDetachedSlots(plugin, (done: number, total: number) =>
+    onProgress?.(done, total)
+  );
 
-  // Every slot Rem on the CardPriority definition, so a detached property can be
-  // recognised by referencing one of them that is NOT the registered slot.
-  const powerup = await plugin.powerup.getPowerupByCode(CARD_PRIORITY_CODE);
-  const slotChildren = ((await powerup?.getChildrenRem().catch(() => [])) || []) as PluginRem[];
-  const knownSlotIds = new Set<string>();
-  for (const c of slotChildren) {
-    if (await c.isPowerupSlot().catch(() => false)) knownSlotIds.add(c._id);
-  }
+  const isDerivable = (s: PrioritySource | null) => s === 'inherited' || s === 'default';
+  const work = scan.strandedAll.filter(
+    (l: LeftoverProperty) => includeDerivable || !isDerivable(l.ownerSource)
+  );
+  const skippedDerivable = scan.strandedAll.length - work.length;
 
-  const rems = ((await powerup?.taggedRem().catch(() => [])) || []) as PluginRem[];
-
-  // setCardPriority refuses 'inherited'/'default' writes while flashcard
-  // prioritisation is off (mayWriteCardPrioritySource). Without this check the
-  // write would silently no-op, the verification below would fail, and after five
-  // of those the run would abort claiming the repair mechanism is broken — when
-  // in fact it is a setting. Fail loudly and early instead.
-  if (includeDerivable && !(await getIESetting(plugin, enableFlashcardPrioritisationId))) {
-    throw new Error(
-      "includeDerivable was requested but flashcard prioritisation is OFF, so " +
-      "'inherited'/'default' writes are refused by design. Enable the setting, or " +
-      'run without includeDerivable (the default) to repair only manual/incremental values.'
-    );
-  }
+  // The derivable ones are skipped for repair, but their orphan property Rems are
+  // still litter — and they are the RIGHT first target for the deletion test.
+  // Their values are reconstructible from the ancestor cascade, so a delete that
+  // goes wrong costs nothing, whereas the repaired manual values are the most
+  // expensive thing in the set to lose.
+  const derivableOrphanPropertyRemIds = scan.strandedAll
+    .filter((l: LeftoverProperty) => isDerivable(l.ownerSource))
+    .map((l: LeftoverProperty) => l.propertyRemId);
 
   const report: RepairReport = {
     exportedAt: new Date().toISOString(),
     dryRun,
     durationMs: 0,
-    scanned: rems.length,
+    scanned: scan.strandedAll.length,
     candidates: 0,
-    skippedDerivable: 0,
+    skippedDerivable,
     repaired: 0,
     failedVerification: 0,
     errors: [],
     orphanPropertyRemIds: [],
+    derivableOrphanPropertyRemIds,
     samples: [],
     notes,
   };
+  notes.push(
+    `Work list taken from the KB scan: ${scan.leftoverStranded} stranded, ` +
+    `${scan.strandedNeedsRecovery} needing recovery, ${scan.strandedDiscardable} derivable.`
+  );
 
   let stopped = false;
 
-  for (let i = 0; i < rems.length && !stopped; i += BATCH_SIZE) {
-    const batch = rems.slice(i, i + BATCH_SIZE);
+  for (let i = 0; i < work.length && !stopped; i++) {
+    if (limit !== undefined && report.repaired >= limit) {
+      stopped = true;
+      notes.push(`Stopped after reaching the limit of ${limit} repair(s).`);
+      break;
+    }
 
-    // Sequential within a batch: each repair is a multi-property write plus a
-    // band sync, and firing 50 of those concurrently saturates the IPC bridge.
-    for (const rem of batch) {
-      if (limit !== undefined && report.repaired >= limit) {
-        stopped = true;
-        notes.push(`Stopped after reaching the limit of ${limit} repair(s).`);
-        break;
+    const item = work[i];
+    try {
+      const rem = await plugin.rem.findOne(item.ownerRemId);
+      if (!rem) {
+        report.errors.push({ remId: item.ownerRemId, error: 'Rem not found' });
+        continue;
       }
 
+      // The scan already read the value off the orphan property; re-validate the
+      // range rather than trusting it, since this is the write path.
+      const storedValue = parseInt(item.value, 10);
+      if (isNaN(storedValue) || storedValue < 0 || storedValue > 100) {
+        report.errors.push({ remId: item.ownerRemId, error: `implausible value "${item.value}"` });
+        continue;
+      }
+
+      // Source and lastUpdated live in hidden slots, which survived the migration,
+      // so the original provenance is restored rather than stamping every repaired
+      // card as a fresh manual edit.
+      const source: PrioritySource = item.ownerSource ?? 'manual';
+      let lastUpdated: number | null = null;
       try {
-        const children = ((await rem.getChildrenRem().catch(() => [])) || []) as PluginRem[];
+        const lu = await rem.getPowerupProperty(CARD_PRIORITY_CODE, LAST_UPDATED_SLOT);
+        const parsed = lu ? parseInt(String(lu), 10) : NaN;
+        if (!isNaN(parsed)) lastUpdated = parsed;
+      } catch {
+        /* leave null — setCardPriority stamps now */
+      }
 
-        let linked = false;
-        let orphan: PluginRem | null = null;
-        let orphanSlotId: string | null = null;
-        for (const child of children) {
-          const refs = refIdsIn(child.text);
-          if (!refs.length) continue;
-          if (refs.includes(registeredId)) {
-            linked = true;
-            break;
-          }
-          const hit = refs.find((id) => knownSlotIds.has(id));
-          if (hit && !orphan) {
-            orphan = child;
-            orphanSlotId = hit;
-          }
-        }
-        // A healthy property wins outright — never touch a Rem that already reads.
-        if (linked || !orphan || !orphanSlotId) continue;
+      report.candidates++;
+      report.orphanPropertyRemIds.push(item.propertyRemId);
 
-        const raw = (await readRawText(plugin, (orphan as any).backText)).trim();
-        if (!/^\d{1,3}$/.test(raw)) continue;
-        const storedValue = Math.min(100, Math.max(0, parseInt(raw, 10)));
-
-        // prioritySource / lastUpdated are hidden slots — they survived the
-        // migration, so the original provenance can be restored rather than
-        // every repaired card being stamped as a fresh manual edit.
-        let source: PrioritySource = 'manual';
-        let lastUpdated: number | null = null;
-        try {
-          const s = await rem.getPowerupProperty(CARD_PRIORITY_CODE, SOURCE_SLOT);
-          if (s === 'manual' || s === 'inherited' || s === 'default' || s === 'incremental') {
-            source = s;
-          }
-          const lu = await rem.getPowerupProperty(CARD_PRIORITY_CODE, LAST_UPDATED_SLOT);
-          const parsed = lu ? parseInt(String(lu), 10) : NaN;
-          if (!isNaN(parsed)) lastUpdated = parsed;
-        } catch {
-          /* fall back to 'manual', the conservative choice: it is never suppressed
-             by mayWriteCardPrioritySource and never silently dropped. */
-        }
-
-        if (!includeDerivable && (source === 'inherited' || source === 'default')) {
-          report.skippedDerivable++;
-          continue;
-        }
-
-        report.candidates++;
-
-        // What the app is using right now, for the record. ONLY for the handful
-        // of rows that get sampled: getCardPriority walks the ancestor chain, and
-        // firing that for thousands of candidates saturates the IPC bridge for no
-        // benefit — the repair itself does not depend on this value.
+      if (report.samples.length < SAMPLE_CAP) {
         let currentValue: number | null = null;
-        if (report.samples.length < SAMPLE_CAP) {
-          try {
-            const { getCardPriority } = await import('./card_priority');
-            const info = await getCardPriority(plugin, rem);
-            currentValue = info?.priority ?? null;
-          } catch {
-            /* diagnostic only */
-          }
+        try {
+          const { getCardPriority } = await import('./card_priority');
+          currentValue = (await getCardPriority(plugin, rem))?.priority ?? null;
+        } catch {
+          /* diagnostic only */
         }
-
-        const candidate: RepairCandidate = {
-          remId: rem._id,
+        report.samples.push({
+          remId: item.ownerRemId,
           text: (await safeRemTextToString(plugin, rem.text)).slice(0, 120),
           storedValue,
           currentValue,
           source,
           lastUpdated,
-          orphanPropertyRemId: orphan._id,
-          orphanSlotId,
-        };
-        if (report.samples.length < SAMPLE_CAP) report.samples.push(candidate);
-        report.orphanPropertyRemIds.push(orphan._id);
-
-        if (dryRun) continue;
-
-        await setCardPriority(plugin, rem, storedValue, source, true);
-
-        // Restore the original timestamp: setCardPriority stamps Date.now(), but
-        // this is a repair, not an edit, and lastUpdated is how inheritance and
-        // the analytics decide precedence.
-        if (lastUpdated !== null) {
-          try {
-            await rem.setPowerupProperty(CARD_PRIORITY_CODE, LAST_UPDATED_SLOT, [String(lastUpdated)]);
-          } catch { /* non-fatal — the priority itself is what matters */ }
-        }
-
-        // Verify through the API that was broken. A write that does not read back
-        // means the repair does not work on this build and we must stop.
-        const check = await rem.getPowerupProperty(CARD_PRIORITY_CODE, PRIORITY_SLOT).catch(() => null);
-        if (check != null && String(check).trim() === String(storedValue)) {
-          report.repaired++;
-        } else {
-          report.failedVerification++;
-          if (report.failedVerification >= 5) {
-            stopped = true;
-            notes.push(
-              'ABORTED: 5 writes did not read back. The repair mechanism is not working ' +
-              'on this build — nothing further was attempted.'
-            );
-            break;
-          }
-        }
-      } catch (e: any) {
-        report.errors.push({ remId: rem._id, error: String(e?.message ?? e) });
+          orphanPropertyRemId: item.propertyRemId,
+          orphanSlotId: item.slotId,
+        });
       }
+
+      if (dryRun) continue;
+
+      await setCardPriority(plugin, rem, storedValue, source, true);
+
+      // Restore the original timestamp, but only when it is plausibly a
+      // millisecond value. Some Rems carry a lastUpdated of `2025` — the year —
+      // which parses to Jan 1970 and would make the card look older than the
+      // knowledge base. Faithfully restoring a broken value has no upside.
+      if (lastUpdated !== null && lastUpdated > 1_000_000_000_000) {
+        try {
+          await rem.setPowerupProperty(CARD_PRIORITY_CODE, LAST_UPDATED_SLOT, [String(lastUpdated)]);
+        } catch { /* non-fatal — the priority itself is what matters */ }
+      }
+
+      // Verify through the API that was broken. A write that does not read back
+      // means the repair does not work on this build and we must stop.
+      const check = await rem.getPowerupProperty(CARD_PRIORITY_CODE, PRIORITY_SLOT).catch(() => null);
+      if (check != null && String(check).trim() === String(storedValue)) {
+        report.repaired++;
+      } else {
+        report.failedVerification++;
+        if (report.failedVerification >= 5) {
+          stopped = true;
+          notes.push(
+            'ABORTED: 5 writes did not read back. The repair mechanism is not working ' +
+            'on this build — nothing further was attempted.'
+          );
+          break;
+        }
+      }
+    } catch (e: any) {
+      report.errors.push({ remId: item.ownerRemId, error: String(e?.message ?? e) });
     }
 
-    onProgress?.(Math.min(i + BATCH_SIZE, rems.length), rems.length);
+    onProgress?.(i + 1, work.length);
   }
 
   if (dryRun) {
@@ -316,6 +292,16 @@ export interface DeletionProbe {
   ownerText: string | null;
   /** Value the orphan was holding, captured before deletion so it can be restored by hand. */
   storedValue: string | null;
+  /** The owner's CardPriority source, read only when the raw value is empty. */
+  ownerSource: string | null;
+  /**
+   * The priority the app actually resolves for the owner (getCardPriority),
+   * either side of the deletion. For a derivable orphan the raw property reads
+   * empty both times, so this is the only check with any meaning: it follows the
+   * ancestor cascade exactly as the rest of the plugin does.
+   */
+  resolvedBefore: number | null;
+  resolvedAfter: number | null;
   ownerChildCountBefore: number | null;
   ownerChildCountAfter: number | null;
   /** The owner's CardPriority value read through the API, before and after. */
@@ -341,16 +327,37 @@ export interface DeletionProbe {
 export async function testDeleteOrphanProperties(
   plugin: RNPlugin,
   orphanPropertyRemIds: string[],
-  limit = 3
+  limit = 3,
+  onProgress?: (done: number, total: number) => void
 ): Promise<DeletionProbe[]> {
   const probes: DeletionProbe[] = [];
+  const targets = orphanPropertyRemIds.slice(0, limit);
+  let processed = 0;
 
-  for (const id of orphanPropertyRemIds.slice(0, limit)) {
+  for (const id of targets) {
+    // Abort the whole run the moment one deletion disturbs a value. At bulk
+    // scale, continuing past the first DANGER would turn a single recoverable
+    // mistake into hundreds.
+    if (probes.some((p) => p.verdict.startsWith('DANGER'))) {
+      probes.push({
+        orphanPropertyRemId: id,
+        ownerRemId: null, ownerText: null, storedValue: null, ownerSource: null,
+        resolvedBefore: null, resolvedAfter: null,
+        ownerChildCountBefore: null, ownerChildCountAfter: null,
+        apiValueBefore: null, apiValueAfter: null, deleted: false,
+        verdict: 'ABORTED — a previous deletion reported DANGER; nothing further was attempted.',
+      });
+      break;
+    }
+    onProgress?.(++processed, targets.length);
     const probe: DeletionProbe = {
       orphanPropertyRemId: id,
       ownerRemId: null,
       ownerText: null,
       storedValue: null,
+      ownerSource: null,
+      resolvedBefore: null,
+      resolvedAfter: null,
       ownerChildCountBefore: null,
       ownerChildCountAfter: null,
       apiValueBefore: null,
@@ -381,15 +388,35 @@ export async function testDeleteOrphanProperties(
       probe.apiValueBefore =
         (await owner.getPowerupProperty(CARD_PRIORITY_CODE, PRIORITY_SLOT).catch(() => null)) ?? null;
 
-      // Refuse if the good value is not in place — deleting would then be the only
-      // copy going away.
-      if (probe.apiValueBefore == null || String(probe.apiValueBefore).trim() === '') {
+      // Refuse unless the owner already has a readable priority in its own slot.
+      //
+      // An earlier version also accepted a derivable source ('inherited'/'default')
+      // on the theory that such a value is recomputed on demand and the orphan
+      // therefore holds nothing unique. That was WRONG: setCardPriority writes
+      // priority, source and lastUpdated together, so an inherited value is
+      // MATERIALISED into the Rem's own slot like any other. An empty slot with a
+      // surviving source is damage, and the orphan holds the only copy of that
+      // materialised value — deleting it forces every later read to walk the
+      // ancestor chain instead (see the ancestor-walk cost this plugin already
+      // fights) and leaves lastUpdated reporting 0.
+      //
+      // So the rule is simply: repair first, then delete. No exceptions by source.
+      const src = await owner.getPowerupProperty(CARD_PRIORITY_CODE, SOURCE_SLOT).catch(() => null);
+      probe.ownerSource = (src as string) ?? null;
+      const hasReadableValue =
+        probe.apiValueBefore != null && String(probe.apiValueBefore).trim() !== '';
+      if (!hasReadableValue) {
         probe.verdict =
-          'REFUSED: the owner has no readable CardPriority value, so this orphan may hold ' +
-          'the only copy. Repair the Rem first, then delete.';
+          `REFUSED: the owner's priority slot is empty (source "${probe.ownerSource ?? 'unknown'}"), ` +
+          'so this orphan holds the only materialised copy. Run the repair with ' +
+          'includeDerivable first, then delete.';
         probes.push(probe);
         continue;
       }
+
+      // The effective priority BEFORE — what the app shows the user. For a
+      // derivable orphan this comes from the ancestor cascade, not the property.
+      probe.resolvedBefore = (await getCardPriority(plugin, owner).catch(() => null))?.priority ?? null;
 
       await orphan.remove();
       probe.deleted = true;
@@ -397,14 +424,30 @@ export async function testDeleteOrphanProperties(
       probe.ownerChildCountAfter = ((await owner.getChildrenRem().catch(() => [])) || []).length;
       probe.apiValueAfter =
         (await owner.getPowerupProperty(CARD_PRIORITY_CODE, PRIORITY_SLOT).catch(() => null)) ?? null;
+      probe.resolvedAfter = (await getCardPriority(plugin, owner).catch(() => null))?.priority ?? null;
 
-      if (probe.apiValueAfter != null && probe.apiValueAfter === probe.apiValueBefore) {
-        probe.verdict = 'OK — orphan removed, the repaired priority still reads correctly.';
+      // The test is "did anything CHANGE", not "is there a value". An earlier
+      // version required apiValueAfter to be non-null, which reported every
+      // derivable orphan as DANGER with the self-refuting message "changed from
+      // null to null" — those read empty either side by definition.
+      const rawUnchanged = probe.apiValueBefore === probe.apiValueAfter;
+      const resolvedUnchanged = probe.resolvedBefore === probe.resolvedAfter;
+
+      if (rawUnchanged && resolvedUnchanged) {
+        probe.verdict =
+          `OK — orphan removed (children ${probe.ownerChildCountBefore} → ` +
+          `${probe.ownerChildCountAfter}); the priority the app resolves is unchanged ` +
+          `(${probe.resolvedBefore ?? 'none'}).`;
+      } else if (!rawUnchanged) {
+        probe.verdict =
+          `DANGER: the stored priority changed from ${probe.apiValueBefore} to ` +
+          `${probe.apiValueAfter}. Deleting the orphan disturbed the good property. ` +
+          `DO NOT run a bulk cleanup. Restore by setting this Rem's priority to ${probe.storedValue}.`;
       } else {
         probe.verdict =
-          `DANGER: the API value changed from ${probe.apiValueBefore} to ${probe.apiValueAfter}. ` +
-          'Deleting the orphan disturbed the good property. DO NOT run a bulk cleanup. ' +
-          `Restore by setting this Rem's priority back to ${probe.storedValue}.`;
+          `DANGER: the RESOLVED priority changed from ${probe.resolvedBefore} to ` +
+          `${probe.resolvedAfter} even though the stored property did not. The orphan was ` +
+          `contributing to inheritance. DO NOT run a bulk cleanup.`;
       }
     } catch (e: any) {
       probe.error = String(e?.message ?? e);
@@ -414,20 +457,35 @@ export async function testDeleteOrphanProperties(
     probes.push(probe);
   }
 
-  console.log('\n========== ORPHAN DELETION TEST ==========');
+  const deleted = probes.filter((p) => p.deleted).length;
+  const danger = probes.filter((p) => p.verdict.startsWith('DANGER')).length;
+  const refused = probes.filter((p) => p.verdict.startsWith('REFUSED')).length;
+  console.log('\n========== ORPHAN DELETION ==========');
+  console.log(
+    `deleted: ${deleted}   OK: ${deleted - danger}   DANGER: ${danger}   refused: ${refused}` +
+    `   (of ${probes.length} attempted)`
+  );
+  if (danger > 0) console.log('*** STOP — a deletion disturbed a value. Do not continue. ***');
+  // Cap the table: a bulk run produces hundreds of identical OK rows, and the
+  // summary above is what matters. Anything abnormal is printed in full below.
   console.table(
-    probes.map((p) => ({
+    probes.slice(0, 20).map((p) => ({
       orphan: p.orphanPropertyRemId,
       owner: p.ownerRemId ?? '(none)',
       held: p.storedValue ?? '',
       'children before': p.ownerChildCountBefore ?? '',
       'children after': p.ownerChildCountAfter ?? '',
-      'API before': p.apiValueBefore ?? '(empty)',
-      'API after': p.apiValueAfter ?? '(empty)',
+      'stored before': p.apiValueBefore ?? '(empty)',
+      'stored after': p.apiValueAfter ?? '(empty)',
+      'RESOLVED before': p.resolvedBefore ?? '(none)',
+      'RESOLVED after': p.resolvedAfter ?? '(none)',
       deleted: p.deleted,
     }))
   );
-  for (const p of probes) console.log(`${p.orphanPropertyRemId}: ${p.verdict}`);
+  for (const p of probes) {
+    if (p.verdict.startsWith('OK') && probes.length > 20) continue;
+    console.log(`${p.orphanPropertyRemId}: ${p.verdict}`);
+  }
   console.log('==========================================\n');
 
   return probes;

--- a/src/lib/raw_slot_repair.ts
+++ b/src/lib/raw_slot_repair.ts
@@ -1,0 +1,463 @@
+// Repair pass for CardPriority properties detached by the storage/sync overhaul.
+//
+// WHY CARDPRIORITY FIRST
+// ----------------------
+// The KB scan (lib/raw_slot_scan.ts) found the detachment in both priority
+// powerups, but they are not equally urgent:
+//
+//   Incremental — ~100% detached, yet MITIGATED. getIncrementalRemFromRem
+//     recovers the value from the Rem's own repetition history, so the plugin
+//     shows the right number today.
+//
+//   CardPriority — ~6.7% detached and NOT mitigated. getCardPriority has no
+//     history to fall back on; it silently resolves an inherited value or the
+//     default. Those priorities are simply wrong in the app right now, even
+//     though the correct value is still sitting on the Rem.
+//
+// So this repairs CardPriority. The mechanism is the one proven by hand in the
+// support report: writing through the normal path creates a new, correctly
+// referenced property Rem. The stale one is left behind — deliberately. Deleting
+// it is a separate, staged step (see `testDeleteOrphanProperties`), because at
+// this scale an unverified bulk delete is the one action here that could destroy
+// something.
+//
+// WHAT IT PRESERVES
+// -----------------
+// `prioritySource` and `lastUpdated` are HIDDEN slots, so they migrated cleanly
+// and are still readable. The repair therefore restores the value under its
+// ORIGINAL source and re-stamps the ORIGINAL timestamp, rather than rewriting
+// every card as a fresh manual edit. A repair must not look like a user action.
+//
+// Dry-run by default.
+
+import { RNPlugin, PluginRem } from '@remnote/plugin-sdk';
+import { CARD_PRIORITY_CODE, PRIORITY_SLOT, SOURCE_SLOT, LAST_UPDATED_SLOT, PrioritySource } from './card_priority/types';
+import { setCardPriority } from './card_priority';
+import { getPowerupSlotByCodeSafe } from './powerup_slot_compat';
+import { safeRemTextToString } from './pdfUtils';
+import { refIdsIn, readRawText } from './raw_slot_dump';
+import { getIESetting } from './settings';
+import { enableFlashcardPrioritisationId } from './consts';
+
+export interface RepairCandidate {
+  remId: string;
+  text: string;
+  /** The value stranded on the detached property. */
+  storedValue: number;
+  /** What getCardPriority currently resolves to instead — the wrong value in use. */
+  currentValue: number | null;
+  source: PrioritySource;
+  lastUpdated: number | null;
+  /** The mis-pointed property Rem. Left in place; input to the deletion stage. */
+  orphanPropertyRemId: string;
+  orphanSlotId: string;
+}
+
+export interface RepairReport {
+  exportedAt: string;
+  dryRun: boolean;
+  durationMs: number;
+  scanned: number;
+  /** Detached properties found holding a usable value. */
+  candidates: number;
+  /** Skipped because their source is derivable and will be recomputed anyway. */
+  skippedDerivable: number;
+  /** Written successfully and verified readable afterwards. */
+  repaired: number;
+  /** Written but the value still does not read back — investigate before continuing. */
+  failedVerification: number;
+  errors: Array<{ remId: string; error: string }>;
+  /**
+   * Every orphan property Rem left behind, in repair order. This is the input to
+   * `testDeleteOrphanProperties` — keep it; it is the only record of what to clean.
+   */
+  orphanPropertyRemIds: string[];
+  samples: RepairCandidate[];
+  notes: string[];
+}
+
+const BATCH_SIZE = 50;
+const SAMPLE_CAP = 25;
+
+export interface RepairOptions {
+  /** Default true — reports what it WOULD do and writes nothing. */
+  dryRun?: boolean;
+  /**
+   * Repair 'inherited'/'default' values too. Off by default: those are derived,
+   * the plugin recomputes them from the ancestor cascade, and writing them
+   * re-materialises tags that `mayWriteCardPrioritySource` deliberately
+   * suppresses when flashcard prioritisation is disabled. Only 'manual' and
+   * 'incremental' carry information that cannot be reconstructed.
+   */
+  includeDerivable?: boolean;
+  /** Stop after this many repairs. Use a small number for the first live run. */
+  limit?: number;
+  onProgress?: (done: number, total: number) => void;
+}
+
+/**
+ * Finds CardPriority Rems whose priority property is detached, and restores the
+ * stranded value through the canonical write path.
+ */
+export async function repairDetachedCardPriorities(
+  plugin: RNPlugin,
+  options: RepairOptions = {}
+): Promise<RepairReport> {
+  const { dryRun = true, includeDerivable = false, limit, onProgress } = options;
+  const started = Date.now();
+  const notes: string[] = [];
+
+  const registeredSlot = await getPowerupSlotByCodeSafe(plugin, CARD_PRIORITY_CODE, PRIORITY_SLOT);
+  const registeredId = registeredSlot?._id ?? null;
+  if (!registeredId) {
+    throw new Error(
+      'Could not resolve the registered CardPriority priority slot — refusing to run. ' +
+      'Without it, a healthy property is indistinguishable from a detached one.'
+    );
+  }
+
+  // Every slot Rem on the CardPriority definition, so a detached property can be
+  // recognised by referencing one of them that is NOT the registered slot.
+  const powerup = await plugin.powerup.getPowerupByCode(CARD_PRIORITY_CODE);
+  const slotChildren = ((await powerup?.getChildrenRem().catch(() => [])) || []) as PluginRem[];
+  const knownSlotIds = new Set<string>();
+  for (const c of slotChildren) {
+    if (await c.isPowerupSlot().catch(() => false)) knownSlotIds.add(c._id);
+  }
+
+  const rems = ((await powerup?.taggedRem().catch(() => [])) || []) as PluginRem[];
+
+  // setCardPriority refuses 'inherited'/'default' writes while flashcard
+  // prioritisation is off (mayWriteCardPrioritySource). Without this check the
+  // write would silently no-op, the verification below would fail, and after five
+  // of those the run would abort claiming the repair mechanism is broken — when
+  // in fact it is a setting. Fail loudly and early instead.
+  if (includeDerivable && !(await getIESetting(plugin, enableFlashcardPrioritisationId))) {
+    throw new Error(
+      "includeDerivable was requested but flashcard prioritisation is OFF, so " +
+      "'inherited'/'default' writes are refused by design. Enable the setting, or " +
+      'run without includeDerivable (the default) to repair only manual/incremental values.'
+    );
+  }
+
+  const report: RepairReport = {
+    exportedAt: new Date().toISOString(),
+    dryRun,
+    durationMs: 0,
+    scanned: rems.length,
+    candidates: 0,
+    skippedDerivable: 0,
+    repaired: 0,
+    failedVerification: 0,
+    errors: [],
+    orphanPropertyRemIds: [],
+    samples: [],
+    notes,
+  };
+
+  let stopped = false;
+
+  for (let i = 0; i < rems.length && !stopped; i += BATCH_SIZE) {
+    const batch = rems.slice(i, i + BATCH_SIZE);
+
+    // Sequential within a batch: each repair is a multi-property write plus a
+    // band sync, and firing 50 of those concurrently saturates the IPC bridge.
+    for (const rem of batch) {
+      if (limit !== undefined && report.repaired >= limit) {
+        stopped = true;
+        notes.push(`Stopped after reaching the limit of ${limit} repair(s).`);
+        break;
+      }
+
+      try {
+        const children = ((await rem.getChildrenRem().catch(() => [])) || []) as PluginRem[];
+
+        let linked = false;
+        let orphan: PluginRem | null = null;
+        let orphanSlotId: string | null = null;
+        for (const child of children) {
+          const refs = refIdsIn(child.text);
+          if (!refs.length) continue;
+          if (refs.includes(registeredId)) {
+            linked = true;
+            break;
+          }
+          const hit = refs.find((id) => knownSlotIds.has(id));
+          if (hit && !orphan) {
+            orphan = child;
+            orphanSlotId = hit;
+          }
+        }
+        // A healthy property wins outright — never touch a Rem that already reads.
+        if (linked || !orphan || !orphanSlotId) continue;
+
+        const raw = (await readRawText(plugin, (orphan as any).backText)).trim();
+        if (!/^\d{1,3}$/.test(raw)) continue;
+        const storedValue = Math.min(100, Math.max(0, parseInt(raw, 10)));
+
+        // prioritySource / lastUpdated are hidden slots — they survived the
+        // migration, so the original provenance can be restored rather than
+        // every repaired card being stamped as a fresh manual edit.
+        let source: PrioritySource = 'manual';
+        let lastUpdated: number | null = null;
+        try {
+          const s = await rem.getPowerupProperty(CARD_PRIORITY_CODE, SOURCE_SLOT);
+          if (s === 'manual' || s === 'inherited' || s === 'default' || s === 'incremental') {
+            source = s;
+          }
+          const lu = await rem.getPowerupProperty(CARD_PRIORITY_CODE, LAST_UPDATED_SLOT);
+          const parsed = lu ? parseInt(String(lu), 10) : NaN;
+          if (!isNaN(parsed)) lastUpdated = parsed;
+        } catch {
+          /* fall back to 'manual', the conservative choice: it is never suppressed
+             by mayWriteCardPrioritySource and never silently dropped. */
+        }
+
+        if (!includeDerivable && (source === 'inherited' || source === 'default')) {
+          report.skippedDerivable++;
+          continue;
+        }
+
+        report.candidates++;
+
+        // What the app is using right now, for the record. ONLY for the handful
+        // of rows that get sampled: getCardPriority walks the ancestor chain, and
+        // firing that for thousands of candidates saturates the IPC bridge for no
+        // benefit — the repair itself does not depend on this value.
+        let currentValue: number | null = null;
+        if (report.samples.length < SAMPLE_CAP) {
+          try {
+            const { getCardPriority } = await import('./card_priority');
+            const info = await getCardPriority(plugin, rem);
+            currentValue = info?.priority ?? null;
+          } catch {
+            /* diagnostic only */
+          }
+        }
+
+        const candidate: RepairCandidate = {
+          remId: rem._id,
+          text: (await safeRemTextToString(plugin, rem.text)).slice(0, 120),
+          storedValue,
+          currentValue,
+          source,
+          lastUpdated,
+          orphanPropertyRemId: orphan._id,
+          orphanSlotId,
+        };
+        if (report.samples.length < SAMPLE_CAP) report.samples.push(candidate);
+        report.orphanPropertyRemIds.push(orphan._id);
+
+        if (dryRun) continue;
+
+        await setCardPriority(plugin, rem, storedValue, source, true);
+
+        // Restore the original timestamp: setCardPriority stamps Date.now(), but
+        // this is a repair, not an edit, and lastUpdated is how inheritance and
+        // the analytics decide precedence.
+        if (lastUpdated !== null) {
+          try {
+            await rem.setPowerupProperty(CARD_PRIORITY_CODE, LAST_UPDATED_SLOT, [String(lastUpdated)]);
+          } catch { /* non-fatal — the priority itself is what matters */ }
+        }
+
+        // Verify through the API that was broken. A write that does not read back
+        // means the repair does not work on this build and we must stop.
+        const check = await rem.getPowerupProperty(CARD_PRIORITY_CODE, PRIORITY_SLOT).catch(() => null);
+        if (check != null && String(check).trim() === String(storedValue)) {
+          report.repaired++;
+        } else {
+          report.failedVerification++;
+          if (report.failedVerification >= 5) {
+            stopped = true;
+            notes.push(
+              'ABORTED: 5 writes did not read back. The repair mechanism is not working ' +
+              'on this build — nothing further was attempted.'
+            );
+            break;
+          }
+        }
+      } catch (e: any) {
+        report.errors.push({ remId: rem._id, error: String(e?.message ?? e) });
+      }
+    }
+
+    onProgress?.(Math.min(i + BATCH_SIZE, rems.length), rems.length);
+  }
+
+  if (dryRun) {
+    notes.unshift('DRY RUN — nothing was written.');
+  }
+  if (!includeDerivable && report.skippedDerivable > 0) {
+    notes.push(
+      `${report.skippedDerivable} detached propert(ies) had a derivable source ` +
+      "('inherited'/'default') and were skipped; the plugin recomputes those from the " +
+      'ancestor cascade. Re-run with includeDerivable to restore them anyway.'
+    );
+  }
+  if (report.orphanPropertyRemIds.length > 0) {
+    notes.push(
+      `${report.orphanPropertyRemIds.length} orphaned property Rem(s) remain on their Rems ` +
+      'and will show as a stray "Unnamed — N" row. They are listed in orphanPropertyRemIds; ' +
+      'clean them only via the staged deletion test.'
+    );
+  }
+
+  report.durationMs = Date.now() - started;
+  logRepair(report);
+  return report;
+}
+
+// ── Deletion staging ────────────────────────────────────────────────────────
+
+export interface DeletionProbe {
+  orphanPropertyRemId: string;
+  ownerRemId: string | null;
+  ownerText: string | null;
+  /** Value the orphan was holding, captured before deletion so it can be restored by hand. */
+  storedValue: string | null;
+  ownerChildCountBefore: number | null;
+  ownerChildCountAfter: number | null;
+  /** The owner's CardPriority value read through the API, before and after. */
+  apiValueBefore: string | null;
+  apiValueAfter: string | null;
+  deleted: boolean;
+  error?: string;
+  verdict: string;
+}
+
+/**
+ * Deletes a SMALL, explicitly capped set of orphaned property Rems and records
+ * the owning Rem's state either side of each deletion.
+ *
+ * This exists so the bulk cleanup is never the first time a deletion is tried.
+ * The question it answers is narrow: does removing the mis-pointed property Rem
+ * leave the repaired priority intact, or does RemNote treat the two properties as
+ * one and take the good value with it?
+ *
+ * Run it only on Rems already repaired — the value must exist in its new, correct
+ * property before the old one is removed, or the deletion is destructive.
+ */
+export async function testDeleteOrphanProperties(
+  plugin: RNPlugin,
+  orphanPropertyRemIds: string[],
+  limit = 3
+): Promise<DeletionProbe[]> {
+  const probes: DeletionProbe[] = [];
+
+  for (const id of orphanPropertyRemIds.slice(0, limit)) {
+    const probe: DeletionProbe = {
+      orphanPropertyRemId: id,
+      ownerRemId: null,
+      ownerText: null,
+      storedValue: null,
+      ownerChildCountBefore: null,
+      ownerChildCountAfter: null,
+      apiValueBefore: null,
+      apiValueAfter: null,
+      deleted: false,
+      verdict: '',
+    };
+
+    try {
+      const orphan = await plugin.rem.findOne(id);
+      if (!orphan) {
+        probe.verdict = 'Property Rem not found — already gone?';
+        probes.push(probe);
+        continue;
+      }
+
+      probe.storedValue = await readRawText(plugin, (orphan as any).backText);
+
+      const owner = await orphan.getParentRem().catch(() => undefined);
+      if (!owner) {
+        probe.verdict = 'No parent Rem — refusing to delete something unattached.';
+        probes.push(probe);
+        continue;
+      }
+      probe.ownerRemId = owner._id;
+      probe.ownerText = (await safeRemTextToString(plugin, owner.text)).slice(0, 120);
+      probe.ownerChildCountBefore = ((await owner.getChildrenRem().catch(() => [])) || []).length;
+      probe.apiValueBefore =
+        (await owner.getPowerupProperty(CARD_PRIORITY_CODE, PRIORITY_SLOT).catch(() => null)) ?? null;
+
+      // Refuse if the good value is not in place — deleting would then be the only
+      // copy going away.
+      if (probe.apiValueBefore == null || String(probe.apiValueBefore).trim() === '') {
+        probe.verdict =
+          'REFUSED: the owner has no readable CardPriority value, so this orphan may hold ' +
+          'the only copy. Repair the Rem first, then delete.';
+        probes.push(probe);
+        continue;
+      }
+
+      await orphan.remove();
+      probe.deleted = true;
+
+      probe.ownerChildCountAfter = ((await owner.getChildrenRem().catch(() => [])) || []).length;
+      probe.apiValueAfter =
+        (await owner.getPowerupProperty(CARD_PRIORITY_CODE, PRIORITY_SLOT).catch(() => null)) ?? null;
+
+      if (probe.apiValueAfter != null && probe.apiValueAfter === probe.apiValueBefore) {
+        probe.verdict = 'OK — orphan removed, the repaired priority still reads correctly.';
+      } else {
+        probe.verdict =
+          `DANGER: the API value changed from ${probe.apiValueBefore} to ${probe.apiValueAfter}. ` +
+          'Deleting the orphan disturbed the good property. DO NOT run a bulk cleanup. ' +
+          `Restore by setting this Rem's priority back to ${probe.storedValue}.`;
+      }
+    } catch (e: any) {
+      probe.error = String(e?.message ?? e);
+      probe.verdict = `Threw: ${probe.error}`;
+    }
+
+    probes.push(probe);
+  }
+
+  console.log('\n========== ORPHAN DELETION TEST ==========');
+  console.table(
+    probes.map((p) => ({
+      orphan: p.orphanPropertyRemId,
+      owner: p.ownerRemId ?? '(none)',
+      held: p.storedValue ?? '',
+      'children before': p.ownerChildCountBefore ?? '',
+      'children after': p.ownerChildCountAfter ?? '',
+      'API before': p.apiValueBefore ?? '(empty)',
+      'API after': p.apiValueAfter ?? '(empty)',
+      deleted: p.deleted,
+    }))
+  );
+  for (const p of probes) console.log(`${p.orphanPropertyRemId}: ${p.verdict}`);
+  console.log('==========================================\n');
+
+  return probes;
+}
+
+function logRepair(report: RepairReport): void {
+  console.log('\n========== CARDPRIORITY REPAIR ==========');
+  console.log(report.dryRun ? 'DRY RUN — nothing written.' : 'LIVE RUN');
+  console.table([{
+    scanned: report.scanned,
+    candidates: report.candidates,
+    'skipped (derivable)': report.skippedDerivable,
+    repaired: report.repaired,
+    'failed verification': report.failedVerification,
+    errors: report.errors.length,
+    seconds: (report.durationMs / 1000).toFixed(1),
+  }]);
+  if (report.samples.length) {
+    console.log('\nSample of what is being restored (storedValue is the recovered value,');
+    console.log('currentValue is the wrong one the app is using now):');
+    console.table(report.samples.map((s) => ({
+      rem: s.text.slice(0, 50),
+      remId: s.remId,
+      restore: s.storedValue,
+      'currently': s.currentValue ?? '(none)',
+      source: s.source,
+      orphan: s.orphanPropertyRemId,
+    })));
+  }
+  if (report.errors.length) console.table(report.errors.slice(0, 20));
+  for (const n of report.notes) console.log(`NOTE: ${n}`);
+  console.log('=========================================\n');
+}

--- a/src/lib/raw_slot_scan.ts
+++ b/src/lib/raw_slot_scan.ts
@@ -1,0 +1,467 @@
+// KB-wide sizing scan for the post-overhaul slot damage.
+//
+// WHY THIS EXISTS
+// ---------------
+// lib/raw_slot_dump.ts explains one Rem in full detail. That proved WHAT is
+// broken but says nothing about HOW MUCH, and the two defects it uncovered have
+// very different consequences at scale:
+//
+//   1. DETACHED PRIORITY — the priority property's slot reference points at an
+//      orphaned, nameless slot Rem instead of the registered one. The value is
+//      still on the Rem, so this is recoverable: rewriting the priority creates a
+//      correctly-referenced property (confirmed on two Rems).
+//
+//   2. DANGLING DATE — the Next Rep Date property is correctly referenced, but
+//      the Daily Document it points at no longer exists. Nothing on the property
+//      can be recovered; only the plugin's own `nextRepMs` history stamp saves
+//      the schedule. This is the one that could represent real loss.
+//
+// The observed sample hinted that dangling dates correlate with how far ahead the
+// reference was written (a 30-day interval failed; two 1-day intervals survived),
+// which would mean empty future daily documents did not survive the migration.
+// The interval breakdown below tests that against the whole knowledge base rather
+// than three Rems.
+//
+// Covers BOTH priority powerups — Incremental and CardPriority — because they
+// share the display name "Priority" and the leading theory is that a name-keyed
+// migration step is what crossed the references over.
+//
+// READ-ONLY. Every call is a getter; nothing here writes.
+
+import { RNPlugin, PluginRem, BuiltInPowerupCodes } from '@remnote/plugin-sdk';
+import { powerupCode, prioritySlotCode, nextRepDateSlotCode, repHistorySlotCode } from './consts';
+import { CARD_PRIORITY_CODE, PRIORITY_SLOT } from './card_priority/types';
+import { safeRemTextToString } from './pdfUtils';
+import { getPowerupSlotByCodeSafe } from './powerup_slot_compat';
+import { refIdsIn, readRawText } from './raw_slot_dump';
+
+export interface ScanSample {
+  remId: string;
+  text: string;
+  /** The value found on the property, when there is one. */
+  storedValue: string | null;
+  /** The slot Rem the property actually references. */
+  pointsAt: string | null;
+  pointsAtName: string | null;
+}
+
+export interface PowerupScanResult {
+  label: string;
+  code: string;
+  /** Registered priority slot definition — the id a healthy property references. */
+  registeredSlotId: string | null;
+  /** Rems carrying this powerup. */
+  total: number;
+  /** Priority property present and referencing the registered slot. */
+  ok: number;
+  /** Priority property present but referencing an unregistered (orphan) slot. */
+  detached: number;
+  /** No priority property found at all — nothing was ever written, or it is gone. */
+  missing: number;
+  /** detached / total, as a percentage. */
+  detachedPct: number;
+  /** Which orphan slot Rems the detached properties point at, and how often. */
+  orphanTargets: Array<{ slotDefId: string; name: string; count: number }>;
+  samples: ScanSample[];
+}
+
+export interface DateScanResult {
+  /** Incremental Rems that have a Next Rep Date property at all. */
+  totalWithProperty: number;
+  /** Its Daily Document reference resolves. */
+  ok: number;
+  /** Its Daily Document reference points at a Rem that no longer exists. */
+  dangling: number;
+  /** Property present but holding no reference at all. */
+  empty: number;
+  danglingPct: number;
+  /**
+   * Dangling-vs-healthy split by the scheduling interval recorded in the Rem's
+   * last history entry — i.e. how far ahead the Daily Document reference was
+   * written. If short intervals survive and long ones do not, future-dated daily
+   * documents were pruned.
+   */
+  byInterval: Array<{ bucket: string; ok: number; dangling: number }>;
+  samples: ScanSample[];
+}
+
+export interface SlotScanReport {
+  exportedAt: string;
+  durationMs: number;
+  incremental: PowerupScanResult;
+  cardPriority: PowerupScanResult;
+  nextRepDate: DateScanResult;
+  /**
+   * Rems carrying BOTH powerups where a detached property was found. Both
+   * powerups' priority slots are displayed as "Priority" and a detached property
+   * no longer says which one it came from, so these are attributed on a
+   * best-effort basis and counted here so the ambiguity is visible.
+   */
+  ambiguousBothPowerups: number;
+  /** Orphan slot Rems present on the two powerup definitions. */
+  orphanSlotsOnDefinitions: Array<{ powerup: string; slotDefId: string; name: string }>;
+  notes: string[];
+}
+
+const SAMPLE_CAP = 20;
+const BATCH_SIZE = 200;
+
+const INTERVAL_BUCKETS: Array<{ bucket: string; test: (d: number) => boolean }> = [
+  { bucket: '0–1 days', test: (d) => d <= 1 },
+  { bucket: '2–7 days', test: (d) => d <= 7 },
+  { bucket: '8–30 days', test: (d) => d <= 30 },
+  { bucket: '31–90 days', test: (d) => d <= 90 },
+  { bucket: '90+ days', test: () => true },
+  { bucket: '(unknown)', test: () => true },
+];
+
+const bucketFor = (days: number | null): string => {
+  if (days == null || isNaN(days)) return '(unknown)';
+  return INTERVAL_BUCKETS.find((b) => b.bucket !== '(unknown)' && b.test(days))!.bucket;
+};
+
+/** Every slot-definition Rem hanging off a powerup, registered or not. */
+async function slotChildrenOf(
+  plugin: RNPlugin,
+  code: string
+): Promise<Array<{ id: string; name: string }>> {
+  const powerup = await plugin.powerup.getPowerupByCode(code).catch(() => undefined);
+  if (!powerup) return [];
+  const children = await powerup.getChildrenRem().catch(() => []);
+  const out: Array<{ id: string; name: string }> = [];
+  for (const child of children || []) {
+    if (!(await child.isPowerupSlot().catch(() => false))) continue;
+    out.push({ id: child._id, name: await safeRemTextToString(plugin, child.text) });
+  }
+  return out;
+}
+
+/**
+ * Scans the whole knowledge base and sizes both defects.
+ *
+ * @param onProgress Called as batches complete so the UI can show progress.
+ * @param analyzeIntervals Read each Rem's history to bucket dangling dates by
+ *        scheduling interval. Costs one extra property read per Incremental Rem;
+ *        it is what tests the "future daily documents were pruned" theory.
+ */
+export async function scanKbForDetachedSlots(
+  plugin: RNPlugin,
+  onProgress?: (done: number, total: number, phase: string) => void,
+  analyzeIntervals = true
+): Promise<SlotScanReport> {
+  const started = Date.now();
+  const notes: string[] = [];
+
+  // ── Slot definitions: which ids are legitimate, which are orphans ─────────
+  const [incSlotChildren, cardSlotChildren] = await Promise.all([
+    slotChildrenOf(plugin, powerupCode),
+    slotChildrenOf(plugin, CARD_PRIORITY_CODE),
+  ]);
+  const [incPrioritySlot, cardPrioritySlot, nextRepSlot] = await Promise.all([
+    getPowerupSlotByCodeSafe(plugin, powerupCode, prioritySlotCode),
+    getPowerupSlotByCodeSafe(plugin, CARD_PRIORITY_CODE, PRIORITY_SLOT),
+    getPowerupSlotByCodeSafe(plugin, powerupCode, nextRepDateSlotCode),
+  ]);
+  const incPriorityId = incPrioritySlot?._id ?? null;
+  const cardPriorityId = cardPrioritySlot?._id ?? null;
+  const nextRepId = nextRepSlot?._id ?? null;
+
+  // Names for every slot Rem we might see referenced, so orphans are identifiable.
+  const slotNameById = new Map<string, string>();
+  for (const s of [...incSlotChildren, ...cardSlotChildren]) slotNameById.set(s.id, s.name);
+
+  // The union of all slot Rems on both definitions. A property child references
+  // one of these; if it is not the registered priority slot, it is detached.
+  const allSlotIds = new Set<string>(slotNameById.keys());
+
+  const orphanSlotsOnDefinitions: SlotScanReport['orphanSlotsOnDefinitions'] = [];
+  for (const [label, children, registeredIds] of [
+    ['Incremental', incSlotChildren, [incPriorityId, nextRepId]],
+    ['CardPriority', cardSlotChildren, [cardPriorityId]],
+  ] as const) {
+    for (const c of children) {
+      // A slot child with no name is an orphan by definition; a named one that we
+      // cannot map back to a registered code is reported too, minus the ones we
+      // positively resolved.
+      const isNamedAndKnown = c.name && c.name !== 'Untitled' && c.name !== 'Missing Name';
+      if (!isNamedAndKnown && !registeredIds.includes(c.id)) {
+        orphanSlotsOnDefinitions.push({ powerup: label, slotDefId: c.id, name: c.name || '(unnamed)' });
+      }
+    }
+  }
+
+  if (!incPriorityId) notes.push('Incremental priority slot could not be resolved — its counts are unreliable.');
+  if (!cardPriorityId) notes.push('CardPriority priority slot could not be resolved — its counts are unreliable.');
+
+  // ── Gather the populations ────────────────────────────────────────────────
+  const incPowerup = await plugin.powerup.getPowerupByCode(powerupCode).catch(() => undefined);
+  const cardPowerup = await plugin.powerup.getPowerupByCode(CARD_PRIORITY_CODE).catch(() => undefined);
+  const incRems = ((await incPowerup?.taggedRem().catch(() => [])) || []) as PluginRem[];
+  const cardRems = ((await cardPowerup?.taggedRem().catch(() => [])) || []) as PluginRem[];
+
+  const incIds = new Set(incRems.map((r) => r._id));
+
+  const mkResult = (label: string, code: string, registeredSlotId: string | null): PowerupScanResult => ({
+    label, code, registeredSlotId,
+    total: 0, ok: 0, detached: 0, missing: 0, detachedPct: 0,
+    orphanTargets: [], samples: [],
+  });
+  const incremental = mkResult('Incremental', powerupCode, incPriorityId);
+  const cardPriority = mkResult('CardPriority', CARD_PRIORITY_CODE, cardPriorityId);
+  const nextRepDate: DateScanResult = {
+    totalWithProperty: 0, ok: 0, dangling: 0, empty: 0, danglingPct: 0,
+    byInterval: [], samples: [],
+  };
+  let ambiguousBothPowerups = 0;
+
+  const orphanCounts = new Map<string, Map<string, number>>([
+    [powerupCode, new Map()],
+    [CARD_PRIORITY_CODE, new Map()],
+  ]);
+  // Daily Document targets repeat across many Rems — resolve each id once.
+  const refExistsCache = new Map<string, boolean>();
+  const intervalTally = new Map<string, { ok: number; dangling: number }>();
+
+  /** Classify one Rem's priority property for one powerup. */
+  const classifyPriority = async (
+    rem: PluginRem,
+    children: PluginRem[],
+    registeredId: string | null,
+    result: PowerupScanResult,
+    code: string
+  ): Promise<'ok' | 'detached' | 'missing'> => {
+    let linked: PluginRem | null = null;
+    let detachedChild: PluginRem | null = null;
+    let detachedTarget: string | null = null;
+
+    for (const child of children) {
+      const refs = refIdsIn(child.text);
+      if (!refs.length) continue;
+      if (registeredId && refs.includes(registeredId)) {
+        linked = child;
+        break;
+      }
+      // References a slot Rem that exists on one of the two definitions but is
+      // NOT the registered priority slot — the detached signature.
+      const orphanRef = refs.find((id) => allSlotIds.has(id) && id !== nextRepId);
+      if (orphanRef && !detachedChild) {
+        detachedChild = child;
+        detachedTarget = orphanRef;
+      }
+    }
+
+    if (linked) {
+      const value = await readRawText(plugin, (linked as any).backText);
+      if (value.trim() !== '') {
+        result.ok++;
+        return 'ok';
+      }
+      // Linked but empty — nothing stored, not a detachment.
+      result.missing++;
+      return 'missing';
+    }
+
+    if (detachedChild && detachedTarget) {
+      const value = await readRawText(plugin, (detachedChild as any).backText);
+      // Only count it as a stranded priority if it actually holds a number;
+      // otherwise it is some other slot's property and says nothing about this one.
+      if (/^\s*\d{1,3}\s*$/.test(value)) {
+        result.detached++;
+        const tally = orphanCounts.get(code)!;
+        tally.set(detachedTarget, (tally.get(detachedTarget) || 0) + 1);
+        if (result.samples.length < SAMPLE_CAP) {
+          result.samples.push({
+            remId: rem._id,
+            text: (await safeRemTextToString(plugin, rem.text)).slice(0, 120),
+            storedValue: value.trim(),
+            pointsAt: detachedTarget,
+            pointsAtName: slotNameById.get(detachedTarget) || '(unnamed)',
+          });
+        }
+        return 'detached';
+      }
+    }
+
+    result.missing++;
+    return 'missing';
+  };
+
+  // ── Pass 1: Incremental ───────────────────────────────────────────────────
+  incremental.total = incRems.length;
+  for (let i = 0; i < incRems.length; i += BATCH_SIZE) {
+    const batch = incRems.slice(i, i + BATCH_SIZE);
+    await Promise.all(
+      batch.map(async (rem) => {
+        const children = ((await rem.getChildrenRem().catch(() => [])) || []) as PluginRem[];
+        const verdict = await classifyPriority(rem, children, incPriorityId, incremental, powerupCode);
+        if (verdict === 'detached' && (await rem.hasPowerup(CARD_PRIORITY_CODE).catch(() => false))) {
+          ambiguousBothPowerups++;
+        }
+
+        // Next Rep Date — Incremental only.
+        const dateChild = children.find((c) => nextRepId && refIdsIn(c.text).includes(nextRepId));
+        if (!dateChild) return;
+        nextRepDate.totalWithProperty++;
+
+        const targets = refIdsIn((dateChild as any).backText);
+        if (targets.length === 0) {
+          nextRepDate.empty++;
+          return;
+        }
+
+        let exists = false;
+        for (const id of targets) {
+          let cached = refExistsCache.get(id);
+          if (cached === undefined) {
+            cached = !!(await plugin.rem.findOne(id).catch(() => undefined));
+            refExistsCache.set(id, cached);
+          }
+          if (cached) exists = true;
+        }
+
+        // Interval from the last history entry = how far ahead the reference was
+        // written. The correlation this exposes is the point of the whole scan.
+        let intervalDays: number | null = null;
+        if (analyzeIntervals) {
+          try {
+            const raw = await rem.getPowerupProperty(powerupCode, repHistorySlotCode);
+            const hist = raw ? JSON.parse(String(raw)) : null;
+            if (Array.isArray(hist)) {
+              for (let k = hist.length - 1; k >= 0; k--) {
+                if (typeof hist[k]?.interval === 'number') {
+                  intervalDays = hist[k].interval;
+                  break;
+                }
+              }
+            }
+          } catch {
+            /* unreadable history — bucketed as unknown */
+          }
+        }
+        const bucket = bucketFor(intervalDays);
+        const tally = intervalTally.get(bucket) || { ok: 0, dangling: 0 };
+        if (exists) {
+          nextRepDate.ok++;
+          tally.ok++;
+        } else {
+          nextRepDate.dangling++;
+          tally.dangling++;
+          if (nextRepDate.samples.length < SAMPLE_CAP) {
+            nextRepDate.samples.push({
+              remId: rem._id,
+              text: (await safeRemTextToString(plugin, rem.text)).slice(0, 120),
+              storedValue: intervalDays != null ? `interval ${intervalDays}d` : null,
+              pointsAt: targets[0] ?? null,
+              pointsAtName: '(missing Daily Document)',
+            });
+          }
+        }
+        intervalTally.set(bucket, tally);
+      })
+    );
+    onProgress?.(Math.min(i + BATCH_SIZE, incRems.length), incRems.length, 'Incremental');
+  }
+
+  // ── Pass 2: CardPriority ──────────────────────────────────────────────────
+  cardPriority.total = cardRems.length;
+  for (let i = 0; i < cardRems.length; i += BATCH_SIZE) {
+    const batch = cardRems.slice(i, i + BATCH_SIZE);
+    await Promise.all(
+      batch.map(async (rem) => {
+        const children = ((await rem.getChildrenRem().catch(() => [])) || []) as PluginRem[];
+        const verdict = await classifyPriority(rem, children, cardPriorityId, cardPriority, CARD_PRIORITY_CODE);
+        if (verdict === 'detached' && incIds.has(rem._id)) ambiguousBothPowerups++;
+      })
+    );
+    onProgress?.(Math.min(i + BATCH_SIZE, cardRems.length), cardRems.length, 'CardPriority');
+  }
+
+  // ── Finalise ──────────────────────────────────────────────────────────────
+  const pct = (n: number, d: number) => (d === 0 ? 0 : Math.round((n / d) * 1000) / 10);
+  incremental.detachedPct = pct(incremental.detached, incremental.total);
+  cardPriority.detachedPct = pct(cardPriority.detached, cardPriority.total);
+  nextRepDate.danglingPct = pct(nextRepDate.dangling, nextRepDate.totalWithProperty);
+
+  for (const [code, result] of [[powerupCode, incremental], [CARD_PRIORITY_CODE, cardPriority]] as const) {
+    result.orphanTargets = Array.from(orphanCounts.get(code)!.entries())
+      .map(([slotDefId, count]) => ({ slotDefId, name: slotNameById.get(slotDefId) || '(unnamed)', count }))
+      .sort((a, b) => b.count - a.count);
+  }
+
+  nextRepDate.byInterval = INTERVAL_BUCKETS.map((b) => b.bucket)
+    .filter((bucket, idx, arr) => arr.indexOf(bucket) === idx)
+    .map((bucket) => ({ bucket, ...(intervalTally.get(bucket) || { ok: 0, dangling: 0 }) }))
+    .filter((row) => row.ok > 0 || row.dangling > 0);
+
+  if (ambiguousBothPowerups > 0) {
+    notes.push(
+      `${ambiguousBothPowerups} Rem(s) carry both powerups and had a detached property. ` +
+      'A detached property no longer records which powerup it belonged to, so those are ' +
+      'attributed best-effort and may be counted under either.'
+    );
+  }
+
+  const report: SlotScanReport = {
+    exportedAt: new Date().toISOString(),
+    durationMs: Date.now() - started,
+    incremental,
+    cardPriority,
+    nextRepDate,
+    ambiguousBothPowerups,
+    orphanSlotsOnDefinitions,
+    notes,
+  };
+
+  logSlotScan(report);
+  return report;
+}
+
+/** Console summary, shaped for pasting into the support ticket. */
+export function logSlotScan(report: SlotScanReport): void {
+  console.log('\n========== KB-WIDE SLOT DAMAGE SCAN ==========');
+  console.log(`Took ${(report.durationMs / 1000).toFixed(1)}s\n`);
+
+  console.log('--- Priority slot health ---');
+  console.table(
+    [report.incremental, report.cardPriority].map((r) => ({
+      powerup: r.label,
+      total: r.total,
+      OK: r.ok,
+      DETACHED: r.detached,
+      'no value': r.missing,
+      'detached %': `${r.detachedPct}%`,
+      registeredSlot: r.registeredSlotId ?? '(unresolved)',
+    }))
+  );
+
+  for (const r of [report.incremental, report.cardPriority]) {
+    if (r.orphanTargets.length) {
+      console.log(`\n${r.label} — orphan slots the detached properties point at:`);
+      console.table(r.orphanTargets);
+    }
+  }
+
+  console.log('\n--- Next Rep Date (Daily Document references) ---');
+  console.table([{
+    'with property': report.nextRepDate.totalWithProperty,
+    OK: report.nextRepDate.ok,
+    DANGLING: report.nextRepDate.dangling,
+    'no reference': report.nextRepDate.empty,
+    'dangling %': `${report.nextRepDate.danglingPct}%`,
+  }]);
+
+  if (report.nextRepDate.byInterval.length) {
+    console.log('\nBy scheduling interval — does failure track how far ahead the reference was written?');
+    console.table(report.nextRepDate.byInterval);
+    console.log('If dangling is concentrated in the longer buckets, future-dated daily');
+    console.log('documents did not survive the migration.');
+  }
+
+  if (report.orphanSlotsOnDefinitions.length) {
+    console.log('\n--- Orphan slot Rems on the powerup definitions ---');
+    console.table(report.orphanSlotsOnDefinitions);
+  }
+
+  for (const n of report.notes) console.log(`NOTE: ${n}`);
+  console.log('==============================================\n');
+}

--- a/src/lib/raw_slot_scan.ts
+++ b/src/lib/raw_slot_scan.ts
@@ -30,7 +30,7 @@
 
 import { RNPlugin, PluginRem, BuiltInPowerupCodes } from '@remnote/plugin-sdk';
 import { powerupCode, prioritySlotCode, nextRepDateSlotCode, repHistorySlotCode } from './consts';
-import { CARD_PRIORITY_CODE, PRIORITY_SLOT } from './card_priority/types';
+import { CARD_PRIORITY_CODE, PRIORITY_SLOT, SOURCE_SLOT, PrioritySource } from './card_priority/types';
 import { safeRemTextToString } from './pdfUtils';
 import { getPowerupSlotByCodeSafe } from './powerup_slot_compat';
 import { refIdsIn, readRawText } from './raw_slot_dump';
@@ -76,13 +76,67 @@ export interface DateScanResult {
   empty: number;
   danglingPct: number;
   /**
+   * Of the dangling ones, how many still carry a `nextRepMs` stamp in their own
+   * history. That stamp is the only surviving record of the date the deleted
+   * Daily Document encoded, so it is exactly what a repair would rebuild from —
+   * these are recoverable.
+   */
+  danglingRecoverable: number;
+  /** Dangling with no `nextRepMs` anywhere in history: the date is genuinely gone. */
+  danglingUnrecoverable: number;
+  /** danglingRecoverable / dangling, as a percentage. */
+  recoverablePct: number;
+  /**
    * Dangling-vs-healthy split by the scheduling interval recorded in the Rem's
    * last history entry — i.e. how far ahead the Daily Document reference was
    * written. If short intervals survive and long ones do not, future-dated daily
-   * documents were pruned.
+   * documents were pruned. `recoverable` is the repairable subset of `dangling`.
    */
-  byInterval: Array<{ bucket: string; ok: number; dangling: number }>;
+  byInterval: Array<{ bucket: string; ok: number; dangling: number; recoverable: number }>;
   samples: ScanSample[];
+  /** The cases a repair could NOT fix — the ones actually worth worrying about. */
+  unrecoverableSamples: ScanSample[];
+}
+
+/**
+ * A priority property Rem left behind on a Rem whose priority now reads fine.
+ * Invisible to a readability check, but visible to the user as a stray
+ * "Unnamed — N" row in the outliner.
+ */
+export interface LeftoverProperty {
+  propertyRemId: string;
+  ownerRemId: string;
+  value: string;
+  slotId: string;
+  slotName: string;
+  /**
+   * - `ours`        — the slot Rem is a child of Incremental or CardPriority.
+   * - `deleted-slot`— the slot Rem no longer exists.
+   * - `foreign`     — the slot belongs to some other powerup, so this is somebody
+   *                   else's property and NOT litter. Reported, never counted.
+   */
+  category: 'ours' | 'deleted-slot' | 'foreign';
+  /**
+   * Whether the owning Rem's priority reads correctly through the API right now.
+   *
+   * This is the safety flag for any cleanup:
+   *  - `true`  — the good value lives elsewhere, so this really is litter.
+   *  - `false` — nothing readable on the Rem, so this property may hold the ONLY
+   *              surviving copy of that priority. It must be recovered, never
+   *              deleted.
+   */
+  ownerPriorityReadable: boolean;
+  /**
+   * The owning Rem's CardPriority `prioritySource`, read from its (hidden, and
+   * therefore undamaged) slot. Only populated for stranded leftovers, since it is
+   * what decides their fate:
+   *
+   *  - `manual` / `incremental` — the number carries information nothing else
+   *    holds. RECOVER it.
+   *  - `inherited` / `default`  — derivable; the plugin recomputes it from the
+   *    ancestor cascade, so the leftover is redundant and safe to delete.
+   */
+  ownerSource: PrioritySource | null;
 }
 
 export interface SlotScanReport {
@@ -100,6 +154,54 @@ export interface SlotScanReport {
   ambiguousBothPowerups: number;
   /** Orphan slot Rems present on the two powerup definitions. */
   orphanSlotsOnDefinitions: Array<{ powerup: string; slotDefId: string; name: string }>;
+  /**
+   * Leftover priority property Rems — counted regardless of whether the owning
+   * Rem's priority reads correctly. This is the litter a cleanup pass would
+   * target, and it is deliberately measured separately from `detached`: a Rem can
+   * be perfectly readable and still be carrying one.
+   */
+  leftoverCount: number;
+  /** Leftovers whose owning Rem reads fine — genuine litter, safe to delete. */
+  leftoverSafeToDelete: number;
+  /**
+   * Leftovers on Rems with NO readable priority: this property is the only
+   * surviving copy. These must be RECOVERED (rewritten through the normal path),
+   * never deleted, and they explain part of the `missing` counts above.
+   */
+  leftoverStranded: number;
+  /**
+   * Of the stranded ones, those whose CardPriority source is `manual` or
+   * `incremental` (or unreadable) — the value is real and must be written back.
+   */
+  strandedNeedsRecovery: number;
+  /**
+   * Stranded but `inherited`/`default`: the plugin recomputes those from the
+   * ancestor cascade, so the leftover is redundant and safe to delete.
+   */
+  strandedDiscardable: number;
+  /** Full breakdown of the stranded set by source, with the action each implies. */
+  strandedBySource: Array<{ source: string; count: number; action: 'recover' | 'discardable' }>;
+  /**
+   * Leftovers whose owner's priority slot READS — i.e. the value is materialised
+   * where it belongs and the orphan is genuinely redundant. This is the correct
+   * input to a cleanup: it is derived from the current state, so it updates
+   * automatically once something (a repair, or "Update all inherited Card
+   * Priorities") has populated the slots.
+   */
+  safeToDeleteAll: LeftoverProperty[];
+  /** The stranded ones, for inspection before anything is written. */
+  strandedSamples: LeftoverProperty[];
+  /**
+   * EVERY stranded leftover, uncapped. This is the authoritative work list — the
+   * repair consumes it directly rather than re-deriving the predicate, because
+   * two independent implementations of "is this a stranded priority" disagreed
+   * three times running (324 vs 375) and each disagreement cost a debugging
+   * round. One predicate, two consumers.
+   */
+  strandedAll: LeftoverProperty[];
+  /** Which slot Rems the leftovers point at, and how many each. */
+  leftoverSlots: Array<{ slotId: string; name: string; count: number; category: LeftoverProperty['category'] }>;
+  leftoverSamples: LeftoverProperty[];
   notes: string[];
 }
 
@@ -210,8 +312,10 @@ export async function scanKbForDetachedSlots(
   const cardPriority = mkResult('CardPriority', CARD_PRIORITY_CODE, cardPriorityId);
   const nextRepDate: DateScanResult = {
     totalWithProperty: 0, ok: 0, dangling: 0, empty: 0, danglingPct: 0,
-    byInterval: [], samples: [],
+    danglingRecoverable: 0, danglingUnrecoverable: 0, recoverablePct: 0,
+    byInterval: [], samples: [], unrecoverableSamples: [],
   };
+  const recoverableByBucket = new Map<string, number>();
   let ambiguousBothPowerups = 0;
 
   const orphanCounts = new Map<string, Map<string, number>>([
@@ -220,6 +324,48 @@ export async function scanKbForDetachedSlots(
   ]);
   // Daily Document targets repeat across many Rems — resolve each id once.
   const refExistsCache = new Map<string, boolean>();
+
+  // Slot ids a healthy priority property is allowed to reference. Anything else
+  // carrying a bare number is a leftover.
+  const registeredSlotIds = new Set<string>(
+    [incPriorityId, cardPriorityId, nextRepId].filter((id): id is string => !!id)
+  );
+  // Leftover property Rems, keyed by property Rem id so a Rem carrying both
+  // powerups (scanned twice) cannot double-count.
+  const leftovers = new Map<string, LeftoverProperty>();
+
+  // Identifying a leftover needs the slot's IDENTITY, not just "is it one of the
+  // three ids we resolved". A first cut used that cheaper test and reported 12,793
+  // leftovers — almost all of them legitimate properties of OTHER powerups
+  // (built-in ones included), betrayed by values like 214 and 238 that cannot be
+  // priorities. A property is only ours if the slot Rem it references is a child
+  // of one of OUR two powerup definitions, or has vanished entirely.
+  const ourPowerupIds = new Set<string>(
+    [incPowerup?._id, cardPowerup?._id].filter((id): id is string => !!id)
+  );
+  type SlotInfo = { exists: boolean; name: string; isSlot: boolean; ours: boolean };
+  const slotInfoCache = new Map<string, SlotInfo>();
+  const resolveSlotInfo = async (id: string): Promise<SlotInfo> => {
+    const hit = slotInfoCache.get(id);
+    if (hit) return hit;
+    let info: SlotInfo = { exists: false, name: '', isSlot: false, ours: false };
+    try {
+      const slotRem = await plugin.rem.findOne(id);
+      if (slotRem) {
+        const parent = await slotRem.getParentRem().catch(() => undefined);
+        info = {
+          exists: true,
+          name: await safeRemTextToString(plugin, slotRem.text),
+          isSlot: await slotRem.isPowerupSlot().catch(() => false),
+          ours: !!parent && ourPowerupIds.has(parent._id),
+        };
+      }
+    } catch {
+      /* treat as non-existent */
+    }
+    slotInfoCache.set(id, info);
+    return info;
+  };
   const intervalTally = new Map<string, { ok: number; dangling: number }>();
 
   /** Classify one Rem's priority property for one powerup. */
@@ -233,13 +379,22 @@ export async function scanKbForDetachedSlots(
     let linked: PluginRem | null = null;
     let detachedChild: PluginRem | null = null;
     let detachedTarget: string | null = null;
+    // Leftovers found on THIS Rem in this pass, so the owner's readability can be
+    // stamped onto them once it is known. That flag is what separates litter that
+    // is safe to delete from a value that is the only remaining copy.
+    const leftoversHere: string[] = [];
 
     for (const child of children) {
       const refs = refIdsIn(child.text);
       if (!refs.length) continue;
       if (registeredId && refs.includes(registeredId)) {
+        // Do NOT break here. A Rem whose priority reads perfectly can still be
+        // carrying a leftover property Rem from the migration — the user sees it
+        // as a stray "Unnamed — N" row. Breaking on the healthy one made those
+        // invisible to this scan, which measured readability and silently
+        // reported litter as clean.
         linked = child;
-        break;
+        continue;
       }
       // References a slot Rem that exists on one of the two definitions but is
       // NOT the registered priority slot — the detached signature.
@@ -248,11 +403,58 @@ export async function scanKbForDetachedSlots(
         detachedChild = child;
         detachedTarget = orphanRef;
       }
+
+      // Leftover detection, independent of readability: a Rem whose priority
+      // reads fine can still carry an abandoned property from the migration, and
+      // a write has been observed to strand the old one on a brand-new unnamed
+      // slot Rem (JF0lnO7kCGbDrHRrt), so membership of the known orphan list is
+      // not sufficient either.
+      //
+      // The property must be OURS, which means the slot it references either
+      // belongs to one of our two powerup definitions or no longer exists.
+      // Without that test this flags every numeric property of every other
+      // powerup in the knowledge base.
+      if (
+        refs.length === 1 &&
+        !registeredSlotIds.has(refs[0]) &&
+        !leftovers.has(child._id)
+      ) {
+        const v = (await readRawText(plugin, (child as any).backText)).trim();
+        // Priorities are 0–100. A wider pattern lets page numbers and similar
+        // three-digit metadata in.
+        const looksLikePriority = /^\d{1,3}$/.test(v) && Number(v) <= 100;
+        if (looksLikePriority) {
+          const info = await resolveSlotInfo(refs[0]);
+          // Record every candidate, but CLASSIFY it. Silently dropping the
+          // foreign ones would hide the case that matters most: a leftover whose
+          // slot Rem sits outside both powerup definitions.
+          const category: LeftoverProperty['category'] =
+            !info.exists ? 'deleted-slot' : info.ours ? 'ours' : 'foreign';
+          leftovers.set(child._id, {
+            propertyRemId: child._id,
+            ownerRemId: rem._id,
+            value: v,
+            slotId: refs[0],
+            slotName: !info.exists ? '(slot Rem deleted)' : info.name || '(unnamed)',
+            category,
+            ownerPriorityReadable: false,
+            ownerSource: null,
+          });
+          if (category !== 'foreign') leftoversHere.push(child._id);
+        }
+      }
     }
 
     if (linked) {
       const value = await readRawText(plugin, (linked as any).backText);
       if (value.trim() !== '') {
+        // Mark this Rem's leftovers as safe to remove: the value survives on a
+        // properly linked property. A Rem carrying both powerups is scanned
+        // twice, and one readable powerup is enough — hence set, never unset.
+        for (const id of leftoversHere) {
+          const l = leftovers.get(id);
+          if (l) l.ownerPriorityReadable = true;
+        }
         result.ok++;
         return 'ok';
       }
@@ -321,21 +523,29 @@ export async function scanKbForDetachedSlots(
 
         // Interval from the last history entry = how far ahead the reference was
         // written. The correlation this exposes is the point of the whole scan.
+        //
+        // The same read also answers the question a date repair depends on: is
+        // there a `nextRepMs` stamp to rebuild the Daily Document reference from?
+        // A dangling date with no stamp cannot be recovered from the Rem at all.
         let intervalDays: number | null = null;
+        let recoverableMs: number | null = null;
         if (analyzeIntervals) {
           try {
             const raw = await rem.getPowerupProperty(powerupCode, repHistorySlotCode);
             const hist = raw ? JSON.parse(String(raw)) : null;
             if (Array.isArray(hist)) {
               for (let k = hist.length - 1; k >= 0; k--) {
-                if (typeof hist[k]?.interval === 'number') {
+                if (intervalDays === null && typeof hist[k]?.interval === 'number') {
                   intervalDays = hist[k].interval;
-                  break;
                 }
+                if (recoverableMs === null && typeof hist[k]?.nextRepMs === 'number') {
+                  recoverableMs = hist[k].nextRepMs;
+                }
+                if (intervalDays !== null && recoverableMs !== null) break;
               }
             }
           } catch {
-            /* unreadable history — bucketed as unknown */
+            /* unreadable history — bucketed as unknown, and unrecoverable */
           }
         }
         const bucket = bucketFor(intervalDays);
@@ -346,6 +556,24 @@ export async function scanKbForDetachedSlots(
         } else {
           nextRepDate.dangling++;
           tally.dangling++;
+          // Can a repair rebuild this date? Only if the Rem's own history still
+          // carries the timestamp the reference was supposed to encode.
+          if (recoverableMs !== null) {
+            nextRepDate.danglingRecoverable++;
+            const b = bucketFor(intervalDays);
+            recoverableByBucket.set(b, (recoverableByBucket.get(b) || 0) + 1);
+          } else {
+            nextRepDate.danglingUnrecoverable++;
+            if (nextRepDate.unrecoverableSamples.length < SAMPLE_CAP) {
+              nextRepDate.unrecoverableSamples.push({
+                remId: rem._id,
+                text: (await safeRemTextToString(plugin, rem.text)).slice(0, 120),
+                storedValue: null,
+                pointsAt: targets[0] ?? null,
+                pointsAtName: '(missing Daily Document, no nextRepMs in history)',
+              });
+            }
+          }
           if (nextRepDate.samples.length < SAMPLE_CAP) {
             nextRepDate.samples.push({
               remId: rem._id,
@@ -376,6 +604,66 @@ export async function scanKbForDetachedSlots(
     onProgress?.(Math.min(i + BATCH_SIZE, cardRems.length), cardRems.length, 'CardPriority');
   }
 
+  // ── Stranded leftovers: recover or discard? ───────────────────────────────
+  //
+  // A stranded leftover holds the only surviving copy of a priority — but that
+  // only matters if the value carried information in the first place. The
+  // CardPriority `prioritySource` slot is hidden, so it survived the migration
+  // intact and can still say which:
+  //
+  //   manual / incremental — a deliberate value. Nothing else holds it. RECOVER.
+  //   inherited / default  — derived from the ancestor cascade, which the plugin
+  //                          recomputes on demand. The leftover adds nothing and
+  //                          can simply be deleted.
+  //
+  // Splitting these is what turns "375 stranded values" into a much smaller set
+  // that actually needs writing.
+  const sourceByOwner = new Map<string, PrioritySource | null>();
+  for (const l of leftovers.values()) {
+    if (l.category === 'foreign' || l.ownerPriorityReadable) continue;
+    let source = sourceByOwner.get(l.ownerRemId);
+    if (source === undefined) {
+      source = null;
+      try {
+        const owner = await plugin.rem.findOne(l.ownerRemId);
+        const raw = owner
+          ? await owner.getPowerupProperty(CARD_PRIORITY_CODE, SOURCE_SLOT).catch(() => null)
+          : null;
+        if (raw === 'manual' || raw === 'inherited' || raw === 'default' || raw === 'incremental') {
+          source = raw;
+        }
+      } catch {
+        /* leave null — reported as unknown, and treated as needing recovery */
+      }
+      sourceByOwner.set(l.ownerRemId, source);
+    }
+    l.ownerSource = source;
+  }
+
+  const strandedList = Array.from(leftovers.values()).filter(
+    (l) => l.category !== 'foreign' && !l.ownerPriorityReadable
+  );
+  const isDerivable = (s: PrioritySource | null) => s === 'inherited' || s === 'default';
+  // Unknown source counts as needing recovery: the conservative direction, since
+  // the cost of a redundant write is nothing and the cost of a wrong delete is a
+  // lost priority.
+  const strandedNeedsRecovery = strandedList.filter((l) => !isDerivable(l.ownerSource));
+  const strandedDiscardable = strandedList.filter((l) => isDerivable(l.ownerSource));
+
+  const strandedBySource = Array.from(
+    strandedList.reduce((m, l) => {
+      const key = l.ownerSource ?? '(unreadable)';
+      m.set(key, (m.get(key) || 0) + 1);
+      return m;
+    }, new Map<string, number>())
+  )
+    .map(([source, count]) => ({
+      source,
+      count,
+      action: isDerivable(source as PrioritySource) ? ('discardable' as const) : ('recover' as const),
+    }))
+    .sort((a, b) => b.count - a.count);
+
   // ── Finalise ──────────────────────────────────────────────────────────────
   const pct = (n: number, d: number) => (d === 0 ? 0 : Math.round((n / d) * 1000) / 10);
   incremental.detachedPct = pct(incremental.detached, incremental.total);
@@ -388,9 +676,14 @@ export async function scanKbForDetachedSlots(
       .sort((a, b) => b.count - a.count);
   }
 
+  nextRepDate.recoverablePct = pct(nextRepDate.danglingRecoverable, nextRepDate.dangling);
   nextRepDate.byInterval = INTERVAL_BUCKETS.map((b) => b.bucket)
     .filter((bucket, idx, arr) => arr.indexOf(bucket) === idx)
-    .map((bucket) => ({ bucket, ...(intervalTally.get(bucket) || { ok: 0, dangling: 0 }) }))
+    .map((bucket) => ({
+      bucket,
+      ...(intervalTally.get(bucket) || { ok: 0, dangling: 0 }),
+      recoverable: recoverableByBucket.get(bucket) || 0,
+    }))
     .filter((row) => row.ok > 0 || row.dangling > 0);
 
   if (ambiguousBothPowerups > 0) {
@@ -409,6 +702,35 @@ export async function scanKbForDetachedSlots(
     nextRepDate,
     ambiguousBothPowerups,
     orphanSlotsOnDefinitions,
+    // Only `ours` and `deleted-slot` are litter. `foreign` rows are other
+    // powerups' legitimate properties and are reported for transparency only.
+    leftoverCount: Array.from(leftovers.values()).filter((l) => l.category !== 'foreign').length,
+    leftoverSlots: Array.from(
+      Array.from(leftovers.values()).reduce((m, l) => {
+        const cur =
+          m.get(l.slotId) || { slotId: l.slotId, name: l.slotName, count: 0, category: l.category };
+        cur.count++;
+        m.set(l.slotId, cur);
+        return m;
+      }, new Map<string, { slotId: string; name: string; count: number; category: LeftoverProperty['category'] }>())
+        .values()
+    ).sort((a, b) => b.count - a.count),
+    leftoverSamples: Array.from(leftovers.values())
+      .filter((l) => l.category !== 'foreign')
+      .slice(0, SAMPLE_CAP),
+    leftoverSafeToDelete: Array.from(leftovers.values()).filter(
+      (l) => l.category !== 'foreign' && l.ownerPriorityReadable
+    ).length,
+    leftoverStranded: strandedList.length,
+    strandedNeedsRecovery: strandedNeedsRecovery.length,
+    strandedDiscardable: strandedDiscardable.length,
+    strandedBySource,
+    // Sample the ones that actually need writing, not the discardable majority.
+    strandedSamples: strandedNeedsRecovery.slice(0, SAMPLE_CAP),
+    strandedAll: strandedList,
+    safeToDeleteAll: Array.from(leftovers.values()).filter(
+      (l) => l.category !== 'foreign' && l.ownerPriorityReadable
+    ),
     notes,
   };
 
@@ -448,7 +770,14 @@ export function logSlotScan(report: SlotScanReport): void {
     DANGLING: report.nextRepDate.dangling,
     'no reference': report.nextRepDate.empty,
     'dangling %': `${report.nextRepDate.danglingPct}%`,
+    'recoverable from history': report.nextRepDate.danglingRecoverable,
+    'UNRECOVERABLE': report.nextRepDate.danglingUnrecoverable,
+    'recoverable %': `${report.nextRepDate.recoverablePct}%`,
   }]);
+  if (report.nextRepDate.danglingUnrecoverable > 0) {
+    console.log('\nDangling dates with NO nextRepMs in history — a repair cannot rebuild these:');
+    console.table(report.nextRepDate.unrecoverableSamples);
+  }
 
   if (report.nextRepDate.byInterval.length) {
     console.log('\nBy scheduling interval — does failure track how far ahead the reference was written?');
@@ -460,6 +789,31 @@ export function logSlotScan(report: SlotScanReport): void {
   if (report.orphanSlotsOnDefinitions.length) {
     console.log('\n--- Orphan slot Rems on the powerup definitions ---');
     console.table(report.orphanSlotsOnDefinitions);
+  }
+
+  console.log(`\n--- Leftover priority properties: ${report.leftoverCount} ---`);
+  console.log('(rows below marked "foreign" are other powerups\' legitimate properties');
+  console.log(' and are NOT included in that count — shown so the filter is auditable)');
+  if (report.leftoverSlots.length > 0) {
+    console.log('These sit on Rems whose priority reads CORRECTLY, so they do not appear');
+    console.log('in the detached counts above. The user sees each one as a stray');
+    console.log('"Unnamed — N" row. This is what a cleanup pass would remove.');
+    console.table(report.leftoverSlots);
+    console.log(
+      `  safe to delete (owner reads fine): ${report.leftoverSafeToDelete}` +
+      `   |   STRANDED (only surviving copy): ${report.leftoverStranded}`
+    );
+    if (report.leftoverStranded > 0) {
+      console.log(
+        `  Of the ${report.leftoverStranded} stranded: ` +
+        `${report.strandedNeedsRecovery} need RECOVERY (manual/incremental), ` +
+        `${report.strandedDiscardable} are derivable and can simply be deleted.`
+      );
+      console.table(report.strandedBySource);
+      console.log('  Sample of the ones that must be written back:');
+      console.table(report.strandedSamples);
+    }
+    console.table(report.leftoverSamples);
   }
 
   for (const n of report.notes) console.log(`NOTE: ${n}`);

--- a/src/lib/scheduler.ts
+++ b/src/lib/scheduler.ts
@@ -189,7 +189,14 @@ export async function getNextSpacingDateForRem(
       interval: newInterval,
       wasEarly: wasEarly,
       daysEarlyOrLate: daysEarlyOrLate,
-      priority: incrementalRemInfo.priority, // Record priority at time of rep
+      // Record priority at time of rep — but only when it is a real value.
+      // `prioritySource: 'fallback'` means neither the slot nor the existing
+      // history could supply one, so the number is a placeholder. Stamping it
+      // here would turn an unreadable slot into a permanent wrong priority, and
+      // would overwrite the very history entries the value can be recovered from.
+      ...(incrementalRemInfo.prioritySource === 'fallback'
+        ? {}
+        : { priority: incrementalRemInfo.priority }),
       // reviewTimeSeconds will be added by reviewRem()
     },
   ];

--- a/src/register/commands.ts
+++ b/src/register/commands.ts
@@ -42,6 +42,7 @@ import {
   executePreserveHistoryAndRemove,
 } from '../lib/history_transfer';
 import { resolvePowerupSlotDiagnostic } from '../lib/powerup_slot_compat';
+import { dumpRawPowerupSlots } from '../lib/raw_slot_dump';
 import { togglePdfHighlightBorders } from '../lib/ui_helpers';
 import { CardPriorityInfo, expandCardInfosToCards } from '../lib/card_priority/types';
 import { IncrementalRem as IncrementalRemType } from '../lib/incremental_rem/types';
@@ -1119,6 +1120,36 @@ export async function registerCommands(plugin: ReactRNPlugin) {
 
       // Open the batch card priority widget
       await plugin.widget.openPopup('batch_card_priority');
+    },
+  });
+
+  // Diagnostic: print the RAW stored value of every powerup property on the
+  // focused rem and its descendants. Needed because every priority the plugin
+  // displays has already passed through getIncrementalRemFromRem's `priority = 10`
+  // read fallback, so a displayed 10 cannot be told apart from an unreadable slot.
+  // This reads the property rems directly instead. Read-only.
+  plugin.app.registerCommand({
+    id: 'dump-raw-powerup-slots',
+    name: 'Debug: Dump Raw Powerup Slots (console)',
+    description:
+      'Reads the raw stored value of every powerup property on the focused Rem and its descendants, bypassing getPowerupProperty, and flags values that are stored but unreadable.',
+    action: async () => {
+      const rem = await plugin.focus.getFocusedRem();
+      if (!rem) {
+        await plugin.app.toast('Focus a Rem first.');
+        return;
+      }
+      await plugin.app.toast('Dumping raw powerup slots — see the console.');
+      try {
+        const report = await dumpRawPowerupSlots(plugin, rem);
+        await plugin.app.toast(
+          `Raw dump: ${report.scannedRems} rem(s), ${report.properties.length} propert(ies), ` +
+          `${report.unreachable.length} unreadable. See console.`
+        );
+      } catch (e) {
+        console.error('[RawSlotDump] Error:', e);
+        await plugin.app.toast('Raw slot dump failed — check console.');
+      }
     },
   });
 

--- a/src/widgets/debug.tsx
+++ b/src/widgets/debug.tsx
@@ -17,6 +17,7 @@ import { isPowerupPropertySafe } from '../lib/powerupSlotFilter';
 import { getCardPriority } from '../lib/card_priority';
 import { findNonFlashcardDescendantsWithCardPriority, getSpuriousCardPriorityTags, removeCardPriorityFromSpecificRems, removeCardPriorityFromRem, dumpRemPriorityStructure, findRogueCardPriorityRemsInSubtree, findOrphanedImportedCardPriorities } from '../lib/card_priority/batch';
 import { diagnosePowerupReadPath } from '../lib/powerup_read_diagnostic';
+import { dumpRawPowerupSlots } from '../lib/raw_slot_dump';
 import { getDismissedHistoryFromRem } from '../lib/dismissed';
 import {
   safeRemTextToString,
@@ -27,7 +28,7 @@ import {
   getReadingStatistics,
 } from '../lib/pdfUtils';
 import { formatDuration } from '../lib/utils';
-import { powerupCode, dismissedPowerupCode, dismissedHistorySlotCode, dismissedDateSlotCode, nextRepDateSlotCode, originalIncrementalDateSlotCode, repHistorySlotCode,
+import { powerupCode, dismissedPowerupCode, dismissedHistorySlotCode, dismissedDateSlotCode, nextRepDateSlotCode, originalIncrementalDateSlotCode, repHistorySlotCode, prioritySlotCode,
   priorityShieldHistoryKey, documentPriorityShieldHistoryKey,
   cardPriorityShieldHistoryKey, documentCardPriorityShieldHistoryKey,
   cardShieldCleanupBackupIndexKey, cardShieldCleanupBackupPrefix,
@@ -351,8 +352,30 @@ function Debug() {
         }
       };
 
+      // The Priority slot, verbatim. The "Priority" row in the section above is
+      // incrementalRem.priority, which has already passed through
+      // getIncrementalRemFromRem's `let priority = 10` fallback — so a displayed 10
+      // means either "10 is stored" or "the slot could not be read", and the two
+      // need completely different responses. Reading the slot directly separates
+      // them: `null` here with 10 above is a read failure, not a stored value.
+      const probePrioritySlot = async () => {
+        try {
+          const property = await rem.getPowerupProperty(powerupCode, prioritySlotCode);
+          const richText = await rem.getPowerupPropertyAsRichText(powerupCode, prioritySlotCode);
+          const asString = richText?.length ? await rp.richText.toString(richText) : '';
+          return {
+            getPowerupProperty: property === '' || property == null ? null : String(property),
+            richTextLength: Array.isArray(richText) ? richText.length : null,
+            richTextAsString: asString === '' ? null : asString,
+          };
+        } catch (e) {
+          return { error: String(e) };
+        }
+      };
+
       const rawSlotProbe = (await rem.hasPowerup(powerupCode))
         ? {
+            priority: await probePrioritySlot(),
             nextRepDate: await probeDateSlot(nextRepDateSlotCode),
             originalIncDate: await probeDateSlot(originalIncrementalDateSlotCode),
           }
@@ -579,6 +602,9 @@ function Debug() {
   }>(null);
 
   // On-screen copyable export text (mobile fallback when file/clipboard fail).
+  // Raw powerup-slot dump JSON, kept on screen so it can be copied by hand where
+  // the clipboard API and file download are both blocked (see handleDumpRawSlots).
+  const [rawSlotDumpText, setRawSlotDumpText] = useState<string | null>(null);
   // Result of the settings-migration probe (see handleProbeSettingsPersistence).
   const [isProbingSettings, setIsProbingSettings] = useState(false);
   const [isMigrating, setIsMigrating] = useState(false);
@@ -1981,6 +2007,52 @@ function Debug() {
         (mismatch ? ' — powerup IDENTITY MISMATCH found.' : '.') +
         ' See console.'
       );
+    }
+  };
+
+  // RAW slot dump — evidence for the RemNote support ticket about IncRems whose
+  // priority reverted to 10. The "Priority" row above shows the value AFTER
+  // getIncrementalRemFromRem's `let priority = 10` fallback, so it cannot tell a
+  // stored 10 from an unreadable slot. This bypasses getPowerupProperty and reads
+  // the property rems directly, for this rem and every descendant. Read-only.
+  const handleDumpRawSlots = async () => {
+    if (!rem) return;
+    await plugin.app.toast('Dumping raw powerup slots (rem + descendants)...');
+    try {
+      const report = await dumpRawPowerupSlots(plugin, rem);
+      const json = JSON.stringify(report, null, 2);
+      setRawSlotDumpText(json);
+
+      let copied = false;
+      try {
+        await navigator.clipboard.writeText(json);
+        copied = true;
+      } catch { /* clipboard is often blocked inside the plugin iframe */ }
+
+      let downloaded = false;
+      try {
+        const blob = new Blob([json], { type: 'application/json' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = `raw-slot-dump-${dayjs().format('YYYY-MM-DD-HHmmss')}.json`;
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        setTimeout(() => URL.revokeObjectURL(url), 2000);
+        downloaded = true;
+      } catch (e) {
+        console.warn('[RawSlotDump] File download failed (iframe sandbox?):', e);
+      }
+
+      await plugin.app.toast(
+        `Raw dump: ${report.scannedRems} rem(s), ${report.properties.length} propert(ies), ` +
+        `${report.unreachable.length} unreadable. ` +
+        `${downloaded ? 'JSON downloaded. ' : ''}${copied ? 'Copied. ' : ''}See console.`
+      );
+    } catch (e) {
+      console.error('[RawSlotDump] Error:', e);
+      await plugin.app.toast('Raw slot dump failed — check console.');
     }
   };
 
@@ -3411,7 +3483,27 @@ function Debug() {
             label="Next Rep (Human)"
             data={`${dayjs(incrementalRem.nextRepDate).format('MMMM D, YYYY')} (${dayjs(incrementalRem.nextRepDate).fromNow()})`}
           />
-          <Info className="priority" label="Priority" data={incrementalRem.priority} />
+          {/* Priority is no longer just a number: show where it came from, so a
+              recovered or placeholder value can never pass for a stored one. */}
+          <Info
+            className="priority"
+            label="Priority"
+            data={
+              <span>
+                {incrementalRem.priority}
+                {incrementalRem.prioritySource === 'history' && (
+                  <span style={{ marginLeft: '8px', fontSize: '11px', color: '#f59e0b', fontWeight: 600 }}>
+                    ⚠ recovered from history — the Priority slot is unreadable
+                  </span>
+                )}
+                {incrementalRem.prioritySource === 'fallback' && (
+                  <span style={{ marginLeft: '8px', fontSize: '11px', color: '#ef4444', fontWeight: 600 }}>
+                    ⚠ placeholder — neither the slot nor the history holds a priority
+                  </span>
+                )}
+              </span>
+            }
+          />
           <Info
             className="created-at-raw"
             label="Created At (Raw)"
@@ -3513,6 +3605,27 @@ function Debug() {
           <h2 style={{ fontSize: '14px', fontWeight: 'bold', marginBottom: '12px', paddingBottom: '4px', borderBottom: '1px solid var(--rn-clr-background-tertiary)' }}>
             Incremental Raw Slots (diagnostic)
           </h2>
+          {/* An empty raw slot while "Priority" above shows a number means the
+              number is getIncrementalRemFromRem's fallback, not stored data. */}
+          <Info
+            className="probe-priority"
+            label="Priority slot (raw)"
+            data={
+              <>
+                <pre style={preStyle}>{JSON.stringify(rawSlotProbe.priority, null, 2)}</pre>
+                {'error' in rawSlotProbe.priority ||
+                rawSlotProbe.priority.getPowerupProperty != null ||
+                rawSlotProbe.priority.richTextAsString != null ? null : (
+                  <div style={{ marginTop: '4px', padding: '6px', borderRadius: '4px', border: '1px solid #ef4444', backgroundColor: 'rgba(239, 68, 68, 0.08)', fontSize: '11px', color: 'var(--rn-clr-content-primary)' }}>
+                    ⚠ The Priority slot reads as empty, so the{' '}
+                    <strong>Priority {String(incrementalRem?.priority)}</strong> shown above is the
+                    plugin's read fallback, not a stored value. Use “Dump Raw Slots” to check
+                    whether the real value is still on the Rem under a detached slot.
+                  </div>
+                )}
+              </>
+            }
+          />
           <Info
             className="probe-next-rep"
             label="Next Rep reference"
@@ -3522,6 +3635,33 @@ function Debug() {
             className="probe-created"
             label="Created reference"
             data={<pre style={preStyle}>{JSON.stringify(rawSlotProbe.originalIncDate, null, 2)}</pre>}
+          />
+        </div>
+      )}
+
+      {/* Result of "Dump Raw Slots", kept on screen so it can be selected and
+          copied by hand where the clipboard API and file download are blocked. */}
+      {rawSlotDumpText && (
+        <div style={{ marginTop: '16px' }}>
+          <h2 style={{ fontSize: '14px', fontWeight: 'bold', marginBottom: '8px', paddingBottom: '4px', borderBottom: '1px solid var(--rn-clr-background-tertiary)', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+            Raw Slot Dump (JSON)
+            <button onClick={() => setRawSlotDumpText(null)} style={smallBtnStyle}>Clear</button>
+          </h2>
+          <textarea
+            readOnly
+            value={rawSlotDumpText}
+            onFocus={(e) => e.currentTarget.select()}
+            style={{
+              width: '100%',
+              height: '220px',
+              fontSize: '10px',
+              fontFamily: 'monospace',
+              padding: '8px',
+              borderRadius: '4px',
+              border: '1px solid var(--rn-clr-border)',
+              backgroundColor: 'var(--rn-clr-background-secondary)',
+              color: 'var(--rn-clr-content-primary)',
+            }}
           />
         </div>
       )}
@@ -3619,6 +3759,21 @@ function Debug() {
                  title="Why can't the plugin read this rem's Incremental/CardPriority values? Compares getPowerupByCode() against the rem's actual tags and probes every slot (read-only)"
                >
                  Diagnose Read Path
+               </button>
+               <button
+                 onClick={handleDumpRawSlots}
+                 style={{
+                   fontSize: '11px',
+                   padding: '2px 8px',
+                   backgroundColor: 'var(--rn-clr-background-secondary)',
+                   color: 'var(--rn-clr-content-primary)',
+                   border: '1px solid var(--rn-clr-border)',
+                   borderRadius: '4px',
+                   cursor: 'pointer'
+                 }}
+                 title="Read the RAW stored value of every powerup property on this rem and its descendants, bypassing getPowerupProperty, and flag values that are stored but unreadable (read-only)"
+               >
+                 Dump Raw Slots
                </button>
              </div>
            </h2>

--- a/src/widgets/debug.tsx
+++ b/src/widgets/debug.tsx
@@ -18,6 +18,8 @@ import { getCardPriority } from '../lib/card_priority';
 import { findNonFlashcardDescendantsWithCardPriority, getSpuriousCardPriorityTags, removeCardPriorityFromSpecificRems, removeCardPriorityFromRem, dumpRemPriorityStructure, findRogueCardPriorityRemsInSubtree, findOrphanedImportedCardPriorities } from '../lib/card_priority/batch';
 import { diagnosePowerupReadPath } from '../lib/powerup_read_diagnostic';
 import { dumpRawPowerupSlots } from '../lib/raw_slot_dump';
+import { scanKbForDetachedSlots, SlotScanReport } from '../lib/raw_slot_scan';
+import { repairDetachedCardPriorities, testDeleteOrphanProperties, RepairReport } from '../lib/raw_slot_repair';
 import { getDismissedHistoryFromRem } from '../lib/dismissed';
 import {
   safeRemTextToString,
@@ -605,6 +607,15 @@ function Debug() {
   // Raw powerup-slot dump JSON, kept on screen so it can be copied by hand where
   // the clipboard API and file download are both blocked (see handleDumpRawSlots).
   const [rawSlotDumpText, setRawSlotDumpText] = useState<string | null>(null);
+  // KB-wide slot damage scan (see handleScanKb).
+  const [kbScan, setKbScan] = useState<SlotScanReport | null>(null);
+  const [isScanningKb, setIsScanningKb] = useState(false);
+  const [scanProgress, setScanProgress] = useState<string | null>(null);
+  // CardPriority repair + the staged orphan-deletion test (see handleRepairCardPriority).
+  const [repairReport, setRepairReport] = useState<RepairReport | null>(null);
+  const [isRepairingCP, setIsRepairingCP] = useState(false);
+  const [repairProgress, setRepairProgress] = useState<string | null>(null);
+  const [deletionProbes, setDeletionProbes] = useState<Awaited<ReturnType<typeof testDeleteOrphanProperties>> | null>(null);
   // Result of the settings-migration probe (see handleProbeSettingsPersistence).
   const [isProbingSettings, setIsProbingSettings] = useState(false);
   const [isMigrating, setIsMigrating] = useState(false);
@@ -2056,6 +2067,136 @@ function Debug() {
     }
   };
 
+  // KB-wide sizing scan for the two post-overhaul slot defects. "Dump Raw Slots"
+  // explains ONE rem exhaustively; this counts how many are affected across the
+  // whole knowledge base, for both priority powerups, and breaks the dangling
+  // Daily Document references down by scheduling interval. Read-only, but it
+  // walks every tagged rem — hence the progress state and the explicit run button.
+  const handleScanKb = async () => {
+    setIsScanningKb(true);
+    setScanProgress('Gathering powerup populations…');
+    try {
+      const report = await scanKbForDetachedSlots(plugin, (done, total, phase) => {
+        setScanProgress(`${phase}: ${done} / ${total}`);
+      });
+      setKbScan(report);
+      const json = JSON.stringify(report, null, 2);
+      setRawSlotDumpText(json);
+
+      let copied = false;
+      try {
+        await navigator.clipboard.writeText(json);
+        copied = true;
+      } catch { /* clipboard is often blocked inside the plugin iframe */ }
+
+      try {
+        const blob = new Blob([json], { type: 'application/json' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = `slot-damage-scan-${dayjs().format('YYYY-MM-DD-HHmmss')}.json`;
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        setTimeout(() => URL.revokeObjectURL(url), 2000);
+      } catch (e) {
+        console.warn('[SlotScan] File download failed (iframe sandbox?):', e);
+      }
+
+      await plugin.app.toast(
+        `Scan done: Incremental ${report.incremental.detachedPct}% detached, ` +
+        `CardPriority ${report.cardPriority.detachedPct}% detached, ` +
+        `dates ${report.nextRepDate.danglingPct}% dangling. ${copied ? 'Copied. ' : ''}See console.`
+      );
+    } catch (e) {
+      console.error('[SlotScan] Error:', e);
+      await plugin.app.toast('KB scan failed — check console.');
+    } finally {
+      setIsScanningKb(false);
+      setScanProgress(null);
+    }
+  };
+
+  // CardPriority repair. CardPriority is repaired before Incremental because it
+  // is the unmitigated case: getIncrementalRemFromRem recovers a detached
+  // priority from the Rem's history, getCardPriority has nothing to fall back on
+  // and silently serves an inherited value or the default instead.
+  //
+  // `limit` caps a live run so the first one can be small and inspected. The
+  // orphaned property Rems are deliberately NOT deleted here — see
+  // handleTestOrphanDeletion.
+  const runCardPriorityRepair = async (dryRun: boolean, limit?: number) => {
+    setIsRepairingCP(true);
+    setRepairProgress(dryRun ? 'Scanning…' : 'Repairing…');
+    try {
+      const report = await repairDetachedCardPriorities(plugin, {
+        dryRun,
+        limit,
+        onProgress: (done, total) => setRepairProgress(`${done} / ${total} Rems`),
+      });
+      setRepairReport(report);
+      setRawSlotDumpText(JSON.stringify(report, null, 2));
+      await plugin.app.toast(
+        dryRun
+          ? `Dry run: ${report.candidates} repairable, ${report.skippedDerivable} skipped as derivable. Nothing written.`
+          : `Repaired ${report.repaired}${report.failedVerification ? `, ${report.failedVerification} FAILED verification` : ''}. See console.`
+      );
+    } catch (e: any) {
+      console.error('[CPRepair] Error:', e);
+      await plugin.app.toast(`Repair failed: ${e?.message ?? e}`);
+    } finally {
+      setIsRepairingCP(false);
+      setRepairProgress(null);
+    }
+  };
+
+  const handleRepairLive = async (limit?: number) => {
+    const n = limit ?? repairReport?.candidates ?? 0;
+    const confirmed = confirm(
+      `This will WRITE to ${limit ? `up to ${limit}` : `all ${n}`} Rem(s), restoring each one's ` +
+      `stranded card priority through the normal write path.\n\n` +
+      `It does NOT delete the old detached property — each repaired Rem will keep a stray ` +
+      `"Unnamed — N" row until the deletion step is verified separately.\n\n` +
+      `Run a dry run first if you have not. Continue?`
+    );
+    if (!confirmed) return;
+    await runCardPriorityRepair(false, limit);
+  };
+
+  // Staged deletion test. Deliberately tiny and separate: this is the one action
+  // in the whole diagnostic set that destroys data, so it must never be first
+  // attempted as part of a bulk pass. It refuses any Rem whose repaired priority
+  // is not already readable, and reports the owner's state either side.
+  const handleTestOrphanDeletion = async () => {
+    const ids = repairReport?.orphanPropertyRemIds ?? [];
+    if (!ids.length) {
+      await plugin.app.toast('Run the repair first — there are no recorded orphan property Rems.');
+      return;
+    }
+    if (repairReport?.dryRun) {
+      await plugin.app.toast('That report is a dry run, so nothing was repaired yet. Run the live repair first.');
+      return;
+    }
+    const confirmed = confirm(
+      `This DELETES 3 orphaned property Rems (of ${ids.length} recorded).\n\n` +
+      `Each one is only removed if the Rem's repaired priority already reads back correctly, ` +
+      `and the value it held is captured first so it can be restored by hand.\n\n` +
+      `Purpose: find out whether deleting the stale property disturbs the good one, BEFORE ` +
+      `any bulk cleanup. Continue?`
+    );
+    if (!confirmed) return;
+
+    await plugin.app.toast('Deleting 3 orphan property Rems…');
+    const probes = await testDeleteOrphanProperties(plugin, ids, 3);
+    setDeletionProbes(probes);
+    const bad = probes.filter((p) => p.verdict.startsWith('DANGER'));
+    await plugin.app.toast(
+      bad.length
+        ? `⚠ ${bad.length} deletion(s) disturbed the good value — DO NOT bulk clean. See console.`
+        : `Deleted ${probes.filter((p) => p.deleted).length}. Priorities intact. See console.`
+    );
+  };
+
   // Cross-KB import diagnostic. Answers ONE question: after importing rems from
   // another KB and finding their manual priorities replaced by the default, is the
   // original value still physically present (attached to the imported KB's own
@@ -3043,6 +3184,31 @@ function Debug() {
   const preStyle = { backgroundColor: 'var(--rn-clr-background-secondary)', padding: '8px', borderRadius: '4px', marginTop: '4px', fontSize: '11px', overflowX: 'auto' as 'auto' };
   const smallBtnStyle: CSSProperties = { fontSize: '11px', padding: '2px 8px', backgroundColor: 'var(--rn-clr-background-secondary)', color: 'var(--rn-clr-content-primary)', border: '1px solid var(--rn-clr-border)', borderRadius: '4px', cursor: 'pointer' };
 
+  // ── SECTION ORDER — please preserve ──────────────────────────────────────
+  //
+  // This widget is opened to answer a question about ONE Rem, so the sections
+  // that describe the focused Rem come first and must stay there:
+  //
+  //   1. General Data              — Rem id and the top-level toggles
+  //   2. Incremental Powerup       ← KEEP AT TOP
+  //   3. Incremental Raw Slots
+  //   4. Card Priority Powerup     ← KEEP AT TOP
+  //   5. Dismissed Powerup
+  //   6. …other per-Rem readouts (cards, PDF structure, page history)…
+  //
+  // Everything that describes the KNOWLEDGE BASE rather than the focused Rem
+  // goes after those — settings migration, shield history, the CardPriority tag
+  // audit — and the whole-KB forensic tools go last, in "Raw Slot Diagnostics".
+  //
+  // Two ways this drifted before, both worth not repeating:
+  //   * "Dump Raw Slots" was bolted onto the *Card Priority* section header,
+  //     where it had nothing to do with card priority.
+  //   * The settings-migration and shield-history blocks sat directly under
+  //     General Data, pushing the Incremental / Card Priority readouts — the
+  //     reason this widget gets opened at all — below the fold.
+  //
+  // Rule of thumb: if a control does not describe the focused Rem, it does not
+  // belong above the per-Rem sections.
   return (
     <div className="incremental-everything-debug p-4 max-h-[80vh] overflow-y-auto" style={{ fontFamily: 'system-ui, -apple-system, sans-serif', color: 'var(--rn-clr-content-primary)', boxSizing: 'border-box' }}>
       <h2 style={{ fontSize: '14px', fontWeight: 'bold', marginBottom: '12px', paddingBottom: '4px', borderBottom: '1px solid var(--rn-clr-background-tertiary)', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
@@ -3094,381 +3260,6 @@ function Debug() {
       </h2>
       <Info className="rem-id" label="Rem ID" data={<code>{remId}</code>} />
 
-      {/* Durable status of the settings migration — which settings were carried
-          into the plugin's own store, which failed, and whether it is done. */}
-      <div style={{ marginTop: '16px' }}>
-        <h2 style={{ fontSize: '14px', fontWeight: 'bold', marginBottom: '8px', paddingBottom: '4px', borderBottom: '1px solid var(--rn-clr-background-tertiary)', display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: '6px' }}>
-          Settings Migration Status
-          <span style={{ display: 'flex', gap: '6px' }}>
-            <button onClick={handleShowMigrationStatus} disabled={isMigrating} style={{ ...smallBtnStyle, cursor: isMigrating ? 'wait' : 'pointer', whiteSpace: 'nowrap' }}>
-              {isMigrating ? 'Working…' : 'Load status'}
-            </button>
-            <button onClick={handleCopyMigrationReport} style={{ ...smallBtnStyle, whiteSpace: 'nowrap' }}>Copy</button>
-            <button onClick={handleForceRemigrate} disabled={isMigrating} style={{ ...smallBtnStyle, cursor: isMigrating ? 'wait' : 'pointer', whiteSpace: 'nowrap' }} title="Re-read every setting and overwrite the stored values. Use only to recover a migration that ran while settings were unreadable.">
-              Force re-run
-            </button>
-          </span>
-        </h2>
-        <div style={{ fontSize: '11px', color: 'var(--rn-clr-content-tertiary)', marginBottom: '6px' }}>
-          The migration copies each setting out of RemNote's settings panel into the plugin's own synced storage. It
-          runs once on load and records the outcome per setting, so this stays readable afterwards. Full detail also
-          goes to the DevTools console.
-        </div>
-        {migrationReport === null ? (
-          <div style={{ fontSize: '11px', color: 'var(--rn-clr-content-tertiary)' }}>
-            Press "Load status" — nothing loaded yet in this widget.
-          </div>
-        ) : (
-          <div style={{ padding: '8px', borderRadius: '4px', border: '1px solid var(--rn-clr-border)', backgroundColor: 'var(--rn-clr-background-secondary)', fontSize: '11px' }}>
-            <div style={{ lineHeight: 1.6, marginBottom: '6px' }}>
-              <div>
-                Status:{' '}
-                <strong style={{ color: migrationReport.complete ? '#16a34a' : '#ef4444' }}>
-                  {migrationReport.complete
-                    ? 'COMPLETE'
-                    : migrationReport.gaveUp
-                      ? 'INCOMPLETE — retries exhausted'
-                      : 'INCOMPLETE — retries on next reload'}
-                </strong>
-              </div>
-              <div>Last run: {new Date(migrationReport.finishedAt).toLocaleString()} (attempt {migrationReport.attempt})</div>
-              <div>
-                {migrationReport.total} settings — <strong>{migrationReport.counts.migrated}</strong> carried over,{' '}
-                {migrationReport.counts.default} at default, {migrationReport.counts['already-present']} already stored,{' '}
-                <strong style={{ color: migrationReport.counts.failed ? '#ef4444' : 'inherit' }}>
-                  {migrationReport.counts.failed} failed
-                </strong>
-              </div>
-            </div>
-            {storedSettings && (
-              <div style={{ marginBottom: '6px', paddingBottom: '6px', borderBottom: '1px solid var(--rn-clr-background-tertiary)' }}>
-                <div style={{ fontWeight: 600, marginBottom: '2px' }}>
-                  Stored blob — {Object.keys(storedSettings).length} key(s)
-                </div>
-                <div style={{ color: 'var(--rn-clr-content-tertiary)', marginBottom: '4px' }}>
-                  Only settings that differ from their default are stored; everything else resolves through the
-                  defaults table, so changing a default still reaches you.
-                </div>
-                {Object.keys(storedSettings).length === 0 ? (
-                  <div style={{ color: 'var(--rn-clr-content-tertiary)' }}>(empty — every setting is at its default)</div>
-                ) : (
-                  Object.entries(storedSettings).map(([k, v]) => (
-                    <div key={k} style={{ lineHeight: 1.5, paddingLeft: '6px' }}>
-                      <code>{k}</code> → <strong>{JSON.stringify(v)}</strong>
-                    </div>
-                  ))
-                )}
-              </div>
-            )}
-            <div style={{ maxHeight: '260px', overflowY: 'auto', paddingTop: '6px', borderTop: '1px solid var(--rn-clr-background-tertiary)' }}>
-              {migrationReport.records.map((r) => (
-                <div key={r.id} style={{ lineHeight: 1.5 }}>
-                  <span style={{ color: r.status === 'failed' ? '#ef4444' : r.status === 'migrated' || r.status === 'converted' ? '#16a34a' : 'var(--rn-clr-content-tertiary)' }}>
-                    {r.status === 'failed' ? '✗' : r.status === 'converted' ? '~' : r.status === 'migrated' ? '●' : '·'}
-                  </span>{' '}
-                  <code>{r.id}</code> → <strong>{JSON.stringify(r.value)}</strong>{' '}
-                  <span style={{ color: 'var(--rn-clr-content-tertiary)' }}>[{r.status}]</span>
-                  {r.error && <div style={{ paddingLeft: '14px', color: '#ef4444' }}>{r.error}</div>}
-                </div>
-              ))}
-            </div>
-          </div>
-        )}
-      </div>
-
-      {/* Settings-migration probe: how does getSetting behave for ids this
-          plugin no longer registers? Decides whether a one-time seed can read
-          legacy values after the old registrations are deleted. */}
-      <div style={{ marginTop: '16px' }}>
-        <h2 style={{ fontSize: '14px', fontWeight: 'bold', marginBottom: '8px', paddingBottom: '4px', borderBottom: '1px solid var(--rn-clr-background-tertiary)', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-          Settings Migration Probe
-          <button
-            onClick={handleProbeSettingsPersistence}
-            disabled={isProbingSettings}
-            style={{ ...smallBtnStyle, cursor: isProbingSettings ? 'wait' : 'pointer', whiteSpace: 'nowrap' }}
-            title="Reads registered, never-registered and de-registered setting ids to see whether stored values outlive their registration"
-          >
-            {isProbingSettings ? 'Probing…' : 'Probe getSetting'}
-          </button>
-        </h2>
-        <div style={{ fontSize: '11px', color: 'var(--rn-clr-content-tertiary)', marginBottom: '6px' }}>
-          Checks whether <code>getSetting</code> returns <code>undefined</code> or throws for an unknown id, and whether
-          values stored for settings the plugin used to register are still readable now that it doesn't.
-        </div>
-        {settingsProbe && (
-          <div style={{ padding: '8px', borderRadius: '4px', border: '1px solid var(--rn-clr-border)', backgroundColor: 'var(--rn-clr-background-secondary)', fontSize: '11px' }}>
-            {(['control', 'never-registered', 'de-registered'] as const).map((group) => (
-              <div key={group} style={{ marginBottom: '8px' }}>
-                <div style={{ fontWeight: 600, marginBottom: '2px' }}>{group}</div>
-                {settingsProbe.rows.filter((r) => r.group === group).map((r) => (
-                  <div key={r.id} style={{ lineHeight: 1.5, paddingLeft: '6px' }}>
-                    <code>{r.id}</code> →{' '}
-                    <strong style={{ color: r.outcome === 'threw' ? '#ef4444' : r.outcome === 'value' ? '#16a34a' : '#d97706' }}>
-                      {r.value}
-                    </strong>
-                    {r.error && <div style={{ paddingLeft: '6px', color: '#ef4444' }}>{r.error}</div>}
-                    <div style={{ paddingLeft: '6px', color: 'var(--rn-clr-content-tertiary)' }}>{r.note}</div>
-                  </div>
-                ))}
-              </div>
-            ))}
-            <div style={{ paddingTop: '6px', borderTop: '1px solid var(--rn-clr-background-tertiary)', lineHeight: 1.6 }}>
-              <div>
-                Unknown id: <strong>{settingsProbe.anyThrew ? 'THROWS — seed needs per-id try/catch' : 'returns undefined — safe to call'}</strong>
-              </div>
-              <div>
-                De-registered ids still holding a value:{' '}
-                <strong>
-                  {settingsProbe.rows.filter((r) => r.group === 'de-registered' && r.outcome === 'value').length}
-                  /{settingsProbe.rows.filter((r) => r.group === 'de-registered').length}
-                </strong>
-              </div>
-              <div style={{ color: 'var(--rn-clr-content-tertiary)' }}>
-                Only a value differing from the old default is conclusive — an unset setting and a pruned one both read
-                as <code>(undefined)</code>.
-              </div>
-            </div>
-          </div>
-        )}
-      </div>
-
-      <div style={{ marginTop: '16px' }}>
-        <h2 style={{ fontSize: '14px', fontWeight: 'bold', marginBottom: '12px', paddingBottom: '4px', borderBottom: '1px solid var(--rn-clr-background-tertiary)', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-          Priority Shield History (KB-wide)
-          <button
-            onClick={handleDumpShieldHistory}
-            disabled={isDumpingShield}
-            style={{ fontSize: '11px', padding: '2px 8px', backgroundColor: 'var(--rn-clr-background-secondary)', color: 'var(--rn-clr-content-primary)', border: '1px solid var(--rn-clr-border)', borderRadius: '4px', cursor: isDumpingShield ? 'wait' : 'pointer' }}
-          >
-            {isDumpingShield ? 'Dumping…' : 'Dump + Export Shield History'}
-          </button>
-        </h2>
-        <div style={{ fontSize: '12px', color: 'var(--rn-clr-content-tertiary)', marginBottom: '8px' }}>
-          Reads all four shield-history synced keys (IncRem/Card × KB/Doc, plus weighted variants) and the live
-          write-side inputs used at QueueExit. Diagnoses whether Card shield history is <strong>empty</strong>,{' '}
-          <strong>orphaned</strong> under a stale KB id, or simply not being written because the cardPriority cache
-          is empty. Full raw JSON is logged to the console, copied to the clipboard, and downloaded as a file.
-        </div>
-        {shieldDump && (
-          <div style={{ marginTop: '8px', padding: '8px', borderRadius: '4px', border: '1px solid var(--rn-clr-border)', backgroundColor: 'var(--rn-clr-background-secondary)' }}>
-            <div style={{ fontSize: '11px', marginBottom: '8px' }}>
-              Current KB: <code>{shieldDump.currentKbId}</code> · isPrimary: <strong>{String(shieldDump.isPrimary)}</strong>
-            </div>
-            {shieldDump.stores.map((s) => {
-              const color =
-                s.status === 'ok' ? '#10b981'
-                : s.status === 'orphaned' ? '#ef4444'
-                : s.status === 'legacy' ? '#d97706'
-                : s.status === 'empty' ? '#ef4444'
-                : 'var(--rn-clr-content-tertiary)';
-              return (
-                <div key={s.key} style={{ marginBottom: '8px', paddingBottom: '6px', borderBottom: '1px solid var(--rn-clr-background-tertiary)' }}>
-                  <div style={{ fontSize: '12px', fontWeight: 600 }}>
-                    {s.label} <span style={{ color, textTransform: 'uppercase', fontSize: '10px' }}>[{s.status}]</span>
-                  </div>
-                  <div style={{ fontSize: '11px', color: 'var(--rn-clr-content-secondary)', marginTop: '2px' }}>{s.verdict}</div>
-                  <div style={{ fontSize: '10px', color: 'var(--rn-clr-content-tertiary)', marginTop: '2px' }}>
-                    current-KB: {s.currentKbDatedEntries} · orphaned: {s.otherKbPartitions.reduce((a, p) => a + p.entryCount, 0)} · legacy-root: {s.legacyRootDatedEntries}
-                  </div>
-                </div>
-              );
-            })}
-            <div style={{ fontSize: '11px', fontWeight: 600, marginTop: '8px', marginBottom: '4px' }}>Live write-side inputs</div>
-            <div style={{ fontSize: '11px', display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '2px 12px' }}>
-              <div>cardPriority cache: <strong style={{ color: shieldDump.live.allCardInfos === 0 ? '#ef4444' : 'inherit' }}>{shieldDump.live.allCardInfos}</strong></div>
-              <div>incRem cache: <strong>{shieldDump.live.allIncRems}</strong></div>
-              <div>cardPriority taggedRem(): <strong style={{ color: shieldDump.live.cardPriorityTaggedRems === 0 ? '#ef4444' : 'inherit' }}>{shieldDump.live.cardPriorityTaggedRems}</strong></div>
-              <div>with priority: <strong>{shieldDump.live.cardInfosWithPriority}</strong></div>
-              <div>with dueCardsOverdue field: <strong>{shieldDump.live.cardInfosWithDueOverdue}</strong></div>
-              <div>currently due-overdue: <strong>{shieldDump.live.cardInfosDueOverdue}</strong></div>
-              <div>card cache loaded flag: <strong>{String(shieldDump.live.cardCacheLoaded)}</strong></div>
-              <div>incRem cache loaded flag: <strong>{String(shieldDump.live.incRemCacheLoaded)}</strong></div>
-              <div>seen cards (session): <strong>{shieldDump.live.seenCardIds}</strong></div>
-              <div>seen rems (session): <strong>{shieldDump.live.seenRemIds}</strong></div>
-            </div>
-            <div style={{ fontSize: '11px', fontWeight: 600, marginTop: '8px', marginBottom: '4px' }}>Serialized size per key (sync-limit suspects)</div>
-            <div style={{ fontSize: '11px' }}>
-              {shieldDump.keySizes.map((k) => (
-                <div key={k.key} style={{ display: 'flex', justifyContent: 'space-between', gap: '12px' }}>
-                  <span style={{ color: 'var(--rn-clr-content-secondary)' }}>{k.label}</span>
-                  <strong style={{ color: k.approxKB >= 100 ? '#ef4444' : k.approxKB >= 50 ? '#d97706' : 'inherit' }}>
-                    {k.chars.toLocaleString()} chars (~{k.approxKB} KB)
-                  </strong>
-                </div>
-              ))}
-            </div>
-          </div>
-        )}
-
-        {/* Mobile-safe export: on Android the file download and clipboard API silently
-            fail, so render the JSON on-screen to select/copy manually. */}
-        {shieldExport && (
-          <div style={{ marginTop: '12px', paddingTop: '8px', borderTop: '1px solid var(--rn-clr-background-tertiary)' }}>
-            <div style={{ fontSize: '12px', fontWeight: 600, marginBottom: '4px', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-              Copyable export (for mobile / when the file didn't save)
-              <button onClick={handleSnapshotToSyncedBackup} style={smallBtnStyle} title="Save this device's card history to a synced backup key that syncs up on reconnect and appears under Restore → Load backups elsewhere">
-                Snapshot → synced backup
-              </button>
-            </div>
-            <div style={{ fontSize: '11px', color: 'var(--rn-clr-content-tertiary)', marginBottom: '6px' }}>
-              Tap a box to select all, or use its Copy button, then paste into the Restore box on another device.
-              The <strong>card-only</strong> export is smaller and is all you need to recover the lost card history.
-              Or use <strong>Snapshot → synced backup</strong>: it saves this device's card history under a new synced
-              key that pushes up when you reconnect (no copy/paste), then restore it elsewhere via "Load backups".
-            </div>
-            {([
-              { label: 'Card-only export', text: shieldExport.cardOnly },
-              { label: 'Full export', text: shieldExport.full },
-            ] as const).map(({ label, text }) => (
-              <div key={label} style={{ marginBottom: '8px' }}>
-                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '2px' }}>
-                  <span style={{ fontSize: '11px', fontWeight: 600 }}>{label} <span style={{ color: 'var(--rn-clr-content-tertiary)', fontWeight: 400 }}>({(text.length / 1024).toFixed(1)} KB)</span></span>
-                  <button onClick={() => copyTextFallback(text)} style={smallBtnStyle}>Copy</button>
-                </div>
-                <textarea
-                  readOnly
-                  value={text}
-                  onFocus={(e) => e.currentTarget.select()}
-                  onClick={(e) => e.currentTarget.select()}
-                  style={{ width: '100%', minHeight: '54px', fontSize: '9px', fontFamily: 'monospace', padding: '6px', border: '1px solid var(--rn-clr-border)', borderRadius: '4px', backgroundColor: 'var(--rn-clr-background-primary)', color: 'var(--rn-clr-content-primary)', boxSizing: 'border-box', whiteSpace: 'pre', overflowWrap: 'normal' }}
-                />
-              </div>
-            ))}
-          </div>
-        )}
-
-        {/* Locate the rem named in a "Diff for <remId> is too large to sync" error. */}
-        <div style={{ marginTop: '12px', paddingTop: '8px', borderTop: '1px solid var(--rn-clr-background-tertiary)' }}>
-          <div style={{ fontSize: '12px', fontWeight: 600, marginBottom: '4px' }}>Locate a "too large to sync" rem</div>
-          <div style={{ fontSize: '11px', color: 'var(--rn-clr-content-tertiary)', marginBottom: '6px' }}>
-            Paste the rem id from a <code>Diff for &lt;remId&gt; is too large to sync</code> error. Reports what that rem
-            is, its text size, and — if it holds JSON — its top-level keys, so we can tell whether the stranded
-            shield history lives inside it.
-          </div>
-          <div style={{ display: 'flex', gap: '6px', alignItems: 'center' }}>
-            <input
-              value={syncRemIdInput}
-              onChange={(e) => setSyncRemIdInput(e.target.value)}
-              placeholder="remId"
-              style={{ flex: 1, fontSize: '11px', padding: '3px 6px', border: '1px solid var(--rn-clr-border)', borderRadius: '4px', backgroundColor: 'var(--rn-clr-background-primary)', color: 'var(--rn-clr-content-primary)', fontFamily: 'monospace' }}
-            />
-            <button onClick={handleProbeSyncRem} disabled={isProbingSyncRem} style={{ ...smallBtnStyle, cursor: isProbingSyncRem ? 'wait' : 'pointer', whiteSpace: 'nowrap' }}>
-              {isProbingSyncRem ? 'Probing…' : 'Inspect Rem'}
-            </button>
-          </div>
-          {syncRemProbe && (
-            <div style={{ marginTop: '8px', padding: '8px', borderRadius: '4px', border: '1px solid var(--rn-clr-border)', backgroundColor: 'var(--rn-clr-background-secondary)', fontSize: '11px' }}>
-              {!syncRemProbe.found ? (
-                <div style={{ color: '#d97706' }}>
-                  <code>{syncRemProbe.remId}</code> — not readable via the plugin API (likely an internal storage doc
-                  owned by RemNote or another plugin). Use RemNote's own "resolve" flow for it.
-                </div>
-              ) : (
-                <div style={{ lineHeight: 1.6 }}>
-                  <div><code>{syncRemProbe.remId}</code></div>
-                  <div>Text size: <strong style={{ color: syncRemProbe.textChars >= 100 * 1024 ? '#ef4444' : 'inherit' }}>{syncRemProbe.textChars.toLocaleString()} chars</strong> (~{Math.round((syncRemProbe.textChars / 1024) * 10) / 10} KB)</div>
-                  <div>Powerups: <strong>{syncRemProbe.remType}</strong></div>
-                  <div>Looks like JSON: <strong>{String(syncRemProbe.looksLikeJson)}</strong></div>
-                  {syncRemProbe.jsonTopKeysPreview && (
-                    <div>JSON top keys: <span style={{ fontFamily: 'monospace', color: 'var(--rn-clr-content-secondary)' }}>{syncRemProbe.jsonTopKeysPreview.join(', ')}</span></div>
-                  )}
-                  <div>Parent: <span style={{ color: 'var(--rn-clr-content-secondary)' }}>{syncRemProbe.parentText ?? '(none)'}</span></div>
-                  {syncRemProbe.ancestorTexts.length > 0 && (
-                    <div>Ancestors: <span style={{ color: 'var(--rn-clr-content-secondary)' }}>{syncRemProbe.ancestorTexts.join(' › ')}</span></div>
-                  )}
-                  <div>Children: <strong>{syncRemProbe.childCount}</strong></div>
-                  {syncRemProbe.textPreview && (
-                    <pre style={preStyle}>{syncRemProbe.textPreview}</pre>
-                  )}
-                </div>
-              )}
-            </div>
-          )}
-        </div>
-
-        {/* Restore shield history from a cleanup backup or a pasted export/backup JSON. */}
-        <div style={{ marginTop: '12px', paddingTop: '8px', borderTop: '1px solid var(--rn-clr-background-tertiary)' }}>
-          <div style={{ fontSize: '12px', fontWeight: 600, marginBottom: '4px', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-            Restore Shield History
-            <button onClick={handleLoadBackups} style={smallBtnStyle}>Load backups</button>
-          </div>
-          <div style={{ fontSize: '11px', color: 'var(--rn-clr-content-tertiary)', marginBottom: '6px' }}>
-            Merges history back into the live store. It is <strong>additive</strong> — an existing day is never
-            overwritten, so current data is safe. Source can be a cleanup backup (auto-saved before "Remove All
-            CardPriority Tags") or a JSON export from another device.
-          </div>
-
-          {backupList && (
-            backupList.length === 0 ? (
-              <div style={{ fontSize: '11px', color: 'var(--rn-clr-content-tertiary)', marginBottom: '6px' }}>No cleanup backups found on this account.</div>
-            ) : (
-              <div style={{ marginBottom: '8px' }}>
-                {backupList.map((b) => (
-                  <div key={b.key} style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: '8px', fontSize: '11px', padding: '4px 0', borderBottom: '1px solid var(--rn-clr-background-tertiary)' }}>
-                    <div>
-                      <div style={{ fontWeight: 600 }}>{b.backedUpAt ? dayjs(b.backedUpAt).format('MMM D, YYYY HH:mm') : '(undated)'} · {b.dateEntries} entr(ies)</div>
-                      <div style={{ color: 'var(--rn-clr-content-tertiary)', fontFamily: 'monospace', fontSize: '10px' }}>KB {b.kbId ?? '?'}</div>
-                    </div>
-                    <button onClick={() => handleRestoreFromBackupKey(b.key)} disabled={isRestoring} style={{ ...smallBtnStyle, cursor: isRestoring ? 'wait' : 'pointer', whiteSpace: 'nowrap' }}>
-                      {isRestoring ? 'Restoring…' : 'Restore'}
-                    </button>
-                  </div>
-                ))}
-              </div>
-            )
-          )}
-
-          <textarea
-            value={restoreJsonInput}
-            onChange={(e) => setRestoreJsonInput(e.target.value)}
-            placeholder="Paste a shield-dump export or backup JSON here…"
-            style={{ width: '100%', minHeight: '60px', fontSize: '10px', fontFamily: 'monospace', padding: '6px', border: '1px solid var(--rn-clr-border)', borderRadius: '4px', backgroundColor: 'var(--rn-clr-background-primary)', color: 'var(--rn-clr-content-primary)', boxSizing: 'border-box' }}
-          />
-          <div style={{ marginTop: '6px' }}>
-            <button onClick={handleRestoreFromJson} disabled={isRestoring || !restoreJsonInput.trim()} style={{ ...smallBtnStyle, cursor: (isRestoring || !restoreJsonInput.trim()) ? 'not-allowed' : 'pointer', fontWeight: 600, opacity: (isRestoring || !restoreJsonInput.trim()) ? 0.5 : 1 }}>
-              {isRestoring ? 'Restoring…' : 'Restore from JSON'}
-            </button>
-          </div>
-
-          {restoreResult && (
-            <div style={{ marginTop: '8px', padding: '8px', borderRadius: '4px', border: '1px solid var(--rn-clr-border)', backgroundColor: 'var(--rn-clr-background-secondary)', fontSize: '11px' }}>
-              <div style={{ fontWeight: 600, marginBottom: '4px' }}>Restored from {restoreResult.source}</div>
-              {restoreResult.perKey.map((p) => (
-                <div key={p.key} style={{ display: 'flex', justifyContent: 'space-between', gap: '12px' }}>
-                  <span style={{ color: 'var(--rn-clr-content-secondary)', fontFamily: 'monospace', fontSize: '10px' }}>{p.key}</span>
-                  <strong style={{ color: p.added > 0 ? '#10b981' : 'inherit' }}>+{p.added} added, {p.skipped} kept</strong>
-                </div>
-              ))}
-            </div>
-          )}
-        </div>
-      </div>
-
-      {tagAudit && (
-        <div style={{ marginTop: '8px', marginBottom: '8px', padding: '8px', borderRadius: '4px', border: '1px solid var(--rn-clr-border)', backgroundColor: 'var(--rn-clr-background-secondary)' }}>
-          <div style={{ fontWeight: 600, fontSize: '12px', marginBottom: '4px' }}>CardPriority Tag Audit (KB-wide)</div>
-          <div style={{ fontSize: '11px', lineHeight: 1.6 }}>
-            <div><code>taggedRem()</code>: <strong>{tagAudit.taggedRemCount}</strong> rems</div>
-            <div>card-bearing rems: <strong>{tagAudit.cardRemCount}</strong></div>
-            <div>direct <code>hasPowerup</code>=true: <strong>{tagAudit.hasPowerupCount}</strong> (of which in taggedRem: {tagAudit.inTaggedRemCount})</div>
-            <div>hasPowerup=true but <em>missing</em> from taggedRem: <strong style={{ color: tagAudit.powerupNotInTaggedRem > 0 ? '#ef4444' : 'inherit' }}>{tagAudit.powerupNotInTaggedRem}</strong></div>
-            <div>priority slot present but <em>no</em> powerup tag: <strong style={{ color: tagAudit.slotButNoPowerup > 0 ? '#ef4444' : 'inherit' }}>{tagAudit.slotButNoPowerup}</strong></div>
-          </div>
-          <div style={{ marginTop: '6px', fontSize: '11px' }}>
-            <div>distinct cardPriority definition rems: <strong style={{ color: tagAudit.distinctDefs.length > 1 ? '#ef4444' : 'inherit' }}>{tagAudit.distinctDefs.length}</strong></div>
-            {tagAudit.distinctDefs.map((d) => (
-              <div key={d.defId} style={{ paddingLeft: '10px', color: 'var(--rn-clr-content-secondary)' }}>
-                • <code>{d.defId}</code> {d.isCanonical ? '(canonical)' : '(DUPLICATE)'} — {d.count} rems
-              </div>
-            ))}
-            {tagAudit.unknownDefCount > 0 && (
-              <div style={{ paddingLeft: '10px', color: 'var(--rn-clr-content-secondary)' }}>• unresolved def on {tagAudit.unknownDefCount} rem(s)</div>
-            )}
-          </div>
-          <div style={{ marginTop: '6px', fontSize: '11px', fontWeight: 600 }}>{tagAudit.verdict}</div>
-          <div style={{ marginTop: '4px', fontSize: '10px', color: 'var(--rn-clr-content-tertiary)' }}>Full breakdown + sample rems in the developer console.</div>
-        </div>
-      )}
       <div className="flex gap-4">
         <Info className="card-disabled" label="Cards Disabled (Locally)" data={isCardDisabledLocally ? <span style={{color: '#ef4444', fontWeight: 600}}>YES</span> : 'No'} />
         <Info className="card-disabled-ancestor" label="Cards Disabled (Inherited)" data={isCardDisabledInAncestors ? <span style={{color: '#ef4444', fontWeight: 600}}>YES</span> : 'No'} />
@@ -3639,32 +3430,6 @@ function Debug() {
         </div>
       )}
 
-      {/* Result of "Dump Raw Slots", kept on screen so it can be selected and
-          copied by hand where the clipboard API and file download are blocked. */}
-      {rawSlotDumpText && (
-        <div style={{ marginTop: '16px' }}>
-          <h2 style={{ fontSize: '14px', fontWeight: 'bold', marginBottom: '8px', paddingBottom: '4px', borderBottom: '1px solid var(--rn-clr-background-tertiary)', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-            Raw Slot Dump (JSON)
-            <button onClick={() => setRawSlotDumpText(null)} style={smallBtnStyle}>Clear</button>
-          </h2>
-          <textarea
-            readOnly
-            value={rawSlotDumpText}
-            onFocus={(e) => e.currentTarget.select()}
-            style={{
-              width: '100%',
-              height: '220px',
-              fontSize: '10px',
-              fontFamily: 'monospace',
-              padding: '8px',
-              borderRadius: '4px',
-              border: '1px solid var(--rn-clr-border)',
-              backgroundColor: 'var(--rn-clr-background-secondary)',
-              color: 'var(--rn-clr-content-primary)',
-            }}
-          />
-        </div>
-      )}
 
       {cardPriority && (
         <div style={{ marginTop: '16px' }}>
@@ -3759,21 +3524,6 @@ function Debug() {
                  title="Why can't the plugin read this rem's Incremental/CardPriority values? Compares getPowerupByCode() against the rem's actual tags and probes every slot (read-only)"
                >
                  Diagnose Read Path
-               </button>
-               <button
-                 onClick={handleDumpRawSlots}
-                 style={{
-                   fontSize: '11px',
-                   padding: '2px 8px',
-                   backgroundColor: 'var(--rn-clr-background-secondary)',
-                   color: 'var(--rn-clr-content-primary)',
-                   border: '1px solid var(--rn-clr-border)',
-                   borderRadius: '4px',
-                   cursor: 'pointer'
-                 }}
-                 title="Read the RAW stored value of every powerup property on this rem and its descendants, bypassing getPowerupProperty, and flag values that are stored but unreadable (read-only)"
-               >
-                 Dump Raw Slots
                </button>
              </div>
            </h2>
@@ -4445,6 +4195,598 @@ function Debug() {
               <pre style={preStyle}>{searchProbe.codePoints.map((c) => `${c.codePoint} ${JSON.stringify(c.char)}`).join('\n')}</pre>
             </details>
           </div>
+        )}
+      </div>
+
+      {/* ── KB-wide diagnostics — kept BELOW the per-Rem sections ─────────────
+          Settings migration, the shield history, and the CardPriority tag audit
+          all describe the knowledge base, not the focused Rem. They used to sit
+          directly under "General Data", pushing the Incremental / Card Priority
+          readouts — the reason this widget gets opened — below the fold. */}
+      {/* Durable status of the settings migration — which settings were carried
+          into the plugin's own store, which failed, and whether it is done. */}
+      <div style={{ marginTop: '16px' }}>
+        <h2 style={{ fontSize: '14px', fontWeight: 'bold', marginBottom: '8px', paddingBottom: '4px', borderBottom: '1px solid var(--rn-clr-background-tertiary)', display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: '6px' }}>
+          Settings Migration Status
+          <span style={{ display: 'flex', gap: '6px' }}>
+            <button onClick={handleShowMigrationStatus} disabled={isMigrating} style={{ ...smallBtnStyle, cursor: isMigrating ? 'wait' : 'pointer', whiteSpace: 'nowrap' }}>
+              {isMigrating ? 'Working…' : 'Load status'}
+            </button>
+            <button onClick={handleCopyMigrationReport} style={{ ...smallBtnStyle, whiteSpace: 'nowrap' }}>Copy</button>
+            <button onClick={handleForceRemigrate} disabled={isMigrating} style={{ ...smallBtnStyle, cursor: isMigrating ? 'wait' : 'pointer', whiteSpace: 'nowrap' }} title="Re-read every setting and overwrite the stored values. Use only to recover a migration that ran while settings were unreadable.">
+              Force re-run
+            </button>
+          </span>
+        </h2>
+        <div style={{ fontSize: '11px', color: 'var(--rn-clr-content-tertiary)', marginBottom: '6px' }}>
+          The migration copies each setting out of RemNote's settings panel into the plugin's own synced storage. It
+          runs once on load and records the outcome per setting, so this stays readable afterwards. Full detail also
+          goes to the DevTools console.
+        </div>
+        {migrationReport === null ? (
+          <div style={{ fontSize: '11px', color: 'var(--rn-clr-content-tertiary)' }}>
+            Press "Load status" — nothing loaded yet in this widget.
+          </div>
+        ) : (
+          <div style={{ padding: '8px', borderRadius: '4px', border: '1px solid var(--rn-clr-border)', backgroundColor: 'var(--rn-clr-background-secondary)', fontSize: '11px' }}>
+            <div style={{ lineHeight: 1.6, marginBottom: '6px' }}>
+              <div>
+                Status:{' '}
+                <strong style={{ color: migrationReport.complete ? '#16a34a' : '#ef4444' }}>
+                  {migrationReport.complete
+                    ? 'COMPLETE'
+                    : migrationReport.gaveUp
+                      ? 'INCOMPLETE — retries exhausted'
+                      : 'INCOMPLETE — retries on next reload'}
+                </strong>
+              </div>
+              <div>Last run: {new Date(migrationReport.finishedAt).toLocaleString()} (attempt {migrationReport.attempt})</div>
+              <div>
+                {migrationReport.total} settings — <strong>{migrationReport.counts.migrated}</strong> carried over,{' '}
+                {migrationReport.counts.default} at default, {migrationReport.counts['already-present']} already stored,{' '}
+                <strong style={{ color: migrationReport.counts.failed ? '#ef4444' : 'inherit' }}>
+                  {migrationReport.counts.failed} failed
+                </strong>
+              </div>
+            </div>
+            {storedSettings && (
+              <div style={{ marginBottom: '6px', paddingBottom: '6px', borderBottom: '1px solid var(--rn-clr-background-tertiary)' }}>
+                <div style={{ fontWeight: 600, marginBottom: '2px' }}>
+                  Stored blob — {Object.keys(storedSettings).length} key(s)
+                </div>
+                <div style={{ color: 'var(--rn-clr-content-tertiary)', marginBottom: '4px' }}>
+                  Only settings that differ from their default are stored; everything else resolves through the
+                  defaults table, so changing a default still reaches you.
+                </div>
+                {Object.keys(storedSettings).length === 0 ? (
+                  <div style={{ color: 'var(--rn-clr-content-tertiary)' }}>(empty — every setting is at its default)</div>
+                ) : (
+                  Object.entries(storedSettings).map(([k, v]) => (
+                    <div key={k} style={{ lineHeight: 1.5, paddingLeft: '6px' }}>
+                      <code>{k}</code> → <strong>{JSON.stringify(v)}</strong>
+                    </div>
+                  ))
+                )}
+              </div>
+            )}
+            <div style={{ maxHeight: '260px', overflowY: 'auto', paddingTop: '6px', borderTop: '1px solid var(--rn-clr-background-tertiary)' }}>
+              {migrationReport.records.map((r) => (
+                <div key={r.id} style={{ lineHeight: 1.5 }}>
+                  <span style={{ color: r.status === 'failed' ? '#ef4444' : r.status === 'migrated' || r.status === 'converted' ? '#16a34a' : 'var(--rn-clr-content-tertiary)' }}>
+                    {r.status === 'failed' ? '✗' : r.status === 'converted' ? '~' : r.status === 'migrated' ? '●' : '·'}
+                  </span>{' '}
+                  <code>{r.id}</code> → <strong>{JSON.stringify(r.value)}</strong>{' '}
+                  <span style={{ color: 'var(--rn-clr-content-tertiary)' }}>[{r.status}]</span>
+                  {r.error && <div style={{ paddingLeft: '14px', color: '#ef4444' }}>{r.error}</div>}
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Settings-migration probe: how does getSetting behave for ids this
+          plugin no longer registers? Decides whether a one-time seed can read
+          legacy values after the old registrations are deleted. */}
+      <div style={{ marginTop: '16px' }}>
+        <h2 style={{ fontSize: '14px', fontWeight: 'bold', marginBottom: '8px', paddingBottom: '4px', borderBottom: '1px solid var(--rn-clr-background-tertiary)', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+          Settings Migration Probe
+          <button
+            onClick={handleProbeSettingsPersistence}
+            disabled={isProbingSettings}
+            style={{ ...smallBtnStyle, cursor: isProbingSettings ? 'wait' : 'pointer', whiteSpace: 'nowrap' }}
+            title="Reads registered, never-registered and de-registered setting ids to see whether stored values outlive their registration"
+          >
+            {isProbingSettings ? 'Probing…' : 'Probe getSetting'}
+          </button>
+        </h2>
+        <div style={{ fontSize: '11px', color: 'var(--rn-clr-content-tertiary)', marginBottom: '6px' }}>
+          Checks whether <code>getSetting</code> returns <code>undefined</code> or throws for an unknown id, and whether
+          values stored for settings the plugin used to register are still readable now that it doesn't.
+        </div>
+        {settingsProbe && (
+          <div style={{ padding: '8px', borderRadius: '4px', border: '1px solid var(--rn-clr-border)', backgroundColor: 'var(--rn-clr-background-secondary)', fontSize: '11px' }}>
+            {(['control', 'never-registered', 'de-registered'] as const).map((group) => (
+              <div key={group} style={{ marginBottom: '8px' }}>
+                <div style={{ fontWeight: 600, marginBottom: '2px' }}>{group}</div>
+                {settingsProbe.rows.filter((r) => r.group === group).map((r) => (
+                  <div key={r.id} style={{ lineHeight: 1.5, paddingLeft: '6px' }}>
+                    <code>{r.id}</code> →{' '}
+                    <strong style={{ color: r.outcome === 'threw' ? '#ef4444' : r.outcome === 'value' ? '#16a34a' : '#d97706' }}>
+                      {r.value}
+                    </strong>
+                    {r.error && <div style={{ paddingLeft: '6px', color: '#ef4444' }}>{r.error}</div>}
+                    <div style={{ paddingLeft: '6px', color: 'var(--rn-clr-content-tertiary)' }}>{r.note}</div>
+                  </div>
+                ))}
+              </div>
+            ))}
+            <div style={{ paddingTop: '6px', borderTop: '1px solid var(--rn-clr-background-tertiary)', lineHeight: 1.6 }}>
+              <div>
+                Unknown id: <strong>{settingsProbe.anyThrew ? 'THROWS — seed needs per-id try/catch' : 'returns undefined — safe to call'}</strong>
+              </div>
+              <div>
+                De-registered ids still holding a value:{' '}
+                <strong>
+                  {settingsProbe.rows.filter((r) => r.group === 'de-registered' && r.outcome === 'value').length}
+                  /{settingsProbe.rows.filter((r) => r.group === 'de-registered').length}
+                </strong>
+              </div>
+              <div style={{ color: 'var(--rn-clr-content-tertiary)' }}>
+                Only a value differing from the old default is conclusive — an unset setting and a pruned one both read
+                as <code>(undefined)</code>.
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+
+      <div style={{ marginTop: '16px' }}>
+        <h2 style={{ fontSize: '14px', fontWeight: 'bold', marginBottom: '12px', paddingBottom: '4px', borderBottom: '1px solid var(--rn-clr-background-tertiary)', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+          Priority Shield History (KB-wide)
+          <button
+            onClick={handleDumpShieldHistory}
+            disabled={isDumpingShield}
+            style={{ fontSize: '11px', padding: '2px 8px', backgroundColor: 'var(--rn-clr-background-secondary)', color: 'var(--rn-clr-content-primary)', border: '1px solid var(--rn-clr-border)', borderRadius: '4px', cursor: isDumpingShield ? 'wait' : 'pointer' }}
+          >
+            {isDumpingShield ? 'Dumping…' : 'Dump + Export Shield History'}
+          </button>
+        </h2>
+        <div style={{ fontSize: '12px', color: 'var(--rn-clr-content-tertiary)', marginBottom: '8px' }}>
+          Reads all four shield-history synced keys (IncRem/Card × KB/Doc, plus weighted variants) and the live
+          write-side inputs used at QueueExit. Diagnoses whether Card shield history is <strong>empty</strong>,{' '}
+          <strong>orphaned</strong> under a stale KB id, or simply not being written because the cardPriority cache
+          is empty. Full raw JSON is logged to the console, copied to the clipboard, and downloaded as a file.
+        </div>
+        {shieldDump && (
+          <div style={{ marginTop: '8px', padding: '8px', borderRadius: '4px', border: '1px solid var(--rn-clr-border)', backgroundColor: 'var(--rn-clr-background-secondary)' }}>
+            <div style={{ fontSize: '11px', marginBottom: '8px' }}>
+              Current KB: <code>{shieldDump.currentKbId}</code> · isPrimary: <strong>{String(shieldDump.isPrimary)}</strong>
+            </div>
+            {shieldDump.stores.map((s) => {
+              const color =
+                s.status === 'ok' ? '#10b981'
+                : s.status === 'orphaned' ? '#ef4444'
+                : s.status === 'legacy' ? '#d97706'
+                : s.status === 'empty' ? '#ef4444'
+                : 'var(--rn-clr-content-tertiary)';
+              return (
+                <div key={s.key} style={{ marginBottom: '8px', paddingBottom: '6px', borderBottom: '1px solid var(--rn-clr-background-tertiary)' }}>
+                  <div style={{ fontSize: '12px', fontWeight: 600 }}>
+                    {s.label} <span style={{ color, textTransform: 'uppercase', fontSize: '10px' }}>[{s.status}]</span>
+                  </div>
+                  <div style={{ fontSize: '11px', color: 'var(--rn-clr-content-secondary)', marginTop: '2px' }}>{s.verdict}</div>
+                  <div style={{ fontSize: '10px', color: 'var(--rn-clr-content-tertiary)', marginTop: '2px' }}>
+                    current-KB: {s.currentKbDatedEntries} · orphaned: {s.otherKbPartitions.reduce((a, p) => a + p.entryCount, 0)} · legacy-root: {s.legacyRootDatedEntries}
+                  </div>
+                </div>
+              );
+            })}
+            <div style={{ fontSize: '11px', fontWeight: 600, marginTop: '8px', marginBottom: '4px' }}>Live write-side inputs</div>
+            <div style={{ fontSize: '11px', display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '2px 12px' }}>
+              <div>cardPriority cache: <strong style={{ color: shieldDump.live.allCardInfos === 0 ? '#ef4444' : 'inherit' }}>{shieldDump.live.allCardInfos}</strong></div>
+              <div>incRem cache: <strong>{shieldDump.live.allIncRems}</strong></div>
+              <div>cardPriority taggedRem(): <strong style={{ color: shieldDump.live.cardPriorityTaggedRems === 0 ? '#ef4444' : 'inherit' }}>{shieldDump.live.cardPriorityTaggedRems}</strong></div>
+              <div>with priority: <strong>{shieldDump.live.cardInfosWithPriority}</strong></div>
+              <div>with dueCardsOverdue field: <strong>{shieldDump.live.cardInfosWithDueOverdue}</strong></div>
+              <div>currently due-overdue: <strong>{shieldDump.live.cardInfosDueOverdue}</strong></div>
+              <div>card cache loaded flag: <strong>{String(shieldDump.live.cardCacheLoaded)}</strong></div>
+              <div>incRem cache loaded flag: <strong>{String(shieldDump.live.incRemCacheLoaded)}</strong></div>
+              <div>seen cards (session): <strong>{shieldDump.live.seenCardIds}</strong></div>
+              <div>seen rems (session): <strong>{shieldDump.live.seenRemIds}</strong></div>
+            </div>
+            <div style={{ fontSize: '11px', fontWeight: 600, marginTop: '8px', marginBottom: '4px' }}>Serialized size per key (sync-limit suspects)</div>
+            <div style={{ fontSize: '11px' }}>
+              {shieldDump.keySizes.map((k) => (
+                <div key={k.key} style={{ display: 'flex', justifyContent: 'space-between', gap: '12px' }}>
+                  <span style={{ color: 'var(--rn-clr-content-secondary)' }}>{k.label}</span>
+                  <strong style={{ color: k.approxKB >= 100 ? '#ef4444' : k.approxKB >= 50 ? '#d97706' : 'inherit' }}>
+                    {k.chars.toLocaleString()} chars (~{k.approxKB} KB)
+                  </strong>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Mobile-safe export: on Android the file download and clipboard API silently
+            fail, so render the JSON on-screen to select/copy manually. */}
+        {shieldExport && (
+          <div style={{ marginTop: '12px', paddingTop: '8px', borderTop: '1px solid var(--rn-clr-background-tertiary)' }}>
+            <div style={{ fontSize: '12px', fontWeight: 600, marginBottom: '4px', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+              Copyable export (for mobile / when the file didn't save)
+              <button onClick={handleSnapshotToSyncedBackup} style={smallBtnStyle} title="Save this device's card history to a synced backup key that syncs up on reconnect and appears under Restore → Load backups elsewhere">
+                Snapshot → synced backup
+              </button>
+            </div>
+            <div style={{ fontSize: '11px', color: 'var(--rn-clr-content-tertiary)', marginBottom: '6px' }}>
+              Tap a box to select all, or use its Copy button, then paste into the Restore box on another device.
+              The <strong>card-only</strong> export is smaller and is all you need to recover the lost card history.
+              Or use <strong>Snapshot → synced backup</strong>: it saves this device's card history under a new synced
+              key that pushes up when you reconnect (no copy/paste), then restore it elsewhere via "Load backups".
+            </div>
+            {([
+              { label: 'Card-only export', text: shieldExport.cardOnly },
+              { label: 'Full export', text: shieldExport.full },
+            ] as const).map(({ label, text }) => (
+              <div key={label} style={{ marginBottom: '8px' }}>
+                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '2px' }}>
+                  <span style={{ fontSize: '11px', fontWeight: 600 }}>{label} <span style={{ color: 'var(--rn-clr-content-tertiary)', fontWeight: 400 }}>({(text.length / 1024).toFixed(1)} KB)</span></span>
+                  <button onClick={() => copyTextFallback(text)} style={smallBtnStyle}>Copy</button>
+                </div>
+                <textarea
+                  readOnly
+                  value={text}
+                  onFocus={(e) => e.currentTarget.select()}
+                  onClick={(e) => e.currentTarget.select()}
+                  style={{ width: '100%', minHeight: '54px', fontSize: '9px', fontFamily: 'monospace', padding: '6px', border: '1px solid var(--rn-clr-border)', borderRadius: '4px', backgroundColor: 'var(--rn-clr-background-primary)', color: 'var(--rn-clr-content-primary)', boxSizing: 'border-box', whiteSpace: 'pre', overflowWrap: 'normal' }}
+                />
+              </div>
+            ))}
+          </div>
+        )}
+
+        {/* Locate the rem named in a "Diff for <remId> is too large to sync" error. */}
+        <div style={{ marginTop: '12px', paddingTop: '8px', borderTop: '1px solid var(--rn-clr-background-tertiary)' }}>
+          <div style={{ fontSize: '12px', fontWeight: 600, marginBottom: '4px' }}>Locate a "too large to sync" rem</div>
+          <div style={{ fontSize: '11px', color: 'var(--rn-clr-content-tertiary)', marginBottom: '6px' }}>
+            Paste the rem id from a <code>Diff for &lt;remId&gt; is too large to sync</code> error. Reports what that rem
+            is, its text size, and — if it holds JSON — its top-level keys, so we can tell whether the stranded
+            shield history lives inside it.
+          </div>
+          <div style={{ display: 'flex', gap: '6px', alignItems: 'center' }}>
+            <input
+              value={syncRemIdInput}
+              onChange={(e) => setSyncRemIdInput(e.target.value)}
+              placeholder="remId"
+              style={{ flex: 1, fontSize: '11px', padding: '3px 6px', border: '1px solid var(--rn-clr-border)', borderRadius: '4px', backgroundColor: 'var(--rn-clr-background-primary)', color: 'var(--rn-clr-content-primary)', fontFamily: 'monospace' }}
+            />
+            <button onClick={handleProbeSyncRem} disabled={isProbingSyncRem} style={{ ...smallBtnStyle, cursor: isProbingSyncRem ? 'wait' : 'pointer', whiteSpace: 'nowrap' }}>
+              {isProbingSyncRem ? 'Probing…' : 'Inspect Rem'}
+            </button>
+          </div>
+          {syncRemProbe && (
+            <div style={{ marginTop: '8px', padding: '8px', borderRadius: '4px', border: '1px solid var(--rn-clr-border)', backgroundColor: 'var(--rn-clr-background-secondary)', fontSize: '11px' }}>
+              {!syncRemProbe.found ? (
+                <div style={{ color: '#d97706' }}>
+                  <code>{syncRemProbe.remId}</code> — not readable via the plugin API (likely an internal storage doc
+                  owned by RemNote or another plugin). Use RemNote's own "resolve" flow for it.
+                </div>
+              ) : (
+                <div style={{ lineHeight: 1.6 }}>
+                  <div><code>{syncRemProbe.remId}</code></div>
+                  <div>Text size: <strong style={{ color: syncRemProbe.textChars >= 100 * 1024 ? '#ef4444' : 'inherit' }}>{syncRemProbe.textChars.toLocaleString()} chars</strong> (~{Math.round((syncRemProbe.textChars / 1024) * 10) / 10} KB)</div>
+                  <div>Powerups: <strong>{syncRemProbe.remType}</strong></div>
+                  <div>Looks like JSON: <strong>{String(syncRemProbe.looksLikeJson)}</strong></div>
+                  {syncRemProbe.jsonTopKeysPreview && (
+                    <div>JSON top keys: <span style={{ fontFamily: 'monospace', color: 'var(--rn-clr-content-secondary)' }}>{syncRemProbe.jsonTopKeysPreview.join(', ')}</span></div>
+                  )}
+                  <div>Parent: <span style={{ color: 'var(--rn-clr-content-secondary)' }}>{syncRemProbe.parentText ?? '(none)'}</span></div>
+                  {syncRemProbe.ancestorTexts.length > 0 && (
+                    <div>Ancestors: <span style={{ color: 'var(--rn-clr-content-secondary)' }}>{syncRemProbe.ancestorTexts.join(' › ')}</span></div>
+                  )}
+                  <div>Children: <strong>{syncRemProbe.childCount}</strong></div>
+                  {syncRemProbe.textPreview && (
+                    <pre style={preStyle}>{syncRemProbe.textPreview}</pre>
+                  )}
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+
+        {/* Restore shield history from a cleanup backup or a pasted export/backup JSON. */}
+        <div style={{ marginTop: '12px', paddingTop: '8px', borderTop: '1px solid var(--rn-clr-background-tertiary)' }}>
+          <div style={{ fontSize: '12px', fontWeight: 600, marginBottom: '4px', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+            Restore Shield History
+            <button onClick={handleLoadBackups} style={smallBtnStyle}>Load backups</button>
+          </div>
+          <div style={{ fontSize: '11px', color: 'var(--rn-clr-content-tertiary)', marginBottom: '6px' }}>
+            Merges history back into the live store. It is <strong>additive</strong> — an existing day is never
+            overwritten, so current data is safe. Source can be a cleanup backup (auto-saved before "Remove All
+            CardPriority Tags") or a JSON export from another device.
+          </div>
+
+          {backupList && (
+            backupList.length === 0 ? (
+              <div style={{ fontSize: '11px', color: 'var(--rn-clr-content-tertiary)', marginBottom: '6px' }}>No cleanup backups found on this account.</div>
+            ) : (
+              <div style={{ marginBottom: '8px' }}>
+                {backupList.map((b) => (
+                  <div key={b.key} style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: '8px', fontSize: '11px', padding: '4px 0', borderBottom: '1px solid var(--rn-clr-background-tertiary)' }}>
+                    <div>
+                      <div style={{ fontWeight: 600 }}>{b.backedUpAt ? dayjs(b.backedUpAt).format('MMM D, YYYY HH:mm') : '(undated)'} · {b.dateEntries} entr(ies)</div>
+                      <div style={{ color: 'var(--rn-clr-content-tertiary)', fontFamily: 'monospace', fontSize: '10px' }}>KB {b.kbId ?? '?'}</div>
+                    </div>
+                    <button onClick={() => handleRestoreFromBackupKey(b.key)} disabled={isRestoring} style={{ ...smallBtnStyle, cursor: isRestoring ? 'wait' : 'pointer', whiteSpace: 'nowrap' }}>
+                      {isRestoring ? 'Restoring…' : 'Restore'}
+                    </button>
+                  </div>
+                ))}
+              </div>
+            )
+          )}
+
+          <textarea
+            value={restoreJsonInput}
+            onChange={(e) => setRestoreJsonInput(e.target.value)}
+            placeholder="Paste a shield-dump export or backup JSON here…"
+            style={{ width: '100%', minHeight: '60px', fontSize: '10px', fontFamily: 'monospace', padding: '6px', border: '1px solid var(--rn-clr-border)', borderRadius: '4px', backgroundColor: 'var(--rn-clr-background-primary)', color: 'var(--rn-clr-content-primary)', boxSizing: 'border-box' }}
+          />
+          <div style={{ marginTop: '6px' }}>
+            <button onClick={handleRestoreFromJson} disabled={isRestoring || !restoreJsonInput.trim()} style={{ ...smallBtnStyle, cursor: (isRestoring || !restoreJsonInput.trim()) ? 'not-allowed' : 'pointer', fontWeight: 600, opacity: (isRestoring || !restoreJsonInput.trim()) ? 0.5 : 1 }}>
+              {isRestoring ? 'Restoring…' : 'Restore from JSON'}
+            </button>
+          </div>
+
+          {restoreResult && (
+            <div style={{ marginTop: '8px', padding: '8px', borderRadius: '4px', border: '1px solid var(--rn-clr-border)', backgroundColor: 'var(--rn-clr-background-secondary)', fontSize: '11px' }}>
+              <div style={{ fontWeight: 600, marginBottom: '4px' }}>Restored from {restoreResult.source}</div>
+              {restoreResult.perKey.map((p) => (
+                <div key={p.key} style={{ display: 'flex', justifyContent: 'space-between', gap: '12px' }}>
+                  <span style={{ color: 'var(--rn-clr-content-secondary)', fontFamily: 'monospace', fontSize: '10px' }}>{p.key}</span>
+                  <strong style={{ color: p.added > 0 ? '#10b981' : 'inherit' }}>+{p.added} added, {p.skipped} kept</strong>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+
+      {tagAudit && (
+        <div style={{ marginTop: '8px', marginBottom: '8px', padding: '8px', borderRadius: '4px', border: '1px solid var(--rn-clr-border)', backgroundColor: 'var(--rn-clr-background-secondary)' }}>
+          <div style={{ fontWeight: 600, fontSize: '12px', marginBottom: '4px' }}>CardPriority Tag Audit (KB-wide)</div>
+          <div style={{ fontSize: '11px', lineHeight: 1.6 }}>
+            <div><code>taggedRem()</code>: <strong>{tagAudit.taggedRemCount}</strong> rems</div>
+            <div>card-bearing rems: <strong>{tagAudit.cardRemCount}</strong></div>
+            <div>direct <code>hasPowerup</code>=true: <strong>{tagAudit.hasPowerupCount}</strong> (of which in taggedRem: {tagAudit.inTaggedRemCount})</div>
+            <div>hasPowerup=true but <em>missing</em> from taggedRem: <strong style={{ color: tagAudit.powerupNotInTaggedRem > 0 ? '#ef4444' : 'inherit' }}>{tagAudit.powerupNotInTaggedRem}</strong></div>
+            <div>priority slot present but <em>no</em> powerup tag: <strong style={{ color: tagAudit.slotButNoPowerup > 0 ? '#ef4444' : 'inherit' }}>{tagAudit.slotButNoPowerup}</strong></div>
+          </div>
+          <div style={{ marginTop: '6px', fontSize: '11px' }}>
+            <div>distinct cardPriority definition rems: <strong style={{ color: tagAudit.distinctDefs.length > 1 ? '#ef4444' : 'inherit' }}>{tagAudit.distinctDefs.length}</strong></div>
+            {tagAudit.distinctDefs.map((d) => (
+              <div key={d.defId} style={{ paddingLeft: '10px', color: 'var(--rn-clr-content-secondary)' }}>
+                • <code>{d.defId}</code> {d.isCanonical ? '(canonical)' : '(DUPLICATE)'} — {d.count} rems
+              </div>
+            ))}
+            {tagAudit.unknownDefCount > 0 && (
+              <div style={{ paddingLeft: '10px', color: 'var(--rn-clr-content-secondary)' }}>• unresolved def on {tagAudit.unknownDefCount} rem(s)</div>
+            )}
+          </div>
+          <div style={{ marginTop: '6px', fontSize: '11px', fontWeight: 600 }}>{tagAudit.verdict}</div>
+          <div style={{ marginTop: '4px', fontSize: '10px', color: 'var(--rn-clr-content-tertiary)' }}>Full breakdown + sample rems in the developer console.</div>
+        </div>
+      )}
+
+      {/* ── Raw slot diagnostics — KEEP LAST (see the section-order note above) ──
+          These are whole-KB / migration-forensics tools, not properties of the
+          focused Rem, which is why they live at the bottom rather than beside the
+          per-Rem powerup readouts. */}
+      <div style={{ marginTop: '16px' }}>
+        <h2 style={{ fontSize: '14px', fontWeight: 'bold', marginBottom: '12px', paddingBottom: '4px', borderBottom: '1px solid var(--rn-clr-background-tertiary)', display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: '6px', flexWrap: 'wrap' }}>
+          Raw Slot Diagnostics
+          <div style={{ display: 'flex', gap: '6px' }}>
+            <button
+              onClick={handleDumpRawSlots}
+              style={smallBtnStyle}
+              title="Read the RAW stored value of every powerup property on this Rem and its descendants, bypassing getPowerupProperty, and flag values that are stored but unreadable (read-only)"
+            >
+              Dump Raw Slots (this Rem)
+            </button>
+            <button
+              onClick={handleScanKb}
+              disabled={isScanningKb}
+              style={{ ...smallBtnStyle, cursor: isScanningKb ? 'wait' : 'pointer', fontWeight: 600 }}
+              title="Walk EVERY Rem carrying Incremental or CardPriority and count how many have a detached priority slot or a dangling Next Rep Date reference (read-only, slow)"
+            >
+              {isScanningKb ? 'Scanning…' : 'Scan Whole KB'}
+            </button>
+          </div>
+        </h2>
+
+        {scanProgress && (
+          <div style={{ fontSize: '11px', color: 'var(--rn-clr-content-secondary)', marginBottom: '8px' }}>
+            {scanProgress}
+          </div>
+        )}
+
+        {/* ── CardPriority repair ──────────────────────────────────────────────
+            Ordered dry-run → small live run → full run → staged deletion. The
+            deletion is last and separate on purpose: it is the only destructive
+            action here. */}
+        <div style={{ marginBottom: '12px', padding: '8px', borderRadius: '4px', border: '1px solid var(--rn-clr-border)' }}>
+          <div style={{ fontSize: '12px', fontWeight: 600, marginBottom: '2px' }}>CardPriority Repair</div>
+          <div style={{ fontSize: '11px', color: 'var(--rn-clr-content-secondary)', marginBottom: '8px' }}>
+            Restores priorities stranded on detached properties. CardPriority is repaired first
+            because it has no history fallback — those values are wrong in the app right now.
+            Repairing leaves the old property behind; clean it up only after the deletion test.
+          </div>
+          <div style={{ display: 'flex', gap: '6px', flexWrap: 'wrap' }}>
+            <button onClick={() => runCardPriorityRepair(true)} disabled={isRepairingCP} style={{ ...smallBtnStyle, cursor: isRepairingCP ? 'wait' : 'pointer' }}>
+              1. Dry run
+            </button>
+            <button onClick={() => handleRepairLive(25)} disabled={isRepairingCP || !repairReport} style={{ ...smallBtnStyle, cursor: isRepairingCP ? 'wait' : 'pointer' }}>
+              2. Repair 25 (live)
+            </button>
+            <button onClick={() => handleRepairLive()} disabled={isRepairingCP || !repairReport} style={{ ...smallBtnStyle, cursor: isRepairingCP ? 'wait' : 'pointer', fontWeight: 600 }}>
+              3. Repair all (live)
+            </button>
+            <button
+              onClick={handleTestOrphanDeletion}
+              disabled={isRepairingCP || !repairReport || repairReport.dryRun || repairReport.orphanPropertyRemIds.length === 0}
+              style={{ ...smallBtnStyle, cursor: isRepairingCP ? 'wait' : 'pointer', borderColor: '#ef4444', color: '#ef4444' }}
+              title="Deletes 3 orphaned property Rems and reports whether the repaired priority survived. Destructive — run only after a live repair."
+            >
+              4. Test orphan deletion (3)
+            </button>
+          </div>
+
+          {repairProgress && (
+            <div style={{ fontSize: '11px', color: 'var(--rn-clr-content-secondary)', marginTop: '6px' }}>{repairProgress}</div>
+          )}
+
+          {repairReport && (
+            <div style={{ fontSize: '11px', marginTop: '8px', lineHeight: 1.7 }}>
+              <div style={{ fontWeight: 600, color: repairReport.dryRun ? 'var(--rn-clr-content-secondary)' : '#22c55e' }}>
+                {repairReport.dryRun ? 'DRY RUN — nothing written' : 'LIVE RUN'}
+              </div>
+              <div>scanned: <strong>{repairReport.scanned}</strong> · repairable: <strong>{repairReport.candidates}</strong> · skipped as derivable: {repairReport.skippedDerivable}</div>
+              {!repairReport.dryRun && (
+                <div>
+                  repaired: <strong style={{ color: '#22c55e' }}>{repairReport.repaired}</strong>
+                  {repairReport.failedVerification > 0 && (
+                    <> · <strong style={{ color: '#ef4444' }}>failed verification: {repairReport.failedVerification}</strong></>
+                  )}
+                  {repairReport.errors.length > 0 && <> · errors: {repairReport.errors.length}</>}
+                </div>
+              )}
+              <div style={{ color: 'var(--rn-clr-content-tertiary)' }}>
+                orphan property Rems recorded: {repairReport.orphanPropertyRemIds.length}
+              </div>
+              {repairReport.notes.map((n, i) => (
+                <div key={i} style={{ color: 'var(--rn-clr-content-secondary)' }}>ⓘ {n}</div>
+              ))}
+            </div>
+          )}
+
+          {deletionProbes && (
+            <div style={{ marginTop: '8px', fontSize: '11px' }}>
+              <div style={{ fontWeight: 600, marginBottom: '4px' }}>Deletion test</div>
+              {deletionProbes.map((p) => (
+                <div
+                  key={p.orphanPropertyRemId}
+                  style={{ marginBottom: '4px', color: p.verdict.startsWith('DANGER') ? '#ef4444' : 'var(--rn-clr-content-secondary)' }}
+                >
+                  <code>{p.orphanPropertyRemId}</code> — held {p.storedValue ?? '?'} · API {p.apiValueBefore ?? '(empty)'} → {p.apiValueAfter ?? '(empty)'} · children {p.ownerChildCountBefore ?? '?'} → {p.ownerChildCountAfter ?? '?'}
+                  <div>{p.verdict}</div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {kbScan && (
+          <div style={{ marginBottom: '12px' }}>
+            <div style={{ fontSize: '11px', color: 'var(--rn-clr-content-tertiary)', marginBottom: '6px' }}>
+              Scanned in {(kbScan.durationMs / 1000).toFixed(1)}s
+            </div>
+            <table style={{ width: '100%', fontSize: '11px', borderCollapse: 'collapse', marginBottom: '10px' }}>
+              <thead>
+                <tr style={{ textAlign: 'left', color: 'var(--rn-clr-content-tertiary)' }}>
+                  <th style={{ padding: '2px 4px' }}>Powerup</th>
+                  <th style={{ padding: '2px 4px' }}>Total</th>
+                  <th style={{ padding: '2px 4px' }}>OK</th>
+                  <th style={{ padding: '2px 4px' }}>Detached</th>
+                  <th style={{ padding: '2px 4px' }}>No value</th>
+                  <th style={{ padding: '2px 4px' }}>Affected</th>
+                </tr>
+              </thead>
+              <tbody>
+                {[kbScan.incremental, kbScan.cardPriority].map((r) => (
+                  <tr key={r.code}>
+                    <td style={{ padding: '2px 4px', fontWeight: 600 }}>{r.label}</td>
+                    <td style={{ padding: '2px 4px' }}>{r.total}</td>
+                    <td style={{ padding: '2px 4px' }}>{r.ok}</td>
+                    <td style={{ padding: '2px 4px', color: r.detached > 0 ? '#ef4444' : undefined, fontWeight: r.detached > 0 ? 600 : undefined }}>{r.detached}</td>
+                    <td style={{ padding: '2px 4px' }}>{r.missing}</td>
+                    <td style={{ padding: '2px 4px', color: r.detachedPct > 0 ? '#ef4444' : undefined, fontWeight: 600 }}>{r.detachedPct}%</td>
+                  </tr>
+                ))}
+                <tr>
+                  <td style={{ padding: '2px 4px', fontWeight: 600 }}>Next Rep Date</td>
+                  <td style={{ padding: '2px 4px' }}>{kbScan.nextRepDate.totalWithProperty}</td>
+                  <td style={{ padding: '2px 4px' }}>{kbScan.nextRepDate.ok}</td>
+                  <td style={{ padding: '2px 4px', color: kbScan.nextRepDate.dangling > 0 ? '#ef4444' : undefined, fontWeight: kbScan.nextRepDate.dangling > 0 ? 600 : undefined }}>
+                    {kbScan.nextRepDate.dangling} dangling
+                  </td>
+                  <td style={{ padding: '2px 4px' }}>{kbScan.nextRepDate.empty}</td>
+                  <td style={{ padding: '2px 4px', color: kbScan.nextRepDate.danglingPct > 0 ? '#ef4444' : undefined, fontWeight: 600 }}>{kbScan.nextRepDate.danglingPct}%</td>
+                </tr>
+              </tbody>
+            </table>
+
+            {/* The hypothesis test: if dangling refs cluster in the long-interval
+                buckets, future-dated daily documents did not survive migration. */}
+            {kbScan.nextRepDate.byInterval.length > 0 && (
+              <>
+                <div style={{ fontSize: '11px', fontWeight: 600, marginBottom: '4px' }}>
+                  Dangling dates by scheduling interval
+                </div>
+                <table style={{ width: '100%', fontSize: '11px', borderCollapse: 'collapse', marginBottom: '10px' }}>
+                  <thead>
+                    <tr style={{ textAlign: 'left', color: 'var(--rn-clr-content-tertiary)' }}>
+                      <th style={{ padding: '2px 4px' }}>Interval</th>
+                      <th style={{ padding: '2px 4px' }}>Resolves</th>
+                      <th style={{ padding: '2px 4px' }}>Dangling</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {kbScan.nextRepDate.byInterval.map((row) => (
+                      <tr key={row.bucket}>
+                        <td style={{ padding: '2px 4px' }}>{row.bucket}</td>
+                        <td style={{ padding: '2px 4px' }}>{row.ok}</td>
+                        <td style={{ padding: '2px 4px', color: row.dangling > 0 ? '#ef4444' : undefined }}>{row.dangling}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </>
+            )}
+
+            {kbScan.notes.map((n, i) => (
+              <div key={i} style={{ fontSize: '11px', color: 'var(--rn-clr-content-secondary)', marginTop: '4px' }}>
+                ⓘ {n}
+              </div>
+            ))}
+          </div>
+        )}
+
+        {/* Result of either tool, kept on screen so it can be selected and copied
+            by hand where the clipboard API and file download are both blocked. */}
+        {rawSlotDumpText && (
+          <>
+            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '4px' }}>
+              <div className="font-semibold text-xs text-[var(--rn-clr-content-tertiary)] uppercase tracking-wider">JSON</div>
+              <button onClick={() => setRawSlotDumpText(null)} style={smallBtnStyle}>Clear</button>
+            </div>
+            <textarea
+              readOnly
+              value={rawSlotDumpText}
+              onFocus={(e) => e.currentTarget.select()}
+              style={{
+                width: '100%',
+                height: '220px',
+                fontSize: '10px',
+                fontFamily: 'monospace',
+                padding: '8px',
+                borderRadius: '4px',
+                border: '1px solid var(--rn-clr-border)',
+                backgroundColor: 'var(--rn-clr-background-secondary)',
+                color: 'var(--rn-clr-content-primary)',
+              }}
+            />
+          </>
         )}
       </div>
     </div>

--- a/src/widgets/debug.tsx
+++ b/src/widgets/debug.tsx
@@ -2168,19 +2168,41 @@ function Debug() {
   // attempted as part of a bulk pass. It refuses any Rem whose repaired priority
   // is not already readable, and reports the owner's state either side.
   const handleTestOrphanDeletion = async () => {
-    const ids = repairReport?.orphanPropertyRemIds ?? [];
-    if (!ids.length) {
-      await plugin.app.toast('Run the repair first — there are no recorded orphan property Rems.');
+    if (!repairReport) {
+      await plugin.app.toast('Run the repair first (a dry run is enough) so the orphan list exists.');
       return;
     }
-    if (repairReport?.dryRun) {
-      await plugin.app.toast('That report is a dry run, so nothing was repaired yet. Run the live repair first.');
+    // A dry run is sufficient when the targets are DERIVABLE orphans: that list
+    // is produced by the scan and does not depend on anything having been
+    // written. Only the repaired-manual targets require a live run first, since
+    // their safety depends on the value already being restored.
+    const derivableAvailable = (repairReport.derivableOrphanPropertyRemIds ?? []).length > 0;
+    if (repairReport.dryRun && !derivableAvailable) {
+      await plugin.app.toast(
+        'That report is a dry run and recorded no derivable orphans. Run the live repair first.'
+      );
+      return;
+    }
+    // Target only leftovers whose owner's slot ALREADY READS. The scan's
+    // safe-to-delete list is the authority: it is computed from current state, so
+    // it grows automatically once "Update all inherited Card Priorities" or a
+    // repair has materialised the values. Falling back to the repair's own output
+    // covers the case where no scan has been run this session.
+    const ids = (kbScan?.safeToDeleteAll ?? []).map((l) => l.propertyRemId);
+    if (!ids.length) ids.push(...repairReport.orphanPropertyRemIds);
+    if (!ids.length) {
+      await plugin.app.toast(
+        'No repaired Rems recorded. Run the repair (with "incl. inherited" if you want the ' +
+        'derivable ones fixed too) — the deletion only touches Rems whose value is already restored.'
+      );
       return;
     }
     const confirmed = confirm(
       `This DELETES 3 orphaned property Rems (of ${ids.length} recorded).\n\n` +
-      `Each one is only removed if the Rem's repaired priority already reads back correctly, ` +
-      `and the value it held is captured first so it can be restored by hand.\n\n` +
+      `Targets Rems this repair just restored, so the value already exists in the correct ` +
+      `property. Any Rem whose slot is still empty is REFUSED automatically — its orphan ` +
+      `would be the only copy.\n\n` +
+      `The value each orphan held is captured first and printed, so it can be restored by hand.\n\n` +
       `Purpose: find out whether deleting the stale property disturbs the good one, BEFORE ` +
       `any bulk cleanup. Continue?`
     );
@@ -2195,6 +2217,55 @@ function Debug() {
         ? `⚠ ${bad.length} deletion(s) disturbed the good value — DO NOT bulk clean. See console.`
         : `Deleted ${probes.filter((p) => p.deleted).length}. Priorities intact. See console.`
     );
+  };
+
+  // Bulk cleanup. Same per-Rem guard as the 3-Rem test — it is literally the same
+  // function with the cap lifted — plus an abort on the first DANGER so one bad
+  // deletion cannot become hundreds.
+  const handleBulkOrphanDeletion = async () => {
+    // Only Rems this repair restored. Un-repaired ones would be refused per-Rem
+    // anyway, but there is no reason to attempt them: their orphan is still the
+    // only materialised copy of the value.
+    const ids = (kbScan?.safeToDeleteAll ?? []).map((l) => l.propertyRemId);
+    if (!ids.length) ids.push(...(repairReport?.orphanPropertyRemIds ?? []));
+    if (!ids.length) {
+      await plugin.app.toast(
+        'Nothing safe to delete. Run the KB scan — only leftovers whose owner Rem already ' +
+        'reads a priority are eligible.'
+      );
+      return;
+    }
+    const confirmed = confirm(
+      `DELETE ALL ${ids.length} orphan property Rems belonging to Rems this repair restored.\n\n` +
+      `Run the 3-Rem test first and confirm it reported OK — this is the same code ` +
+      `with the cap removed.\n\n` +
+      `Each Rem is still checked individually: one is only deleted if its priority slot ` +
+      `already reads back, and the whole run aborts on the first DANGER.\n\n` +
+      `This cannot be undone. Continue?`
+    );
+    if (!confirmed) return;
+
+    setIsRepairingCP(true);
+    setRepairProgress('Deleting orphans…');
+    try {
+      const probes = await testDeleteOrphanProperties(plugin, ids, ids.length, (done, total) =>
+        setRepairProgress(`Deleting ${done} / ${total}`)
+      );
+      setDeletionProbes(probes.filter((p) => !p.verdict.startsWith('OK')).slice(0, 20));
+      const deleted = probes.filter((p) => p.deleted).length;
+      const bad = probes.filter((p) => p.verdict.startsWith('DANGER')).length;
+      await plugin.app.toast(
+        bad
+          ? `⚠ ABORTED after ${bad} DANGER — ${deleted} deleted. See console.`
+          : `Deleted ${deleted} orphan propert(ies). See console.`
+      );
+    } catch (e: any) {
+      console.error('[OrphanCleanup] Error:', e);
+      await plugin.app.toast(`Cleanup failed: ${e?.message ?? e}`);
+    } finally {
+      setIsRepairingCP(false);
+      setRepairProgress(null);
+    }
   };
 
   // Cross-KB import diagnostic. Answers ONE question: after importing rems from
@@ -4633,8 +4704,22 @@ function Debug() {
               3. Repair all (live)
             </button>
             <button
+              onClick={handleBulkOrphanDeletion}
+              disabled={isRepairingCP}
+              style={{ ...smallBtnStyle, cursor: isRepairingCP ? 'wait' : 'pointer', borderColor: '#ef4444', color: '#ef4444', fontWeight: 600 }}
+              title="Delete ALL recorded orphan property Rems. Each is individually guarded and the run aborts on the first DANGER. Only after the 3-Rem test passes."
+            >
+              5. Delete all orphans
+            </button>
+            <button
               onClick={handleTestOrphanDeletion}
-              disabled={isRepairingCP || !repairReport || repairReport.dryRun || repairReport.orphanPropertyRemIds.length === 0}
+              // Only disabled while busy. Every other precondition is checked in
+              // the handler, which toasts the reason — a disabled button that
+              // silently does nothing is indistinguishable from a broken one, and
+              // this one disabled itself precisely when it became useful: after a
+              // successful repair, `orphanPropertyRemIds` is empty because there
+              // was nothing left to repair.
+              disabled={isRepairingCP}
               style={{ ...smallBtnStyle, cursor: isRepairingCP ? 'wait' : 'pointer', borderColor: '#ef4444', color: '#ef4444' }}
               title="Deletes 3 orphaned property Rems and reports whether the repaired priority survived. Destructive — run only after a live repair."
             >
@@ -4678,7 +4763,7 @@ function Debug() {
                   key={p.orphanPropertyRemId}
                   style={{ marginBottom: '4px', color: p.verdict.startsWith('DANGER') ? '#ef4444' : 'var(--rn-clr-content-secondary)' }}
                 >
-                  <code>{p.orphanPropertyRemId}</code> — held {p.storedValue ?? '?'} · API {p.apiValueBefore ?? '(empty)'} → {p.apiValueAfter ?? '(empty)'} · children {p.ownerChildCountBefore ?? '?'} → {p.ownerChildCountAfter ?? '?'}
+                  <code>{p.orphanPropertyRemId}</code> — held {p.storedValue ?? '?'} · stored {p.apiValueBefore ?? '(empty)'} → {p.apiValueAfter ?? '(empty)'} · resolved {p.resolvedBefore ?? '(none)'} → {p.resolvedAfter ?? '(none)'} · children {p.ownerChildCountBefore ?? '?'} → {p.ownerChildCountAfter ?? '?'}
                   <div>{p.verdict}</div>
                 </div>
               ))}
@@ -4723,6 +4808,17 @@ function Debug() {
                   <td style={{ padding: '2px 4px' }}>{kbScan.nextRepDate.empty}</td>
                   <td style={{ padding: '2px 4px', color: kbScan.nextRepDate.danglingPct > 0 ? '#ef4444' : undefined, fontWeight: 600 }}>{kbScan.nextRepDate.danglingPct}%</td>
                 </tr>
+                {kbScan.nextRepDate.dangling > 0 && (
+                  <tr>
+                    <td style={{ padding: '2px 4px', paddingLeft: '12px', color: 'var(--rn-clr-content-secondary)' }} colSpan={6}>
+                      of those dangling: <strong style={{ color: '#22c55e' }}>{kbScan.nextRepDate.danglingRecoverable}</strong> repairable from history
+                      ({kbScan.nextRepDate.recoverablePct}%)
+                      {kbScan.nextRepDate.danglingUnrecoverable > 0 && (
+                        <> · <strong style={{ color: '#ef4444' }}>{kbScan.nextRepDate.danglingUnrecoverable} unrecoverable</strong></>
+                      )}
+                    </td>
+                  </tr>
+                )}
               </tbody>
             </table>
 
@@ -4739,6 +4835,7 @@ function Debug() {
                       <th style={{ padding: '2px 4px' }}>Interval</th>
                       <th style={{ padding: '2px 4px' }}>Resolves</th>
                       <th style={{ padding: '2px 4px' }}>Dangling</th>
+                      <th style={{ padding: '2px 4px' }}>Repairable</th>
                     </tr>
                   </thead>
                   <tbody>
@@ -4747,12 +4844,45 @@ function Debug() {
                         <td style={{ padding: '2px 4px' }}>{row.bucket}</td>
                         <td style={{ padding: '2px 4px' }}>{row.ok}</td>
                         <td style={{ padding: '2px 4px', color: row.dangling > 0 ? '#ef4444' : undefined }}>{row.dangling}</td>
+                        <td style={{ padding: '2px 4px', color: '#22c55e' }}>{row.recoverable}</td>
                       </tr>
                     ))}
                   </tbody>
                 </table>
               </>
             )}
+
+            {/* Litter, measured independently of readability — a Rem can read
+                correctly and still carry a leftover "Unnamed — N" row. */}
+            <div style={{ fontSize: '11px', marginBottom: '6px' }}>
+              Leftover priority properties:{' '}
+              <strong style={{ color: kbScan.leftoverCount > 0 ? '#f59e0b' : '#22c55e' }}>
+                {kbScan.leftoverCount}
+              </strong>
+              {kbScan.leftoverCount > 0 && (
+                <>
+                  {' '}(<span style={{ color: '#22c55e' }}>{kbScan.leftoverSafeToDelete} safe to delete</span>
+                  {kbScan.leftoverStranded > 0 && (
+                    <>, <strong style={{ color: '#ef4444' }}>{kbScan.leftoverStranded} stranded</strong></>
+                  )})
+                  {kbScan.leftoverStranded > 0 && (
+                    <div style={{ marginTop: '2px' }}>
+                      Of the stranded:{' '}
+                      <strong style={{ color: '#ef4444' }}>{kbScan.strandedNeedsRecovery} need recovery</strong>{' '}
+                      (manual/incremental) ·{' '}
+                      <strong style={{ color: '#22c55e' }}>{kbScan.strandedDiscardable} derivable</strong>, safe to delete
+                      <div style={{ color: 'var(--rn-clr-content-secondary)' }}>
+                        {kbScan.strandedBySource.map((s) => `${s.source}: ${s.count} (${s.action})`).join(' · ')}
+                      </div>
+                    </div>
+                  )}
+                  <div style={{ color: 'var(--rn-clr-content-secondary)', marginTop: '2px' }}>
+                    Excluded as other powerups' own properties:{' '}
+                    {kbScan.leftoverSlots.filter((s) => s.category === 'foreign').map((s) => `${s.name} ×${s.count}`).join(', ') || 'none'}
+                  </div>
+                </>
+              )}
+            </div>
 
             {kbScan.notes.map((n, i) => (
               <div key={i} style={{ fontSize: '11px', color: 'var(--rn-clr-content-secondary)', marginTop: '4px' }}>


### PR DESCRIPTION
## v1.0.35 - August 7th, 2026

### 🐛 Fixed: priorities showing the wrong number after a RemNote update

RemNote's storage/sync overhaul re-pointed some powerup properties at the wrong slot definition — unnamed ones, the *other* priority powerup's, or ones that had since been deleted. **No value was ever lost**: it stayed on the Rem, in a property the plugin could no longer reach. What you saw instead was the fallback. Because both priority powerups use a slot displayed as "Priority", they got crossed with each other.

RemNote fixed the bulk of it in **1.27.24**. This release deals with what survived that fix, and with the reporting that hid it:

- **Incremental priorities are recovered from the Rem's own history** when the slot cannot be read, instead of silently substituting a default. The displayed number now also says where it came from, so a recovered or placeholder value can never pass for a stored one.
- **A repair for Card Priority**, which has no history to fall back on and so was the only case genuinely showing wrong values. It reads the value off the unreachable property and rewrites it through the normal path, keeping the original source and timestamp.
- **Diagnostics to check your own knowledge base** — a raw dump for one Rem and a whole-KB scan — plus a guarded cleanup for the stray `Unnamed — 42` rows the repair leaves behind.

> [!NOTE]
> **If your priorities look wrong after a RemNote update, please get in touch.** The tools above will tell you whether your knowledge base is affected and by how much, and they write nothing. Reports are especially valuable if the damage appears on a RemNote version **after 1.27.24**, or looks different in shape from what is documented — that would point at a path not yet seen. Open an issue on the [plugin's issue tracker](https://github.com/bjsi/incremental-everything/issues) with the scan output.

One related fault is still outstanding on RemNote's side: some **Next Rep Date** properties reference a Daily Document that no longer exists, so RemNote's date row shows `Loading` indefinitely. Scheduling is unaffected — the plugin keeps its own copy of the next-repetition date and reads that — but the date chip cannot be edited by hand until it is rebuilt.
